### PR TITLE
progress-bar fixed styling; fixed version display on storybook gettin…

### DIFF
--- a/.github/workflows/github_pages_angular_master.yml
+++ b/.github/workflows/github_pages_angular_master.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache dependencies for packages/components
         uses: actions/cache@v2

--- a/.github/workflows/github_pages_angular_preview.yml
+++ b/.github/workflows/github_pages_angular_preview.yml
@@ -19,14 +19,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
+        
       - name: Use Node.js 16
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache dependencies for packages/components
         uses: actions/cache@v2

--- a/.github/workflows/github_pages_master.yml
+++ b/.github/workflows/github_pages_master.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache dependencies for packages/components
         uses: actions/cache@v2

--- a/.github/workflows/github_pages_preview.yml
+++ b/.github/workflows/github_pages_preview.yml
@@ -17,14 +17,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
+        
       - name: Use Node.js 16
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache dependencies for packages/components
         uses: actions/cache@v2

--- a/.github/workflows/github_pages_react_master.yml
+++ b/.github/workflows/github_pages_react_master.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache dependencies for packages/components
         uses: actions/cache@v2

--- a/.github/workflows/github_pages_react_preview.yml
+++ b/.github/workflows/github_pages_react_preview.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache dependencies for packages/components
         uses: actions/cache@v2

--- a/.github/workflows/github_pages_vanilla_master.yml
+++ b/.github/workflows/github_pages_vanilla_master.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache dependencies for packages/components
         uses: actions/cache@v2

--- a/.github/workflows/github_pages_vanilla_preview.yml
+++ b/.github/workflows/github_pages_vanilla_preview.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache dependencies for packages/components
         uses: actions/cache@v2

--- a/.github/workflows/github_pages_vue_master.yml
+++ b/.github/workflows/github_pages_vue_master.yml
@@ -20,9 +20,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache dependencies for packages/components
         uses: actions/cache@v2

--- a/.github/workflows/github_pages_vue_preview.yml
+++ b/.github/workflows/github_pages_vue_preview.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Cache dependencies for packages/components
         uses: actions/cache@v2

--- a/examples/stencil-components/angular/package-lock.json
+++ b/examples/stencil-components/angular/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "~15.2.8",
         "@angular/platform-browser-dynamic": "~15.2.8",
         "@angular/router": "~15.2.8",
-        "@infineon/infineon-design-system-stencil": "^18.0.8",
+        "@infineon/infineon-design-system-stencil": "^18.1.2--canary.154.9f0173449eef9d1fa54473c38b5b373f097d0cdc.0",
         "core-js": "^2.5.4",
         "rxjs": "~6.5.3",
         "tslib": "^1.9.0",
