### PR TITLE
replaced dropdown-filter with filter-input

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -39,14 +39,6 @@ export namespace Components {
         "search": boolean;
         "size": 's' | 'm';
     }
-    interface IfxDropdownFilter {
-        "disabled": boolean;
-        "filter": boolean;
-        "icon": boolean;
-        "label": string;
-        "search": boolean;
-        "size": 's' | 'm';
-    }
     interface IfxDropdownItem {
         "checkable": boolean;
         "disabled": boolean;
@@ -55,6 +47,14 @@ export namespace Components {
         "size": 's' | 'm';
     }
     interface IfxDropdownMenu {
+        "disabled": boolean;
+        "filter": boolean;
+        "icon": boolean;
+        "label": string;
+        "search": boolean;
+        "size": 's' | 'm';
+    }
+    interface IfxFilterInput {
         "disabled": boolean;
         "filter": boolean;
         "icon": boolean;
@@ -99,12 +99,6 @@ declare global {
         prototype: HTMLIfxDropdownElement;
         new (): HTMLIfxDropdownElement;
     };
-    interface HTMLIfxDropdownFilterElement extends Components.IfxDropdownFilter, HTMLStencilElement {
-    }
-    var HTMLIfxDropdownFilterElement: {
-        prototype: HTMLIfxDropdownFilterElement;
-        new (): HTMLIfxDropdownFilterElement;
-    };
     interface HTMLIfxDropdownItemElement extends Components.IfxDropdownItem, HTMLStencilElement {
     }
     var HTMLIfxDropdownItemElement: {
@@ -116,6 +110,12 @@ declare global {
     var HTMLIfxDropdownMenuElement: {
         prototype: HTMLIfxDropdownMenuElement;
         new (): HTMLIfxDropdownMenuElement;
+    };
+    interface HTMLIfxFilterInputElement extends Components.IfxFilterInput, HTMLStencilElement {
+    }
+    var HTMLIfxFilterInputElement: {
+        prototype: HTMLIfxFilterInputElement;
+        new (): HTMLIfxFilterInputElement;
     };
     interface HTMLIfxSearchInputElement extends Components.IfxSearchInput, HTMLStencilElement {
     }
@@ -134,9 +134,9 @@ declare global {
         "ifx-button": HTMLIfxButtonElement;
         "ifx-card": HTMLIfxCardElement;
         "ifx-dropdown": HTMLIfxDropdownElement;
-        "ifx-dropdown-filter": HTMLIfxDropdownFilterElement;
         "ifx-dropdown-item": HTMLIfxDropdownItemElement;
         "ifx-dropdown-menu": HTMLIfxDropdownMenuElement;
+        "ifx-filter-input": HTMLIfxFilterInputElement;
         "ifx-search-input": HTMLIfxSearchInputElement;
         "infineon-icon-stencil": HTMLInfineonIconStencilElement;
     }
@@ -174,14 +174,6 @@ declare namespace LocalJSX {
         "search"?: boolean;
         "size"?: 's' | 'm';
     }
-    interface IfxDropdownFilter {
-        "disabled"?: boolean;
-        "filter"?: boolean;
-        "icon"?: boolean;
-        "label"?: string;
-        "search"?: boolean;
-        "size"?: 's' | 'm';
-    }
     interface IfxDropdownItem {
         "checkable"?: boolean;
         "disabled"?: boolean;
@@ -190,6 +182,14 @@ declare namespace LocalJSX {
         "size"?: 's' | 'm';
     }
     interface IfxDropdownMenu {
+        "disabled"?: boolean;
+        "filter"?: boolean;
+        "icon"?: boolean;
+        "label"?: string;
+        "search"?: boolean;
+        "size"?: 's' | 'm';
+    }
+    interface IfxFilterInput {
         "disabled"?: boolean;
         "filter"?: boolean;
         "icon"?: boolean;
@@ -213,9 +213,9 @@ declare namespace LocalJSX {
         "ifx-button": IfxButton;
         "ifx-card": IfxCard;
         "ifx-dropdown": IfxDropdown;
-        "ifx-dropdown-filter": IfxDropdownFilter;
         "ifx-dropdown-item": IfxDropdownItem;
         "ifx-dropdown-menu": IfxDropdownMenu;
+        "ifx-filter-input": IfxFilterInput;
         "ifx-search-input": IfxSearchInput;
         "infineon-icon-stencil": InfineonIconStencil;
     }
@@ -228,9 +228,9 @@ declare module "@stencil/core" {
             "ifx-button": LocalJSX.IfxButton & JSXBase.HTMLAttributes<HTMLIfxButtonElement>;
             "ifx-card": LocalJSX.IfxCard & JSXBase.HTMLAttributes<HTMLIfxCardElement>;
             "ifx-dropdown": LocalJSX.IfxDropdown & JSXBase.HTMLAttributes<HTMLIfxDropdownElement>;
-            "ifx-dropdown-filter": LocalJSX.IfxDropdownFilter & JSXBase.HTMLAttributes<HTMLIfxDropdownFilterElement>;
             "ifx-dropdown-item": LocalJSX.IfxDropdownItem & JSXBase.HTMLAttributes<HTMLIfxDropdownItemElement>;
             "ifx-dropdown-menu": LocalJSX.IfxDropdownMenu & JSXBase.HTMLAttributes<HTMLIfxDropdownMenuElement>;
+            "ifx-filter-input": LocalJSX.IfxFilterInput & JSXBase.HTMLAttributes<HTMLIfxFilterInputElement>;
             "ifx-search-input": LocalJSX.IfxSearchInput & JSXBase.HTMLAttributes<HTMLIfxSearchInputElement>;
             "infineon-icon-stencil": LocalJSX.InfineonIconStencil & JSXBase.HTMLAttributes<HTMLInfineonIconStencilElement>;
         }

--- a/src/components/dropdown-menu/dropdown-menu.scss
+++ b/src/components/dropdown-menu/dropdown-menu.scss
@@ -30,7 +30,7 @@
       color: tokens.$color-gray-400;
     }
 
-    & .inf__search-input, .inf__dropdown-select {
+    & .inf__search-input, .inf__filter-input {
       width: 160px;
       min-height: calc(1.75em + 18px);
       font-size: 0.8125rem;

--- a/src/components/dropdown/dropdown.stories.ts
+++ b/src/components/dropdown/dropdown.stories.ts
@@ -59,12 +59,12 @@ const FilterTemplate = (args) =>
 `<ifx-dropdown>
   <ifx-button color="${args.color}" size="${args.size}" variant="${args.variant}" disabled="${args.disabled}">${args.label}</ifx-button>
   <ifx-dropdown-menu>
-    <ifx-dropdown-filter>
+    <ifx-filter-input>
       <option value="">One</option>
       <option value="">Two</option>
       <option value="">Three</option>
       <option value="">Four</option>
-    </ifx-dropdown-filter>
+    </ifx-filter-input>
     <ifx-dropdown-item>item 1</ifx-dropdown-item>
     <ifx-dropdown-item checkable>item 2</ifx-dropdown-item>
     <ifx-dropdown-item checkable>item 3</ifx-dropdown-item>

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -82,7 +82,7 @@ export class Dropdown {
     }
 
     if (target.className.toLowerCase() === 'inf__search-input'
-      || target.className.toLowerCase() === 'inf__dropdown-select') {
+      || target.className.toLowerCase() === 'inf__filter-input') {
       return;
     }
     

--- a/src/components/filter-input/filter-input.scss
+++ b/src/components/filter-input/filter-input.scss
@@ -1,4 +1,4 @@
-.inf__dropdown-select {
+.inf__filter-input {
   width: 160px;
   min-height: calc(1.75em + 18px);
   font-size: 0.8125rem;

--- a/src/components/filter-input/filter-input.tsx
+++ b/src/components/filter-input/filter-input.tsx
@@ -1,7 +1,7 @@
 import { Component, Prop, h, Element, State } from "@stencil/core";
 
 @Component({
-  tag: 'ifx-dropdown-filter',
+  tag: 'ifx-filter-input',
   styleUrl: '../../index.scss',
   shadow: true
 })
@@ -26,7 +26,7 @@ export class DropdownFilter {
 
   render() {
     return  (
-      <select class="inf__dropdown-select">
+      <select class="inf__filter-input">
         <slot />
         {this.options.map(item => <option>{item.label || item.value}</option>)}
       </select>

--- a/src/components/filter-input/readme.md
+++ b/src/components/filter-input/readme.md
@@ -1,4 +1,4 @@
-# ifx-dropdown-filter
+# ifx-filter-input
 
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -14,15 +14,13 @@
 <body>
   <ifx-alert color="secondary" icon="cInfo24">Lorem ipsum dolor sit, amet consectetur adipisicing elit. Ab, error.</ifx-alert>
 
-  
-    
-    <ifx-dropdown-menu>
-      <ifx-search-input></ifx-search-input>
-      <ifx-dropdown-item checkable>item 1</ifx-dropdown-item>
-      <ifx-dropdown-item>item 2</ifx-dropdown-item>
-      <ifx-dropdown-item>item 3</ifx-dropdown-item>
-      <ifx-dropdown-item>item 4</ifx-dropdown-item>
-    </ifx-dropdown-menu>
+  <ifx-dropdown-menu>
+    <ifx-dropdown-item>item 1</ifx-dropdown-item>
+    <ifx-dropdown-item>item 2</ifx-dropdown-item>
+    <ifx-dropdown-item>item 3</ifx-dropdown-item>
+    <ifx-dropdown-item>item 4</ifx-dropdown-item>
+  </ifx-dropdown-menu>
+
 
  
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,4 +5,4 @@
 @import "./components/dropdown-menu/dropdown-menu";
 @import "./components/dropdown-item/dropdown-item";
 @import "./components/search-input/search-input";
-@import "./components/dropdown-filter/dropdown-filter";
+@import "./components/filter-input/filter-input";


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Renamed ifx-dropdown-filter with ifx-filter-input 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.64--canary.29.3d48eb41a939f727d64d5f52d030980c2fb26235.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@0.0.64--canary.29.3d48eb41a939f727d64d5f52d030980c2fb26235.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@0.0.64--canary.29.3d48eb41a939f727d64d5f52d030980c2fb26235.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
