### PR TITLE
updates on the master branch will now lead to a new package release o…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,8 @@ on:
       - synchronize # canary on new commit
   push:
     branches:
-     # - master
-      - testing-phase
-
+     - master
+ 
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
…n npm registry again

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
After the completion of our testing phase, I have re-enabled the publishing of a new package version on npm registry after a new commit/merge has been made on the master branch. During the testing phase, only canary releases could be made, so testers could use the official version we sent out for testing.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.64--canary.51.b269a6692ee1f4b4a7acb3fef3ab11e9e89a54ae.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@0.0.64--canary.51.b269a6692ee1f4b4a7acb3fef3ab11e9e89a54ae.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@0.0.64--canary.51.b269a6692ee1f4b4a7acb3fef3ab11e9e89a54ae.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
