### PR TITLE
Feature/nesting ifx icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "^2.0.1",
-        "@infineon/infineon-icons": "^1.0.5",
+        "@infineon/infineon-icons": "^1.0.9",
         "@stencil/core": "^2.16.0",
         "classnames": "^2.3.2"
       },
@@ -1966,9 +1966,9 @@
       "license": "MIT"
     },
     "node_modules/@infineon/infineon-icons": {
-      "version": "1.0.5",
-      "resolved": "https://npm.pkg.github.com/download/@infineon/infineon-icons/1.0.5/4824dab29d8797f88f19b91800a30477be01c644",
-      "integrity": "sha512-XX70q8wO9pfNd4oWDj1WVqqy9KgHp5g52f/bt8/kAUEyrM1BTryJyYVH2k4wa55C0l5am4zpRnB5QAyT3jv+zg==",
+      "version": "1.0.9",
+      "resolved": "https://npm.pkg.github.com/download/@infineon/infineon-icons/1.0.9/e3bed68bb28f8d462b7190c11731da8de7f1783a",
+      "integrity": "sha512-Ox6o+7mhLKzbu5j6Px+4iaIn5geb+5WDLVEUtHfgL0QTUm94vV4NnnHhnnljk41c/NypuFrTwUmWRAUZVckuPQ==",
       "dependencies": {
         "xmldom": "^0.6.0"
       }
@@ -26760,9 +26760,9 @@
       "integrity": "sha512-1Ouvknb2dUfSHvCIjg2ZuTKJl583nx/2+fAcKkgiqUofVczC86f1XzzmGcZk3iANfKYHbgcGvM+abJrviO6jJQ=="
     },
     "@infineon/infineon-icons": {
-      "version": "1.0.5",
-      "resolved": "https://npm.pkg.github.com/download/@infineon/infineon-icons/1.0.5/4824dab29d8797f88f19b91800a30477be01c644",
-      "integrity": "sha512-XX70q8wO9pfNd4oWDj1WVqqy9KgHp5g52f/bt8/kAUEyrM1BTryJyYVH2k4wa55C0l5am4zpRnB5QAyT3jv+zg==",
+      "version": "1.0.9",
+      "resolved": "https://npm.pkg.github.com/download/@infineon/infineon-icons/1.0.9/e3bed68bb28f8d462b7190c11731da8de7f1783a",
+      "integrity": "sha512-Ox6o+7mhLKzbu5j6Px+4iaIn5geb+5WDLVEUtHfgL0QTUm94vV4NnnHhnnljk41c/NypuFrTwUmWRAUZVckuPQ==",
       "requires": {
         "xmldom": "^0.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "^2.0.1",
-    "@infineon/infineon-icons": "^1.0.5",
+    "@infineon/infineon-icons": "^1.0.9",
     "@stencil/core": "^2.16.0",
     "classnames": "^2.3.2"
   },

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -15,11 +15,10 @@ export namespace Components {
         "color": 'primary' | 'secondary' | 'success' | 'danger' | 'warning';
         "disabled": boolean;
         "href": string;
-        "iconOnly": boolean;
-        "iconPosition": 'left' | 'right';
-        "label": string;
+        "icon": string;
+        "position": string;
         "setFocus": () => Promise<void>;
-        "size": 's' | 'm';
+        "size": string;
         "target": string;
         "variant": 'solid' | 'outline' | 'outline-text';
     }
@@ -42,7 +41,7 @@ export namespace Components {
     interface IfxDropdownItem {
         "checkable": boolean;
         "disabled": boolean;
-        "icon": boolean;
+        "icon": string;
         "label": string;
         "size": 's' | 'm';
     }
@@ -152,10 +151,9 @@ declare namespace LocalJSX {
         "color"?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning';
         "disabled"?: boolean;
         "href"?: string;
-        "iconOnly"?: boolean;
-        "iconPosition"?: 'left' | 'right';
-        "label"?: string;
-        "size"?: 's' | 'm';
+        "icon"?: string;
+        "position"?: string;
+        "size"?: string;
         "target"?: string;
         "variant"?: 'solid' | 'outline' | 'outline-text';
     }
@@ -178,7 +176,7 @@ declare namespace LocalJSX {
     interface IfxDropdownItem {
         "checkable"?: boolean;
         "disabled"?: boolean;
-        "icon"?: boolean;
+        "icon"?: string;
         "label"?: string;
         "size"?: 's' | 'm';
     }

--- a/src/components/alert/_alert.scss
+++ b/src/components/alert/_alert.scss
@@ -13,15 +13,14 @@
   }
 
   &__alert-icon-wrapper {
-    position: relative;
-    min-width: 48px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    background-color: tokens.$color-default-500;
-    
-    & svg { 
-      stroke: tokens.$color-text-white;
+    display: none;
+    &.show { 
+      position: relative;
+      min-width: 48px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      background-color: tokens.$color-default-500;
     }
   }
 
@@ -30,13 +29,11 @@
     align-items: center;
     justify-content: center;
     min-width: 40px;
+    
 
     & a { 
       line-height: 0;
-
-      & svg { 
-        stroke: tokens.$color-black;
-      }
+      color: tokens.$color-text-black;
 
       &:hover svg { 
         stroke: tokens.$color-default-500;
@@ -66,6 +63,7 @@
 
   & .ifx__alert-icon-wrapper {
     background-color: tokens.$color-default-500;
+    color: tokens.$color-text-white;
   }
 }
 
@@ -74,6 +72,7 @@
 
   & .ifx__alert-icon-wrapper {
     background-color: tokens.$color-highlight-500;
+    color: tokens.$color-text-white;
   }
 }
 
@@ -82,6 +81,7 @@
 
   & .ifx__alert-icon-wrapper {
     background-color: tokens.$color-success-500;
+    color: tokens.$color-text-white;
   }
 }
 
@@ -90,6 +90,7 @@
 
   & .ifx__alert-icon-wrapper {
     background-color: tokens.$color-danger-500;
+    color: tokens.$color-text-white;
   }
 }
 
@@ -98,10 +99,13 @@
 
   & .ifx__alert-icon-wrapper {
     background-color: tokens.$color-warning-500;
+    color: tokens.$color-text-white;
   }
 }
 