@@ -2700,13 +2700,14 @@
       "integrity": "sha512-1w7KCTmMeZu5NUV+bMdNnk4VXqJGCe6q50dwXCioBd9rqoymun9D0rMkrC/O5m/28Je6gHcLwjQ0iiwFrssEyg=="
     },
     "node_modules/@infineon/infineon-design-system-stencil": {
-      "version": "18.0.8",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.0.8.tgz",
-      "integrity": "sha512-fr1H4aszflhHIE1vM0jxmHCNkQDgr2Y1VueHMzzcoqWC1Ax0s7vYSsYS9548kPBLVr4BFTLsozgPRJK7E5ICvQ==",
+      "version": "18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0.tgz",
+      "integrity": "sha512-zS7hUaCRw7kBNiTqWnqAzvuRoz6XVZ//Lt2UJ7GIfm5VWfDkGZn7pbJMFnd80z9lE5OcubbVzudS5aijxBdp5A==",
       "dependencies": {
         "@infineon/design-system-tokens": "^2.0.1",
         "@infineon/infineon-icons": "^1.1.2",
-        "@stencil/core": "^2.16.0"
+        "@stencil/core": "^2.16.0",
+        "fs-extra": "^11.1.1"
       }
     },
     "node_modules/@infineon/infineon-icons": {
@@ -5790,6 +5791,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.2.tgz",
@@ -6053,8 +6067,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
@@ -7195,6 +7208,17 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
@@ -11494,6 +11518,14 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -13918,13 +13950,14 @@
       "integrity": "sha512-1w7KCTmMeZu5NUV+bMdNnk4VXqJGCe6q50dwXCioBd9rqoymun9D0rMkrC/O5m/28Je6gHcLwjQ0iiwFrssEyg=="
     },
     "@infineon/infineon-design-system-stencil": {
-      "version": "18.0.8",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.0.8.tgz",
-      "integrity": "sha512-fr1H4aszflhHIE1vM0jxmHCNkQDgr2Y1VueHMzzcoqWC1Ax0s7vYSsYS9548kPBLVr4BFTLsozgPRJK7E5ICvQ==",
+      "version": "18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0.tgz",
+      "integrity": "sha512-zS7hUaCRw7kBNiTqWnqAzvuRoz6XVZ//Lt2UJ7GIfm5VWfDkGZn7pbJMFnd80z9lE5OcubbVzudS5aijxBdp5A==",
       "requires": {
         "@infineon/design-system-tokens": "^2.0.1",
         "@infineon/infineon-icons": "^1.1.2",
-        "@stencil/core": "^2.16.0"
+        "@stencil/core": "^2.16.0",
+        "fs-extra": "^11.1.1"
       }
     },
     "@infineon/infineon-icons": {
@@ -16336,6 +16369,16 @@
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs-minipass": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.2.tgz",
@@ -16525,8 +16568,7 @@
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "handle-thing": {
       "version": "2.0.1",
@@ -17368,6 +17410,15 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -20596,6 +20647,11 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/examples/stencil-components/angular/package.json
+++ b/examples/stencil-components/angular/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser": "~15.2.8",
     "@angular/platform-browser-dynamic": "~15.2.8",
     "@angular/router": "~15.2.8",
-    "@infineon/infineon-design-system-stencil": "^18.0.21",
+    "@infineon/infineon-design-system-stencil": "^18.1.2--canary.154.9f0173449eef9d1fa54473c38b5b373f097d0cdc.0",
     "core-js": "^2.5.4",
     "rxjs": "~6.5.3",
     "tslib": "^1.9.0",

--- a/examples/stencil-components/react/package-lock.json
+++ b/examples/stencil-components/react/package-lock.json
@@ -8,7 +8,7 @@
       "name": "react-app",
       "version": "0.1.0",
       "dependencies": {
-        "@infineon/infineon-design-system-stencil": "18.0.21",
+        "@infineon/infineon-design-system-stencil": "^18.1.2--canary.154.9f0173449eef9d1fa54473c38b5b373f097d0cdc.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2326,13 +2326,27 @@
       "integrity": "sha512-1w7KCTmMeZu5NUV+bMdNnk4VXqJGCe6q50dwXCioBd9rqoymun9D0rMkrC/O5m/28Je6gHcLwjQ0iiwFrssEyg=="
     },
     "node_modules/@infineon/infineon-design-system-stencil": {
-      "version": "18.0.21",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.0.21.tgz",
-      "integrity": "sha512-YFN855/tSv3fdX9/Eqm2rkQd6BMpJkm4Gr+i/sl16XF2wsfNX9lc/+6K3POsq/MEQ6unBKQiYyhx0C3YPnQZfQ==",
+      "version": "18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0.tgz",
+      "integrity": "sha512-zS7hUaCRw7kBNiTqWnqAzvuRoz6XVZ//Lt2UJ7GIfm5VWfDkGZn7pbJMFnd80z9lE5OcubbVzudS5aijxBdp5A==",
       "dependencies": {
         "@infineon/design-system-tokens": "^2.0.1",
         "@infineon/infineon-icons": "^1.1.2",
-        "@stencil/core": "^2.16.0"
+        "@stencil/core": "^2.16.0",
+        "fs-extra": "^11.1.1"
+      }
+    },
+    "node_modules/@infineon/infineon-design-system-stencil/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/@infineon/infineon-icons": {
@@ -18941,13 +18955,26 @@
       "integrity": "sha512-1w7KCTmMeZu5NUV+bMdNnk4VXqJGCe6q50dwXCioBd9rqoymun9D0rMkrC/O5m/28Je6gHcLwjQ0iiwFrssEyg=="
     },
     "@infineon/infineon-design-system-stencil": {
-      "version": "18.0.21",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.0.21.tgz",
-      "integrity": "sha512-YFN855/tSv3fdX9/Eqm2rkQd6BMpJkm4Gr+i/sl16XF2wsfNX9lc/+6K3POsq/MEQ6unBKQiYyhx0C3YPnQZfQ==",
+      "version": "18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0.tgz",
+      "integrity": "sha512-zS7hUaCRw7kBNiTqWnqAzvuRoz6XVZ//Lt2UJ7GIfm5VWfDkGZn7pbJMFnd80z9lE5OcubbVzudS5aijxBdp5A==",
       "requires": {
         "@infineon/design-system-tokens": "^2.0.1",
         "@infineon/infineon-icons": "^1.1.2",
-        "@stencil/core": "^2.16.0"
+        "@stencil/core": "^2.16.0",
+        "fs-extra": "^11.1.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+          "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        }
       }
     },
     "@infineon/infineon-icons": {

--- a/examples/stencil-components/react/package.json
+++ b/examples/stencil-components/react/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "./",
   "dependencies": {
-    "@infineon/infineon-design-system-stencil": "18.0.21",
+    "@infineon/infineon-design-system-stencil": "^18.1.2--canary.154.9f0173449eef9d1fa54473c38b5b373f097d0cdc.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/examples/stencil-components/vanilla-cdn/package-lock.json
+++ b/examples/stencil-components/vanilla-cdn/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vanilla-cdn",
       "version": "1.0.0",
       "dependencies": {
-        "@infineon/infineon-design-system-stencil": "18.0.21",
+        "@infineon/infineon-design-system-stencil": "^18.1.2--canary.154.9f0173449eef9d1fa54473c38b5b373f097d0cdc.0",
         "typescript": "^4.5.4"
       },
       "devDependencies": {
@@ -408,13 +408,14 @@
       "integrity": "sha512-1w7KCTmMeZu5NUV+bMdNnk4VXqJGCe6q50dwXCioBd9rqoymun9D0rMkrC/O5m/28Je6gHcLwjQ0iiwFrssEyg=="
     },
     "node_modules/@infineon/infineon-design-system-stencil": {
-      "version": "18.0.21",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.0.21.tgz",
-      "integrity": "sha512-YFN855/tSv3fdX9/Eqm2rkQd6BMpJkm4Gr+i/sl16XF2wsfNX9lc/+6K3POsq/MEQ6unBKQiYyhx0C3YPnQZfQ==",
+      "version": "18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0.tgz",
+      "integrity": "sha512-zS7hUaCRw7kBNiTqWnqAzvuRoz6XVZ//Lt2UJ7GIfm5VWfDkGZn7pbJMFnd80z9lE5OcubbVzudS5aijxBdp5A==",
       "dependencies": {
         "@infineon/design-system-tokens": "^2.0.1",
         "@infineon/infineon-icons": "^1.1.2",
-        "@stencil/core": "^2.16.0"
+        "@stencil/core": "^2.16.0",
+        "fs-extra": "^11.1.1"
       }
     },
     "node_modules/@infineon/infineon-icons": {
@@ -810,6 +811,19 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -930,8 +944,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -1296,6 +1309,17 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -1981,6 +2005,14 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -2280,13 +2312,14 @@
       "integrity": "sha512-1w7KCTmMeZu5NUV+bMdNnk4VXqJGCe6q50dwXCioBd9rqoymun9D0rMkrC/O5m/28Je6gHcLwjQ0iiwFrssEyg=="
     },
     "@infineon/infineon-design-system-stencil": {
-      "version": "18.0.21",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.0.21.tgz",
-      "integrity": "sha512-YFN855/tSv3fdX9/Eqm2rkQd6BMpJkm4Gr+i/sl16XF2wsfNX9lc/+6K3POsq/MEQ6unBKQiYyhx0C3YPnQZfQ==",
+      "version": "18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0.tgz",
+      "integrity": "sha512-zS7hUaCRw7kBNiTqWnqAzvuRoz6XVZ//Lt2UJ7GIfm5VWfDkGZn7pbJMFnd80z9lE5OcubbVzudS5aijxBdp5A==",
       "requires": {
         "@infineon/design-system-tokens": "^2.0.1",
         "@infineon/infineon-icons": "^1.1.2",
-        "@stencil/core": "^2.16.0"
+        "@stencil/core": "^2.16.0",
+        "fs-extra": "^11.1.1"
       }
     },
     "@infineon/infineon-icons": {
@@ -2600,6 +2633,16 @@
         "is-callable": "^1.1.3"
       }
     },
+    "fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -2683,8 +2726,7 @@
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "has": {
       "version": "1.0.3",
@@ -2935,6 +2977,15 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -3416,6 +3467,11 @@
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/examples/stencil-components/vanilla-cdn/package.json
+++ b/examples/stencil-components/vanilla-cdn/package.json
@@ -23,7 +23,7 @@
     "vite": "^4.2.1"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-stencil": "18.0.21",
+    "@infineon/infineon-design-system-stencil": "^18.1.2--canary.154.9f0173449eef9d1fa54473c38b5b373f097d0cdc.0",
     "typescript": "^4.5.4"
   }
 }

--- a/examples/stencil-components/vue3-vite/package-lock.json
+++ b/examples/stencil-components/vue3-vite/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vue3-vite",
       "version": "0.0.0",
       "dependencies": {
-        "@infineon/infineon-design-system-stencil": "18.0.22--canary.150.deeaeab2c8c24a0ca1989901c2d5b54e11a61c1b.1",
+        "@infineon/infineon-design-system-stencil": "^18.1.2--canary.154.9f0173449eef9d1fa54473c38b5b373f097d0cdc.0",
         "vue": "^3.2.45"
       },
       "devDependencies": {
@@ -388,13 +388,14 @@
       "integrity": "sha512-1w7KCTmMeZu5NUV+bMdNnk4VXqJGCe6q50dwXCioBd9rqoymun9D0rMkrC/O5m/28Je6gHcLwjQ0iiwFrssEyg=="
     },
     "node_modules/@infineon/infineon-design-system-stencil": {
-      "version": "18.0.22--canary.150.deeaeab2c8c24a0ca1989901c2d5b54e11a61c1b.1",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.0.22--canary.150.deeaeab2c8c24a0ca1989901c2d5b54e11a61c1b.1.tgz",
-      "integrity": "sha512-+3K5mM+TfFuAhf/le5Y0YIoQN37FYMOUJVN2aHD7xR1Xemkkc5W4RNPd4pS9jRSAkyaOtZyjJDU5M8no9NanGw==",
+      "version": "18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0.tgz",
+      "integrity": "sha512-zS7hUaCRw7kBNiTqWnqAzvuRoz6XVZ//Lt2UJ7GIfm5VWfDkGZn7pbJMFnd80z9lE5OcubbVzudS5aijxBdp5A==",
       "dependencies": {
         "@infineon/design-system-tokens": "^2.0.1",
         "@infineon/infineon-icons": "^1.1.2",
-        "@stencil/core": "^2.16.0"
+        "@stencil/core": "^2.16.0",
+        "fs-extra": "^11.1.1"
       }
     },
     "node_modules/@infineon/infineon-icons": {
@@ -1411,6 +1412,19 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1538,8 +1552,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -1959,6 +1972,17 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/klona": {
       "version": "2.0.6",
@@ -2808,6 +2832,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -3214,13 +3246,14 @@
       "integrity": "sha512-1w7KCTmMeZu5NUV+bMdNnk4VXqJGCe6q50dwXCioBd9rqoymun9D0rMkrC/O5m/28Je6gHcLwjQ0iiwFrssEyg=="
     },
     "@infineon/infineon-design-system-stencil": {
-      "version": "18.0.22--canary.150.deeaeab2c8c24a0ca1989901c2d5b54e11a61c1b.1",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.0.22--canary.150.deeaeab2c8c24a0ca1989901c2d5b54e11a61c1b.1.tgz",
-      "integrity": "sha512-+3K5mM+TfFuAhf/le5Y0YIoQN37FYMOUJVN2aHD7xR1Xemkkc5W4RNPd4pS9jRSAkyaOtZyjJDU5M8no9NanGw==",
+      "version": "18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-18.1.2--canary.154.d2ea29ee03f803dfc10c5c6a40ef5e066eac1220.0.tgz",
+      "integrity": "sha512-zS7hUaCRw7kBNiTqWnqAzvuRoz6XVZ//Lt2UJ7GIfm5VWfDkGZn7pbJMFnd80z9lE5OcubbVzudS5aijxBdp5A==",
       "requires": {
         "@infineon/design-system-tokens": "^2.0.1",
         "@infineon/infineon-icons": "^1.1.2",
-        "@stencil/core": "^2.16.0"
+        "@stencil/core": "^2.16.0",
+        "fs-extra": "^11.1.1"
       }
     },
     "@infineon/infineon-icons": {
@@ -4073,6 +4106,16 @@
         "is-callable": "^1.1.3"
       }
     },
