### PR TITLE
Search-field height issue

### DIFF
--- a/packages/components/src/components/search-field/search-field.scss
+++ b/packages/components/src/components/search-field/search-field.scss
@@ -32,9 +32,9 @@
       height: 36px;
     }
 
-    &.search-field__wrapper-m {
-      height: tokens.$ifxSpace150;
-    }
+    // &.search-field__wrapper-m {
+    //   height: tokens.$ifxSpace150;
+    // }
 
     // &:not(.search-field__wrapper-s):not(.search-field__wrapper-m) {
     //   height: 48px;

--- a/packages/components/src/components/search-field/search-field.tsx
+++ b/packages/components/src/components/search-field/search-field.tsx
@@ -83,9 +83,7 @@ export class SearchField {
   getSizeClass() {
     return `${this.size}` === "s"
       ? "search-field__wrapper-s"
-      : `${this.size}` === "m"
-        ? "search-field__wrapper-m"
-        : "";
+      : "";
   }
 
 

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -42,6 +42,8 @@
     top: 12px;
     right: 12px;
     cursor: pointer;
+    //order: 2;
+    //padding-right: 12px;
   }
 
   .tooltip-dismissible-content {

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -21,6 +21,7 @@
 
 <body>
 
+
 </body>
 
 </html>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Removed the addition of 'search-field__wrapper-m' from JS and SCSS. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.16.4--canary.474.1bc08eb13cce58543590381c5af692085b8caadc.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.16.4--canary.474.1bc08eb13cce58543590381c5af692085b8caadc.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.16.4--canary.474.1bc08eb13cce58543590381c5af692085b8caadc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
