### PR TITLE
Navbar: assignedNodes error 

### DIFF
--- a/packages/components/src/components/navbar/navbar.tsx
+++ b/packages/components/src/components/navbar/navbar.tsx
@@ -30,7 +30,6 @@ export class Navbar {
       return;
     }
     element.tabIndex = -1;
-    console.log("ev list")
 
     // Select all a elements in the navbar and set their tabIndex to -1 to make them non-focusable
     const aElements = element.querySelectorAll('a');
@@ -39,19 +38,19 @@ export class Navbar {
     }
 
     const slot = element.querySelector('slot');
-    const assignedNodes = slot.assignedNodes();
-
-    for (let i = 0; i < assignedNodes.length; i++) {
-      const node = assignedNodes[i] as HTMLElement;
-      if (node.nodeName === 'IFX-NAVBAR-ITEM') {
-        const navbarItem = node as HTMLIfxNavbarItemElement;
-
-        // Get all navigation items
-        const aElements = navbarItem?.shadowRoot.querySelectorAll('a');
-        for (let i = 0; i < aElements.length; i++) {
-          aElements[i].tabIndex = -1;
+    if(slot) { 
+      const assignedNodes = slot.assignedNodes();
+      for (let i = 0; i < assignedNodes.length; i++) {
+        const node = assignedNodes[i] as HTMLElement;
+        if (node.nodeName === 'IFX-NAVBAR-ITEM') {
+          const navbarItem = node as HTMLIfxNavbarItemElement;
+  
+          // Get all navigation items
+          const aElements = navbarItem?.shadowRoot.querySelectorAll('a');
+          for (let i = 0; i < aElements.length; i++) {
+            aElements[i].tabIndex = -1;
+          }
         }
-
       }
     }
   }
@@ -62,8 +61,6 @@ export class Navbar {
     this.searchBarIsOpen = !this.searchBarIsOpen;
     const navbarItems = this.el.querySelectorAll('ifx-navbar-item')
     const moreMenu = this.el.shadowRoot.querySelector('.navbar__container-left-content-navigation-dropdown-menu');
-    const navbarContainerLeftSide = this.el.shadowRoot.querySelector('.navbar__container-left')
-    console.log(navbarContainerLeftSide)
 
     if (e.detail) {
       for (let i = 0; i < navbarItems.length; i++) {

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -21,7 +21,6 @@
 
 <body>
 
-  
 </body>
 
 </html>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Fixed the assignedNodes error by simply putting creating a condition where the assignedNodes method is invoked only if slots exist. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.23.10--canary.564.d8ca8ea4e67ed6d5082f891782d750c7b4e82188.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.23.10--canary.564.d8ca8ea4e67ed6d5082f891782d750c7b4e82188.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.23.10--canary.564.d8ca8ea4e67ed6d5082f891782d750c7b4e82188.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