+    "fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -4163,8 +4206,7 @@
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "has": {
       "version": "1.0.3",
@@ -4460,6 +4502,15 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "peer": true
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
     },
     "klona": {
       "version": "2.0.6",
@@ -5032,6 +5083,11 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "update-browserslist-db": {
       "version": "1.0.11",

--- a/examples/stencil-components/vue3-vite/package.json
+++ b/examples/stencil-components/vue3-vite/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p build:stencil preview:link"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-stencil": "18.0.22--canary.150.deeaeab2c8c24a0ca1989901c2d5b54e11a61c1b.1",
+    "@infineon/infineon-design-system-stencil": "^18.1.2--canary.154.9f0173449eef9d1fa54473c38b5b373f097d0cdc.0",
     "vue": "^3.2.45"
   },
   "devDependencies": {

--- a/examples/stencil-components/vue3-vite/src/components/HelloWorld.vue
+++ b/examples/stencil-components/vue3-vite/src/components/HelloWorld.vue
@@ -27,13 +27,16 @@ const buttons = ref(["Button 1", "Button 2", "Button 3"]);
 
       <p>{{ msg }}</p>
       <ifx-progress-bar value="50" size="m" show-label="true"></ifx-progress-bar>
-      <ifx-progress-bar :value="progressValue.value" size="m" show-label="true"
+      <ifx-progress-bar :value="progressValue" size="m" show-label="true"
         @ifxChange:progressValue="handleProgressUpdate"></ifx-progress-bar>
 
-      <ifx-button variant="solid" icon="" position="left" href="" target="_blank" color="primary" size="m"
-        disabled="false" @click="updateProgressOnClick">
-        Update progress
-      </ifx-button>
+      <div>
+        <ifx-button variant="solid" icon="" position="left" href="" target="_blank" color="primary" size="m"
+          disabled="false" @click="updateProgressOnClick">
+          Update progress
+        </ifx-button>
+      </div>
+
 
 
       <br />

--- a/packages/components/src/components/accordion/readme.md
+++ b/packages/components/src/components/accordion/readme.md
@@ -1,4 +1,4 @@
-# ifx-tag
+# ifx-accordion-item
 
 
 

--- a/packages/components/src/components/progress-bar/progress-bar.scss
+++ b/packages/components/src/components/progress-bar/progress-bar.scss
@@ -1,6 +1,12 @@
 @use "../../../node_modules/@infineon/design-system-tokens/dist/tokens";
 
 
+:host {
+  display: flex;
+  width: 100%;
+}
+
+
 .progress-bar {
   height: 16px;
   border-radius: 1px;
@@ -8,6 +14,13 @@
   right: 0;
   top: 0;
   left: 0;
+  display: flex;
+  height: 16px;
+  border-radius: 1px;
+  width: 100%; // Ensure the bar itself can grow up to 100% width
+  overflow: hidden; // Ensures that the inner progress bar doesn't exceed the width of the outer progress bar
+
+
 
   .label {
     height: 17px;

--- a/packages/components/src/stories/setup/GettingStarted_en.md
+++ b/packages/components/src/stories/setup/GettingStarted_en.md
@@ -1,7 +1,7 @@
 # Infineon Design System Stencil Web Components
 [![GitHub Repo Issues](https://img.shields.io/github/issues/Infineon/infineon-design-system-stencil?style=plastic)](https://github.com/Infineon/infineon-design-system-stencil/issues)
 [![GitHub Pull Requests](https://img.shields.io/github/issues-pr-raw/Infineon/infineon-design-system-stencil?style=plastic)](https://github.com/Infineon/infineon-design-system-stencil/pulls)
-[![GitHub Repo Version](https://img.shields.io/github/package-json/v/Infineon/infineon-design-system-stencil?style=plastic)](https://github.com/Infineon/infineon-design-system-stencil/blob/master/package.json)
+[![GitHub Repo Version](https://img.shields.io/npm/v/@infineon/infineon-design-system-stencil)](https://www.npmjs.com/package/@infineon/infineon-design-system-stencil)
 [![GitHub Master Branch Weekly Commits](https://img.shields.io/github/commit-activity/w/Infineon/infineon-design-system-stencil/master?style=plastic)](https://github.com/Infineon/infineon-design-system-stencil/tree/master)
 [![GitHub Repo Contributors](https://img.shields.io/github/contributors/Infineon/infineon-design-system-stencil?style=plastic)](https://github.com/Infineon/infineon-design-system-stencil/graphs/contributors)
 [![GitHub Repo Discussions](https://img.shields.io/github/discussions/Infineon/infineon-design-system-stencil)](https://github.com/Infineon/infineon-design-system-stencil/)


### PR DESCRIPTION
…g started page

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Progress-bar styling bug fixed
Storybook Getting Started page now displays the current version again
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.1.2--canary.154.59500ad96a1e97e7588b7fd71688df2d355d3770.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@18.1.2--canary.154.59500ad96a1e97e7588b7fd71688df2d355d3770.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@18.1.2--canary.154.59500ad96a1e97e7588b7fd71688df2d355d3770.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
