### PR TITLE
Ddded display property to the missing components

### DIFF
--- a/packages/components/src/components/alert/alert.scss
+++ b/packages/components/src/components/alert/alert.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+  display: block;
+}
+
 .alert {
   display: flex;
   border: 1px solid tokens.$ifxColorOcean500;

--- a/packages/components/src/components/badge/badge.scss
+++ b/packages/components/src/components/badge/badge.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+  display: inline-flex;
+}
+
 .badge__container {
   display: inline-flex;
   justify-content: center;

--- a/packages/components/src/components/breadcrumb/breadcrumb.scss
+++ b/packages/components/src/components/breadcrumb/breadcrumb.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+  display: flex;
+}
+
 .breadcrumb {
   list-style: none;
   padding: 0px;

--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -3,6 +3,7 @@
 
 :host {
   vertical-align: bottom;
+  display: inline-flex;
 }
 
 .btn {

--- a/packages/components/src/components/card/card.scss
+++ b/packages/components/src/components/card/card.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+  display: inline-flex;
+}
+
 .card {
   position: relative;
   display: inline-flex;

--- a/packages/components/src/components/icon-button/icon-button.scss
+++ b/packages/components/src/components/icon-button/icon-button.scss
@@ -1,5 +1,9 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 
+:host { 
+  display: inline-flex;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;

--- a/packages/components/src/components/link/link.scss
+++ b/packages/components/src/components/link/link.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+  display: inline-flex;
+}
+
 .link {
   display: inline-flex;
   align-items: center;

--- a/packages/components/src/components/list-group/list-group.scss
+++ b/packages/components/src/components/list-group/list-group.scss
@@ -1,11 +1,9 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 
 
-// :host {
-//   & ifx-list-group { 
-//     width: initial;
-//   }
-// }
+:host  {
+  display: inline-flex;
+}
 
 .list-group-container {
   display: inline-flex;

--- a/packages/components/src/components/navbar/navbar.scss
+++ b/packages/components/src/components/navbar/navbar.scss
@@ -3,6 +3,7 @@
 
 :host { 
   width: 100%;
+  display: block;
 }
 
 

--- a/packages/components/src/components/number-indicator/number-indicator.scss
+++ b/packages/components/src/components/number-indicator/number-indicator.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+  display: inline-flex;
+}
+
 .numberIndicator__container {
   display: inline-flex;
   padding: 0px 4px;

--- a/packages/components/src/components/pagination/pagination.scss
+++ b/packages/components/src/components/pagination/pagination.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+  display: inline-flex;
+}
+
 .container  {
   display: inline-flex;
   justify-content: center;

--- a/packages/components/src/components/progress-bar/progress-bar.scss
+++ b/packages/components/src/components/progress-bar/progress-bar.scss
@@ -1,11 +1,9 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 
-
 :host {
   display: flex;
   width: 100%;
 }
-
 
 .progress-bar {
   height: tokens.$ifxSize200;

--- a/packages/components/src/components/radio-button/radio-button.scss
+++ b/packages/components/src/components/radio-button/radio-button.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+    display: inline-flex;
+}
+
 .radioButton__container {
     box-sizing: border-box;
     display: inline-flex;

--- a/packages/components/src/components/search-bar/search-bar.scss
+++ b/packages/components/src/components/search-bar/search-bar.scss
@@ -3,6 +3,7 @@
 
 :host { 
   width: 100%; //revert
+  display: flex;
 }
 
 .search-bar {

--- a/packages/components/src/components/search-field/search-field.scss
+++ b/packages/components/src/components/search-field/search-field.scss
@@ -1,5 +1,9 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 
+:host { 
+  display: flex;
+}
+
 .search-field {
   box-sizing: border-box;
   background-color: tokens.$ifxColorBaseWhite;

--- a/packages/components/src/components/sidebar/sidebar.scss
+++ b/packages/components/src/components/sidebar/sidebar.scss
@@ -3,6 +3,7 @@
 
 :host {
   height: 100%;
+  display: inline-flex;
 }
 
 .sidebar__container {

--- a/packages/components/src/components/tabs/tabs.scss
+++ b/packages/components/src/components/tabs/tabs.scss
@@ -2,9 +2,9 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
-// :host {
-//   display: block;
-// }
+:host {
+  display: flex;
+}
 
 .tabs {
   display: flex;

--- a/packages/components/src/components/tag/tag.scss
+++ b/packages/components/src/components/tag/tag.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+  display: inline-flex;
+}
+
 .container {
   display: inline-flex;
   align-items: center;

--- a/packages/components/src/components/text-field/text-field.scss
+++ b/packages/components/src/components/text-field/text-field.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+  display: flex;
+}
+
 .textInput__container {
   display: flex;
   flex-direction: column;

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -1,6 +1,10 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
+:host { 
+  display: inline-flex;
+}
+
 .tooltip__container {
   display: inline-flex;
   flex-direction: column;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Some of the components did not have a display property set on their :host wrapper. I have added it to those that were missing it. This was necessary for allowing users to add margin or other needed attributes to the component wrappers.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.23.10--canary.560.e3e79bbfacc3c1b1dc7c8a58f857ccf951ef0810.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.23.10--canary.560.e3e79bbfacc3c1b1dc7c8a58f857ccf951ef0810.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.23.10--canary.560.e3e79bbfacc3c1b1dc7c8a58f857ccf951ef0810.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