-
+// ifx-icon:empty { 
+//   display: none;
+//  }
 
 
 

--- a/src/components/alert/alert.stories.ts
+++ b/src/components/alert/alert.stories.ts
@@ -23,7 +23,7 @@ export default {
 
 
 const DefaultTemplate = (args) =>
-  `<ifx-alert  color="${args.color}" icon="${args.icon ? args.iconType : ""}">${args.label}</ifx-alert>`;
+  `<ifx-alert color="${args.color}" icon="${args.icon ? args.iconType : ""}">${args.label}</ifx-alert>`;
 
   export const Default = DefaultTemplate.bind({});
  

--- a/src/components/alert/alert.tsx
+++ b/src/components/alert/alert.tsx
@@ -1,9 +1,9 @@
-import { Component, Prop, h, State, Element } from '@stencil/core';
+import { Component, Prop, h, Element } from '@stencil/core';
 import classNames from 'classnames';
 
 @Component({
   tag: 'ifx-alert',
-  styleUrl: '_alert.scss',
+  styleUrl: '../../index.scss',
   shadow: true,
 })
 
@@ -12,7 +12,6 @@ export class Card {
   @Prop() icon: string;
   @Prop() overflowing: boolean
   @Element() el;
-  @State() iconsArray: any[] = [<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 24 24"><title>c info 24</title><g stroke-linecap="round" stroke-width="2" fill="none" stroke="" stroke-linejoin="round"><circle cx="12" cy="12" r="11"></circle><line x1="12" y1="11" x2="12" y2="17" stroke=""></line><circle cx="12" cy="7" r="1" stroke="" fill="#000000"></circle></g></svg>]
 
   isOverflowing() { 
     const el = this.el.shadowRoot.querySelector('.ifx__alert-text')
@@ -23,54 +22,33 @@ export class Card {
     }
   }
 
-  verifyIcons(icon1, icon2) { 
-    if(icon1 === icon2) { 
-      return true;
-    } else if(icon2?.split(" ").join("") === icon1?.split(" ").join("-")) {
-      return true
-    } else if(icon2?.split(" ").join("").toLowerCase() === icon1?.split(" ").join("").toLowerCase()) {
-      return true
-    } else {
-      console.error('Icon name does not exist!')
-      return false
+  toggleIcon(ifxIconWrapper) { 
+    ifxIconWrapper.classList.toggle('show')
+  }
+
+  componentDidRender() { 
+    this.isOverflowing()
+    const ifxAlert = this.el.shadowRoot.querySelector('.alert');
+    const ifxIconWrapper = ifxAlert.querySelector('.ifx__alert-icon-wrapper')
+    const ifxIcon = ifxIconWrapper.querySelector('ifx-icon');
+    const ifxSvg = ifxIcon.querySelector('svg')
+    if(ifxSvg) {
+      this.toggleIcon(ifxIconWrapper)
     }
   }
 
-
-  getIcon() { 
-    const svgIcon = this.iconsArray.find((icons) => {
-      let titleIndex = icons['$children$'].findIndex((val) => val['$tag$'] === 'title');
-      let titleArray = icons['$children$'][titleIndex]['$children$']
-      let title = titleArray[0]['$text$']
-      const icon =  this.verifyIcons(title, this.icon)
-      return icon
-    })
-
-    return svgIcon
-  }
-
-  
-  componentDidRender() { 
-    this.isOverflowing()
-  }
-
-
   render() {
-
-    const iconSVG_close = <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 16 16"><title>cross 16</title><g stroke-width="1" stroke-linejoin="round" fill="none" stroke="" stroke-linecap="round" class="nc-icon-wrapper"><line x1="13.5" y1="2.5" x2="2.5" y2="13.5" data-cap="butt"></line> <line x1="2.5" y1="2.5" x2="13.5" y2="13.5" data-cap="butt"></line> </g></svg>
-    
     return (
       <div class={this.getClassNames()}>
-       {this.icon &&  
-       <div class="ifx__alert-icon-wrapper">
-         {this.getIcon()}
-        </div>}
+       <div class='ifx__alert-icon-wrapper'>
+        <ifx-icon icon={this.icon}></ifx-icon>
+       </div>
         <div class="ifx__alert-text">
           <slot />
         </div>
         <div class="ifx__close-icon-wrapper">
         <a href="#">
-          {iconSVG_close}
+          <ifx-icon icon='cross-16'></ifx-icon>
         </a>
         </div>
       </div>

--- a/src/components/alert/readme.md
+++ b/src/components/alert/readme.md
@@ -14,6 +14,19 @@
 | `overflowing` | `overflowing` |             | `boolean`                                                        | `undefined` |
 
 
+## Dependencies
+
+### Depends on
+
+- [ifx-icon](../icon)
+
+### Graph
+```mermaid
+graph TD;
+  ifx-alert --> ifx-icon
+  style ifx-alert fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -2,8 +2,7 @@
 
 
 .btn {
-  display: inline-flex;
-  justify-content: center;
+  display: inline-flex; 
   align-items: center;
   min-width: 80px;
   min-height: 40px;
@@ -16,9 +15,7 @@
   line-height: 24px;
   outline: none;
   font-family: tokens.$font-family-body;
-  text-align: center;
   text-decoration: none;
-  vertical-align: middle;
   user-select: none;
   border: 1px solid rgba(0, 0, 0, 0);
   font-size: 1rem;
@@ -33,99 +30,58 @@
   color: tokens.$color-text-white;
   background-color: tokens.$color-default-500;
   border-color: tokens.$color-default-500;
-
-  & svg { 
-    stroke: tokens.$color-text-white;
-  }
-
 }
 
 .btn-outline-primary {
   background-color: tokens.$color-bg-white;
   color: tokens.$color-default-500;
   border-color: tokens.$color-default-500;
-
-  & svg { 
-    stroke: tokens.$color-default-500;
-  }
 }
 
 .btn-secondary {
   color: tokens.$color-text-white;
   background-color: tokens.$color-highlight-500;
   border-color: tokens.$color-highlight-500;
-
-  & svg { 
-    stroke: tokens.$color-text-white;
-  }
 }
 
 .btn-outline-secondary {
   background-color: tokens.$color-bg-white;
   color: tokens.$color-highlight-500;
   border-color: tokens.$color-highlight-500;
-
-  & svg { 
-    stroke: tokens.$color-highlight-500;
-  }
 }
 
 .btn-success {
   color: tokens.$color-text-black;
   background-color: tokens.$color-success-500;
   border-color: tokens.$color-success-500;
-
-  & svg { 
-    stroke: tokens.$color-text-black;
-  }
 }
 
 .btn-outline-success {
   background-color: tokens.$color-bg-white;
   border-color: tokens.$color-success-500;
-
-  & svg { 
-    stroke: tokens.$color-text-black;
-  }
 }
 
 .btn-danger {
   color: tokens.$color-text-white;
   background-color: tokens.$color-danger-500;
   border-color: tokens.$color-danger-500;
-
-  & svg { 
-    stroke: tokens.$color-text-white;
-  }
 }
 
 .btn-outline-danger {
   background-color: tokens.$color-bg-white;
   color: tokens.$color-danger-500;
   border-color: tokens.$color-danger-500;
-
-  & svg { 
-    stroke: tokens.$color-danger-500;
-  }
 }
 
 .btn-warning {
   color: tokens.$color-text-black;
   background-color: tokens.$color-warning-500;
   border-color: tokens.$color-warning-500;
-
-  & svg { 
-    stroke: tokens.$color-text-black;
-  }
 }
 
 .btn-outline-warning {
   background-color: tokens.$color-bg-white;
   border-color: tokens.$color-warning-500;
-
-  & svg { 
-    stroke: tokens.$color-text-black;
-  }
 }
 
 
@@ -374,19 +330,11 @@
 
     &:hover {
       color: tokens.$color-default-600;
-
-       & svg { 
-        stroke: tokens.$color-default-600;
-       }
     }
 
     &:active,
     &.active {
       color: tokens.$color-default-700;
-
-      & svg { 
-        stroke: tokens.$color-default-700;
-       }
     }
 
     &:disabled,
@@ -395,14 +343,6 @@
       background-color: transparent;
       border-color: transparent;
       color: tokens.$color-gray-300;
-
-      & svg { 
-        stroke: tokens.$color-gray-300;
-       }
-    }
-
-    & svg { 
-      stroke: tokens.$color-default-500;
     }
   }
 
@@ -412,19 +352,11 @@
 
     &:hover {
       color: tokens.$color-highlight-600;
-
-      & svg { 
-        stroke: tokens.$color-highlight-600;
-      }
     }
 
     &:active,
     &.active {
       color: tokens.$color-highlight-700;
-
-      & svg { 
-        stroke: tokens.$color-highlight-700;
-      }
     }
 
     &:disabled,
@@ -433,14 +365,6 @@
       background-color: transparent;
       border-color: transparent;
       color: tokens.$color-gray-300;
-
-      & svg { 
-        stroke: tokens.$color-gray-300;
-      }
-    }
-
-    & svg { 
-      stroke: tokens.$color-highlight-500;
     }
   }
 
@@ -450,19 +374,11 @@
 
     &:hover {
       color: tokens.$color-success-600;
-
-      & svg { 
-        stroke: tokens.$color-success-600;
-      }
     }
 
     &:active,
     &.active {
       color: tokens.$color-success-700;
-
-      & svg { 
-        stroke: tokens.$color-success-700;
-      }
     }
 
     &:disabled,
@@ -471,14 +387,6 @@
       background-color: transparent;
       border-color: transparent;
       color: tokens.$color-gray-300;
-
-      & svg { 
-        stroke: tokens.$color-gray-300;
-      }
-    }
-
-    & svg { 
-      stroke: tokens.$color-success-500;
     }
   }
 
@@ -488,19 +396,11 @@
 
     &:hover {
       color: tokens.$color-danger-600;
-
-      & svg { 
-        stroke: tokens.$color-danger-600;
-      }
     }
 
     &:active,
     &.active {
       color: tokens.$color-danger-700;
-
-      & svg { 
-        stroke: tokens.$color-danger-700;
-      }
     }
 
     &:disabled,
@@ -509,15 +409,8 @@
       background-color: transparent;
       border-color: transparent;
       color: tokens.$color-gray-300;
-
-      & svg { 
-        stroke: tokens.$color-gray-300;
-      }
     }
 
-    & svg { 
-      stroke: tokens.$color-danger-500;
-    }
   }
 
   &.btn-warning-outline-text {
@@ -526,19 +419,11 @@
 
     &:hover {
       color: tokens.$color-warning-600;
-
-      & svg { 
-        stroke: tokens.$color-warning-600;
-      }
     }
 
     &:active,
     &.active {
       color: tokens.$color-warning-700;
-
-      & svg { 
-        stroke: tokens.$color-warning-700;
-      }
     }
 
     &:disabled,
@@ -547,30 +432,11 @@
       background-color: transparent;
       border-color: transparent;
       color: tokens.$color-gray-300;
-
-      & svg { 
-        stroke: tokens.$color-gray-300;
-      }
-    }
-
-    & svg { 
-      stroke: tokens.$color-warning-500;
     }
   }
 }
 
 
-
-.ifx {
-  &__btn-icon {
-    &--before {
-      margin-right: 10px;
-    }
-
-    &--after {
-      margin-left: 10px;
-    }
-  }
-}
-
-
+ifx-icon:empty { 
+  display: none;
+ }

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -437,6 +437,6 @@
 }
 
 
-ifx-icon:empty { 
-  display: none;
- }
+// ifx-icon:empty { 
+//   display: none;
+//  }

--- a/src/components/button/button.stories.ts
+++ b/src/components/button/button.stories.ts
@@ -6,10 +6,10 @@ export default {
     color: "primary",
     size: "m",
     disabled: false,
-    icon: false,
+    icon: "",
+    position: 'left',
     href: "",
-    iconPosition: 'left'
-
+    target: '_blank'
   },
 
   argTypes: {
@@ -25,8 +25,12 @@ export default {
       options: ['s', 'm'],
       control: { type: 'radio' },
     },
-    iconPosition: {
+    position: {
       options: ['left', 'right'],
+      control: { type: 'radio' }
+    },
+    target: { 
+      options: ['_blank', '_self', '_parent'],
       control: { type: 'radio' }
     }
 
@@ -35,103 +39,13 @@ export default {
 
 
 const DefaultTemplate = (args) =>
-  `<ifx-button  variant="${args.variant}" href="${args.href}" target="_blank" color="${args.color}" size="${args.size}" disabled="${args.disabled}">
+  `<ifx-button  variant="${args.variant}" icon="${args.icon}" position="${args.position}" href="${args.href}" target="${args.target}" color="${args.color}" size="${args.size}" disabled="${args.disabled}">
   ${args.label}
   </ifx-button>`;
-
-const IconOnlyTemplate = (args) =>
-  `<ifx-button variant="${args.variant}" color="${args.color}" href="${args.href}" target="_blank" size="${args.size}" icon-only>
-  <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 16 16"><title>star 16</title><g stroke-width="1" stroke-linejoin="round" fill="currentColor" stroke="" stroke-linecap="round" class="nc-icon-wrapper"><polygon points="8,0.867 10.318,5.563 15.5,6.316 11.75,9.971 12.635,15.133 8,12.696 3.365,15.133 4.25,9.971 0.5,6.316 5.682,5.563 " data-cap="butt"></polygon> </g></svg>
-</ifx-button>`;
-
-const IconToTheLeftTemplate = (args) =>
-  `<ifx-button variant="${args.variant}" color="${args.color}" href="${args.href}" target="_blank" size="${args.size}" disabled="${args.disabled}" iconPosition="${args.iconPosition}">
-  <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 16 16"><title>star 16</title><g stroke-width="1" stroke-linejoin="round" fill="currentColor" stroke="" stroke-linecap="round" class="nc-icon-wrapper"><polygon points="8,0.867 10.318,5.563 15.5,6.316 11.75,9.971 12.635,15.133 8,12.696 3.365,15.133 4.25,9.971 0.5,6.316 5.682,5.563 " data-cap="butt"></polygon> </g></svg>
- ${args.label}
-  </ifx-button>`;
-
-const IconToTheRightTemplate = (args) =>
-  `<ifx-button l variant="${args.variant}" color="${args.color}" href="${args.href}" target="_blank" size="${args.size}" disabled="${args.disabled}" iconPosition="${args.iconPosition}">
-  ${args.label}   <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 16 16"><title>star 16</title><g stroke-width="1" stroke-linejoin="round" fill="currentColor" stroke="" stroke-linecap="round" class="nc-icon-wrapper"><polygon points="8,0.867 10.318,5.563 15.5,6.316 11.75,9.971 12.635,15.133 8,12.696 3.365,15.133 4.25,9.971 0.5,6.316 5.682,5.563 " data-cap="butt"></polygon> </g></svg>
-
-  </ifx-button>`;
-
-
 
 
 export const Default = DefaultTemplate.bind({});
 Default.argTypes = {
-  icon: {
-    table: {
-      disable: true,
-    }
-  },
-  iconPosition: {
-    table: {
-      disable: true,
-    },
-  }
+
 };
 
-export const WithLink = DefaultTemplate.bind({});
-WithLink.args = {
-  href: 'https://example.com',
-};
-WithLink.argTypes = {
-  icon: {
-    table: {
-      disable: true,
-    }
-  },
-  iconPosition: {
-    table: {
-      disable: true,
-    },
-  }
-};
-export const IconOnly = IconOnlyTemplate.bind({});
-IconOnly.argTypes = {
-  icon: {
-    table: {
-      disable: true,
-    }
-  },
-  iconPosition: {
-    table: {
-      disable: true,
-    },
-  }
-};
-
-export const IconToTheLeft = IconToTheLeftTemplate.bind({});
-IconToTheLeft.args = {
-  iconPosition: 'left'
-}
-IconToTheLeft.argTypes = {
-  icon: {
-    table: {
-      disable: true,
-    },
-  },
-  iconPosition: {
-    table: {
-      disable: true,
-    },
-  }
-};
-export const IconToTheRight = IconToTheRightTemplate.bind({});
-IconToTheRight.args = {
-  iconPosition: 'right'
-}
-IconToTheRight.argTypes = {
-  icon: {
-    table: {
-      disable: true,
-    },
-  },
-  iconPosition: {
-    table: {
-      disable: true,
-    },
-  }
-};

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, Host, Method } from '@stencil/core';
+import { Component, Prop, h, Host, Method, Element } from '@stencil/core';
 import classNames from 'classnames';
 
 @Component({
@@ -8,16 +8,15 @@ import classNames from 'classnames';
 })
 
 export class Button {
-  @Prop() label: string;
   @Prop() variant: 'solid' | 'outline' | 'outline-text';
   @Prop() color: 'primary' | 'secondary' | 'success' | 'danger' | 'warning';
-  @Prop() size: 's' | 'm';
+  @Prop() size: string;
   @Prop() disabled: boolean;
-
-  @Prop() iconOnly: boolean = false;
-  @Prop({ reflect: true }) iconPosition: 'left' | 'right' = 'left';
+  @Prop() icon: string;
+  @Prop({mutable: true}) position: string = 'left'
   @Prop() href: string;
   @Prop() target: string = '_self';
+  @Element() el;
 
   private focusableElement: HTMLElement;
 
@@ -26,6 +25,13 @@ export class Button {
     this.focusableElement.focus();
   }
 
+  componentWillLoad() {
+    if (this.position === '') {
+      this.position = 'left';
+    }
+  }
+
+  
   render() {
     return (
       <Host>
@@ -37,13 +43,18 @@ export class Button {
             target={this.target}
             rel={this.target === '_blank' ? 'noopener noreferrer' : undefined}
           >
-            <slot />
+           {this.icon && this.position === 'left' && <ifx-icon icon={this.icon}></ifx-icon>}
+            <slot></slot>
+           {this.icon && this.position === 'right' && <ifx-icon icon={this.icon}></ifx-icon>}
           </a>
         ) : (
-          <button class={this.getClassNames()}
+          <button 
+            class={this.getClassNames()}
             type="button"
           >
+            {this.icon && this.position === 'left' && <ifx-icon icon={this.icon}></ifx-icon>}
             <slot></slot>
+            {this.icon && this.position === 'right' && <ifx-icon icon={this.icon}></ifx-icon>}
           </button>
         )}
       </Host>
@@ -71,10 +82,6 @@ export class Button {
       'btn',
       this.size && `btn-${this.getSizeClass()}`,
       `btn-${this.getVariantClass()}`,
-      this.iconOnly && `btn-icon-only`,
-      !this.iconOnly &&
-      this.iconPosition &&
-      `btn--icon-${this.iconPosition}`,
       this.disabled ? 'disabled' : ''
     );
   }

--- a/src/components/button/readme.md
+++ b/src/components/button/readme.md
@@ -7,17 +7,16 @@
 
 ## Properties
 
-| Property       | Attribute       | Description | Type                                                             | Default     |
-| -------------- | --------------- | ----------- | ---------------------------------------------------------------- | ----------- |
-| `color`        | `color`         |             | `"danger" \| "primary" \| "secondary" \| "success" \| "warning"` | `undefined` |
-| `disabled`     | `disabled`      |             | `boolean`                                                        | `undefined` |
-| `href`         | `href`          |             | `string`                                                         | `undefined` |
-| `iconOnly`     | `icon-only`     |             | `boolean`                                                        | `false`     |
-| `iconPosition` | `icon-position` |             | `"left" \| "right"`                                              | `'left'`    |
-| `label`        | `label`         |             | `string`                                                         | `undefined` |
-| `size`         | `size`          |             | `"m" \| "s"`                                                     | `undefined` |
-| `target`       | `target`        |             | `string`                                                         | `'_self'`   |
-| `variant`      | `variant`       |             | `"outline" \| "outline-text" \| "solid"`                         | `undefined` |
+| Property   | Attribute  | Description | Type                                                             | Default     |
+| ---------- | ---------- | ----------- | ---------------------------------------------------------------- | ----------- |
+| `color`    | `color`    |             | `"danger" \| "primary" \| "secondary" \| "success" \| "warning"` | `undefined` |
+| `disabled` | `disabled` |             | `boolean`                                                        | `undefined` |
+| `href`     | `href`     |             | `string`                                                         | `undefined` |
+| `icon`     | `icon`     |             | `string`                                                         | `undefined` |
+| `position` | `position` |             | `string`                                                         | `'left'`    |
+| `size`     | `size`     |             | `string`                                                         | `undefined` |
+| `target`   | `target`   |             | `string`                                                         | `'_self'`   |
+| `variant`  | `variant`  |             | `"outline" \| "outline-text" \| "solid"`                         | `undefined` |
 
 
 ## Methods
@@ -32,6 +31,19 @@ Type: `Promise<void>`
 
 
 
+
+## Dependencies
+
+### Depends on
+
+- [ifx-icon](../icon)
+
+### Graph
+```mermaid
+graph TD;
+  ifx-button --> ifx-icon
+  style ifx-button fill:#f9f,stroke:#333,stroke-width:4px
+```
 
 ----------------------------------------------
 

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -2,7 +2,7 @@ import { Component, Prop, h, Host } from '@stencil/core';
 
 @Component({
   tag: 'ifx-card',
-  styleUrl: '_card.scss',
+  styleUrl: '../../index.scss',
   shadow: true,
 })
 

--- a/src/components/dropdown-item/dropdown-item.scss
+++ b/src/components/dropdown-item/dropdown-item.scss
@@ -1,7 +1,5 @@
 @use "../../../node_modules/@infineon/design-system-tokens/dist/tokens";
 
-
- 
  .dropdown-item {
       display: flex; 
       align-items: center;
@@ -92,6 +90,6 @@
       }
     }
 
-    ifx-icon:empty { 
-      display: none;
-    }
+    // ifx-icon:empty { 
+    //   display: none;
+    // }

--- a/src/components/dropdown-item/dropdown-item.scss
+++ b/src/components/dropdown-item/dropdown-item.scss
@@ -5,6 +5,7 @@
  .dropdown-item {
       display: flex; 
       align-items: center;
+      gap: 12px;
       width: 100%;
       text-align: inherit;
       white-space: nowrap;
@@ -47,10 +48,13 @@
       
    
       & .form-check-label {
-         flex: 1;
          &:hover { 
           cursor: pointer;
          }
+      }
+
+      & .form-check-input {
+        border-radius: 1px;
       }
 
       &:focus {
@@ -86,12 +90,8 @@
           fill: none;
         }
       }
-
-      & svg {
-        width: 13px;
-        height: 13px;
-        margin-right: 10px;
-        vertical-align: -0.5px;
-      }
     }
 
+    ifx-icon:empty { 
+      display: none;
+    }

--- a/src/components/dropdown-item/dropdown-item.tsx
+++ b/src/components/dropdown-item/dropdown-item.tsx
@@ -3,6 +3,7 @@ import { Component, Prop, h, Element, State } from "@stencil/core";
 @Component({
   tag: 'ifx-dropdown-item',
   styleUrl: '../../index.scss',
+  //styleUrls: ['../../global/global-theme.scss', './dropdown-item.scss'],
   shadow: true
 })
 
@@ -11,7 +12,7 @@ export class DropdownItem {
   @Prop() label: string;
   @Prop() size: 's' | 'm';
   @Prop() disabled: boolean;
-  @Prop() icon: boolean = false;
+  @Prop() icon: string;
   @Prop() checkable: boolean = false;
   @State() checkboxColor: string = "";
   @Element() el;
@@ -28,11 +29,10 @@ export class DropdownItem {
   }
 
   render() {
-
     return (
        <a href="javascript:;" class={`dropdown-item ${this.checkboxColor}`}>
           {this.checkable && <input type="checkbox" id="checkbox4" class={`form-check-input`} />}
-          <ifx-icon icon="bell24"></ifx-icon>
+          {this.icon && <ifx-icon icon={this.icon}></ifx-icon>}
           <label htmlFor="checkbox4" class="form-check-label"><slot /></label>
         </a>
     )

--- a/src/components/dropdown-item/dropdown-item.tsx
+++ b/src/components/dropdown-item/dropdown-item.tsx
@@ -3,7 +3,6 @@ import { Component, Prop, h, Element, State } from "@stencil/core";
 @Component({
   tag: 'ifx-dropdown-item',
   styleUrl: '../../index.scss',
-  //styleUrls: ['../../global/global-theme.scss', './dropdown-item.scss'],
   shadow: true
 })
 

--- a/src/components/dropdown-item/readme.md
+++ b/src/components/dropdown-item/readme.md
@@ -11,7 +11,7 @@
 | ----------- | ----------- | ----------- | ------------ | ----------- |
 | `checkable` | `checkable` |             | `boolean`    | `false`     |
 | `disabled`  | `disabled`  |             | `boolean`    | `undefined` |
-| `icon`      | `icon`      |             | `boolean`    | `false`     |
+| `icon`      | `icon`      |             | `string`     | `undefined` |
 | `label`     | `label`     |             | `string`     | `undefined` |
 | `size`      | `size`      |             | `"m" \| "s"` | `undefined` |
 
@@ -20,7 +20,7 @@
 
 ### Depends on
 
-- [ifx-icon](../..)
+- [ifx-icon](../icon)
 
 ### Graph
 ```mermaid

--- a/src/components/dropdown-menu/dropdown-menu.scss
+++ b/src/components/dropdown-menu/dropdown-menu.scss
@@ -67,7 +67,7 @@
       color: tokens.$color-text-black;
    
       & .form-check-label {
-         flex: 1;
+         //flex: 1;
          &:hover { 
           cursor: pointer;
          }

--- a/src/components/dropdown-menu/dropdown-menu.scss
+++ b/src/components/dropdown-menu/dropdown-menu.scss
@@ -1,6 +1,5 @@
 @use "../../../node_modules/@infineon/design-system-tokens/dist/tokens";
 
-
   .dropdown-menu { 
     display: none;
   }

--- a/src/components/dropdown/_dropdown.scss
+++ b/src/components/dropdown/_dropdown.scss
@@ -51,7 +51,4 @@
 }
 
 
-.form-check-input {
-  border-radius: 1px;
-  margin-right: 12px;
-}
+

--- a/src/components/icon/infineonIconStencil.scss
+++ b/src/components/icon/infineonIconStencil.scss
@@ -1,0 +1,3 @@
+ifx-icon { 
+  display: inline-flex;
+}

--- a/src/components/icon/infineonIconStencil.tsx
+++ b/src/components/icon/infineonIconStencil.tsx
@@ -45,7 +45,6 @@ export class InfineonIconStencil {
 }
   
   componentWillLoad() {
-    console.log('icon', this.icon)
     this.ifxIcon = getIcon(this.icon);
   }
 

--- a/src/components/icon/infineonIconStencil.tsx
+++ b/src/components/icon/infineonIconStencil.tsx
@@ -8,44 +8,62 @@ import { getIcon } from '@infineon/infineon-icons'
 })
 
 export class InfineonIconStencil {
-  @Prop({ mutable: true }) icon: any = "";
+  @Prop({ mutable: true }) icon: any;
   @Prop({ mutable: true }) ifxIcon: any;
  
   convertStringToHtml(htmlString) { 
     const div = document.createElement('div')
     div.innerHTML = htmlString
-    return div.firstElementChild
+    return div.firstChild
   }
 
-  convertPathToVnode(pathString) { 
-    const pathToObject = Array
-    .from(pathString.attributes, ({ name, value }) => ({ name, value }))
-    .reduce((acc, current) => {
-      acc[current.name] = current.value
-      return acc
-    }, {})
-    const objToVnode = h("path", pathToObject)
-    return objToVnode
+  convertHtmlToObject(htmlElement) { 
+    let pathToObject = Array
+      .from(htmlElement.attributes, ({ name, value }) => ({ name, value }))
+      .reduce((acc, current) => {
+        acc[current.name] = current.value
+        return acc
+      }, {})
+
+    return pathToObject
+  }
+
+  convertPathsToVnode(htmlPath) { 
+    let svgPaths = []
+    const parentPath = this.convertHtmlToObject(htmlPath);
+    const parentPathToVnode = h("path", parentPath);
+    svgPaths.push(parentPathToVnode)
+    if(htmlPath.firstChild) { 
+      const paths = htmlPath.querySelectorAll('path');
+      const pathLength = htmlPath.querySelectorAll('path').length;
+      for(let i = 0; i < pathLength; i++) { 
+        let pathToObject = this.convertHtmlToObject(paths[i])
+        let objToVnode = h("path", pathToObject)
+        svgPaths.push(objToVnode)
+      }      
+    }
+    return svgPaths
   }
 
   getSVG(svgPath) {
-    return <svg class="inline-svg" width={this.ifxIcon.width} height={this.ifxIcon.height} xmlns="http://www.w3.org/2000/svg" fill={this.ifxIcon.fill} viewBox={this.ifxIcon.viewBox}>{svgPath}</svg>
+    return <svg class="inline-svg" width={this.ifxIcon.width} height={this.ifxIcon.height} xmlns="http://www.w3.org/2000/svg" fill={this.ifxIcon.fill} viewBox={this.ifxIcon.viewBox}>{...svgPath}</svg>
   }
 
   constructIcon() {
     if(this.ifxIcon) {
       const htmlPath = this.convertStringToHtml(this.ifxIcon.svgContent)
-      const svgPath = this.convertPathToVnode(htmlPath)
+      const svgPath = this.convertPathsToVnode(htmlPath)
       const SVG = this.getSVG(svgPath)
       return SVG;
     } else {
       console.error('Icon not found!')
       return ""
     }
-}
-  
+  }
+
   componentWillLoad() {
-    this.ifxIcon = getIcon(this.icon);
+    const removeHyphen = (str) => str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (_m, chr) => chr);
+    this.ifxIcon = getIcon(removeHyphen(this.icon));
   }
 
   render() {

--- a/src/components/icon/infineonIconStencil.tsx
+++ b/src/components/icon/infineonIconStencil.tsx
@@ -1,13 +1,14 @@
-import { Component, Prop, h } from '@stencil/core';
+import { Component, Prop, h, Host } from '@stencil/core';
 import { getIcon } from '@infineon/infineon-icons'
 
 
 @Component({
   tag: 'ifx-icon',
+  styleUrl: './infineonIconStencil.scss'
 })
 
 export class InfineonIconStencil {
-  @Prop({ mutable: true }) icon: any;
+  @Prop({ mutable: true }) icon: any = "";
   @Prop({ mutable: true }) ifxIcon: any;
  
   convertStringToHtml(htmlString) { 
@@ -44,14 +45,15 @@ export class InfineonIconStencil {
 }
   
   componentWillLoad() {
+    console.log('icon', this.icon)
     this.ifxIcon = getIcon(this.icon);
   }
 
   render() {
     return (
-      <div class="svg-wrapper">
+      <Host>
       {this.constructIcon()}
-      </div>
+      </Host>
     );
   }
 }

--- a/src/components/icon/readme.md
+++ b/src/components/icon/readme.md
@@ -17,9 +17,9 @@
 
 ### Used by
 
- - [ifx-alert](./components/alert)
- - [ifx-button](./components/button)
- - [ifx-dropdown-item](./components/dropdown-item)
+ - [ifx-alert](../alert)
+ - [ifx-button](../button)
+ - [ifx-dropdown-item](../dropdown-item)
 
 ### Graph
 ```mermaid

--- a/src/components/icon/readme.md
+++ b/src/components/icon/readme.md
@@ -9,7 +9,7 @@
 
 | Property  | Attribute  | Description | Type  | Default     |
 | --------- | ---------- | ----------- | ----- | ----------- |
-| `icon`    | `icon`     |             | `any` | `""`        |
+| `icon`    | `icon`     |             | `any` | `undefined` |
 | `ifxIcon` | `ifx-icon` |             | `any` | `undefined` |
 
 

--- a/src/global/global-theme.scss
+++ b/src/global/global-theme.scss
@@ -6,3 +6,7 @@
   line-height: tokens.$font-line-height-m;
   font-family: tokens.$font-family-body;
 }
+
+ifx-icon:empty { 
+  display: none;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -14,15 +14,14 @@
 <body>
 
 
-  <ifx-alert color="primary" icon="calendar-16">my alert</ifx-alert>
+  <ifx-alert color="warning" icon="c-info-24">my alert</ifx-alert>
+  <ifx-button color="secondary" icon="B-e-L-L2-4">my button</ifx-button>
+  <ifx-button color="warning" icon="bell24">my button</ifx-button>
+  <ifx-button color="danger" icon="cINFO-16">my button</ifx-button>
+  <ifx-button color="primary" icon="">my button</ifx-button>
+  <ifx-button color="secondary" icon="asfdsfsf">my button</ifx-button>
+  <ifx-button color="warning">my button</ifx-button>
 
-  <ifx-dropdown-menu>
-    <ifx-dropdown-item icon="fsfsfsf">One</ifx-dropdown-item>
-    <ifx-dropdown-item icon="">One</ifx-dropdown-item>
-    <ifx-dropdown-item>One</ifx-dropdown-item>
-    <ifx-dropdown-item icon="calendar-16">four</ifx-dropdown-item>
-  </ifx-dropdown-menu>
-  
 
 </body>
 

--- a/src/index.html
+++ b/src/index.html
@@ -13,14 +13,15 @@
 
 <body>
 
-    <ifx-dropdown-menu>
-      <ifx-dropdown-item checkable>one</ifx-dropdown-item>
-      <ifx-dropdown-item checkable>two</ifx-dropdown-item>
-      <ifx-dropdown-item checkable>three</ifx-dropdown-item>
-      <ifx-dropdown-item checkable>four</ifx-dropdown-item>
-    </ifx-dropdown-menu>
- 
 
+  <ifx-alert color="primary" icon="calendar-16">my alert</ifx-alert>
+
+  <ifx-dropdown-menu>
+    <ifx-dropdown-item icon="fsfsfsf">One</ifx-dropdown-item>
+    <ifx-dropdown-item icon="">One</ifx-dropdown-item>
+    <ifx-dropdown-item>One</ifx-dropdown-item>
+    <ifx-dropdown-item icon="calendar-16">four</ifx-dropdown-item>
+  </ifx-dropdown-menu>
   
 
 </body>

--- a/src/index.scss
+++ b/src/index.scss
@@ -6,3 +6,4 @@
 @import "./components/dropdown-item/dropdown-item";
 @import "./components/search-input/search-input";
 @import "./components/filter-input/filter-input";
+@import "./components/alert/alert";

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -24,9 +24,11 @@ export const config: Config = {
       serviceWorker: null, // disable service workers
     },
   ],
+  
   plugins: [
     sass()
   ],
+  
   // rollupPlugins: {
   //   after: [
   //     nodePolyfills(),


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

- Nested the ifx-icon in alert, button and dropdown-item
- Created separate component folder for ifx-icon
- Replace the svg wrapper with <host>
- modify the scss of the above mentioned components to remove styles on 'stroke' 
- replaced margins with gap whenever the container is flex
- Made the icon position on the button component work
- Updated storybook
- Fixed the case when icon string is empty
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.64--canary.40.754c46e8fca8c341021a04d6ae516765280b03b7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@0.0.64--canary.40.754c46e8fca8c341021a04d6ae516765280b03b7.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@0.0.64--canary.40.754c46e8fca8c341021a04d6ae516765280b03b7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
