### PR TITLE
Icons in Storybook: Replaced string with select list

### DIFF
--- a/packages/components/src/components/card/card.stories.ts
+++ b/packages/components/src/components/card/card.stories.ts
@@ -1,3 +1,6 @@
+import { icons } from '@infineon/infineon-icons';
+
+
 export default {
   title: "Components/Card",
   tags: ['autodocs'],
@@ -9,7 +12,6 @@ export default {
     button: 'button',
     href: "",
     target: '_blank',
-    icon: 'c-info-16',
     position: 'right'
   },
 
@@ -30,6 +32,10 @@ export default {
     target: {
       options: ['_blank', '_self', '_parent'],
       control: { type: 'radio' }
+    }, 
+    iconName: {
+      options: Object.values(icons).map(i => i['name']),
+      control: { type: 'select' }
     }
   }
 };

--- a/packages/components/src/components/icon/infineonIconStencil.stories.ts
+++ b/packages/components/src/components/icon/infineonIconStencil.stories.ts
@@ -1,3 +1,5 @@
+import { icons } from '@infineon/infineon-icons';
+
 export default {
   title: 'Components/Icon',
   tags: ['autodocs'],
@@ -6,7 +8,10 @@ export default {
     icon: "c-check-16"
   },
   argTypes: {
-    icon: { control: 'text' }
+    icon: {
+      options: Object.values(icons).map(i => i['name']),
+      control: { type: 'select' }
+    }
   },
 
 

--- a/packages/components/src/components/navbar/navbar.stories.ts
+++ b/packages/components/src/components/navbar/navbar.stories.ts
@@ -1,3 +1,4 @@
+import { icons } from '@infineon/infineon-icons';
 
 export default {
   title: "Components/Navbar",
@@ -13,6 +14,12 @@ export default {
     searchBarShowCloseButton: true,
     navbarPositionFixed: false
   },
+  argTypes: { 
+    iconName: {
+      options: Object.values(icons).map(i => i['name']),
+      control: { type: 'select' }
+    }
+  }
 };
 
 

--- a/packages/components/src/components/text-field/text-field.stories.ts
+++ b/packages/components/src/components/text-field/text-field.stories.ts
@@ -1,4 +1,5 @@
 import { action } from '@storybook/addon-actions';
+import { icons } from '@infineon/infineon-icons';
 
 export default {
   title: "Components/Text Field",
@@ -12,7 +13,6 @@ export default {
     placeholder: 'Placeholder',
     error: false,
     caption: "Caption",
-    icon: "calendar-16",
     required: true,
     optional: false,
   },
@@ -23,6 +23,10 @@ export default {
       control: { type: 'radio' },
     },
     onIfxInput: { action: 'ifxInput' },
+    iconName: {
+      options: Object.values(icons).map(i => i['name']),
+      control: { type: 'select' }
+    }
   }
 };
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Replaced the icon string control in Storybook with a list of all the icons for the few components where it was missing: Card, Icon, Navbar and Text-Field
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.23.10--canary.571.e751ee2840f3aea5106a4ac90840d75de379eeaf.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.23.10--canary.571.e751ee2840f3aea5106a4ac90840d75de379eeaf.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.23.10--canary.571.e751ee2840f3aea5106a4ac90840d75de379eeaf.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
