### PR TITLE
Navbar: removed the icon string control option. 

### DIFF
--- a/packages/components/src/components/navbar/navbar.stories.ts
+++ b/packages/components/src/components/navbar/navbar.stories.ts
@@ -5,7 +5,6 @@ export default {
   args: {
     applicationName: 'Application name',
     hideLabel: false,
-    icon: "calendar16",
     navbarItemTarget: "_blank",
     navbarItemHref: "",
     navbarMenuHref: "",


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Removed the icon string control option from the navbar stories. 
The select list of all the icons is now the only icon control option. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.23.14--canary.579.bd94ee4632ffd8b980211c960c8debae3534e2a9.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.23.14--canary.579.bd94ee4632ffd8b980211c960c8debae3534e2a9.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.23.14--canary.579.bd94ee4632ffd8b980211c960c8debae3534e2a9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
