### PR TITLE
added height 100% to sidebar host

### DIFF
--- a/packages/components/src/components/sidebar/sidebar.scss
+++ b/packages/components/src/components/sidebar/sidebar.scss
@@ -1,5 +1,9 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 
+:host { 
+  height: 100%;
+}
+
 .sidebar__container {
   box-sizing: border-box;
   display: inline-flex;

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -21,8 +21,6 @@
 
 <body>
 
-
-
 </body>
 
 </html>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Added height of 100% to the host of Sidebar. This is needed for some cases, such as when the sidebar is inside a flex container with a flex-direction of column.