### PR TITLE
Icons on Storybook: added default icon on text-field and tag.

### DIFF
--- a/packages/components/src/components/card/card.stories.ts
+++ b/packages/components/src/components/card/card.stories.ts
@@ -1,5 +1,3 @@
-import { icons } from '@infineon/infineon-icons';
-
 
 export default {
   title: "Components/Card",
@@ -32,10 +30,6 @@ export default {
     target: {
       options: ['_blank', '_self', '_parent'],
       control: { type: 'radio' }
-    }, 
-    iconName: {
-      options: Object.values(icons).map(i => i['name']),
-      control: { type: 'select' }
     }
   }
 };

--- a/packages/components/src/components/navbar/navbar.stories.ts
+++ b/packages/components/src/components/navbar/navbar.stories.ts
@@ -15,7 +15,7 @@ export default {
     navbarPositionFixed: false
   },
   argTypes: { 
-    iconName: {
+    icon: {
       options: Object.values(icons).map(i => i['name']),
       control: { type: 'select' }
     }

--- a/packages/components/src/components/tag/tag.stories.ts
+++ b/packages/components/src/components/tag/tag.stories.ts
@@ -6,6 +6,7 @@ export default {
 
   args: {
     label: "Tag label",
+    icon: 'chevron-up-16',
   },
   argTypes: {
     icon: {
@@ -22,7 +23,3 @@ const DefaultTemplate = (args) =>
 export const Default = DefaultTemplate.bind({});
 
 
-export const WithIcon = DefaultTemplate.bind({});
-WithIcon.args = {
-  icon: 'chevron-up-16',
-}

--- a/packages/components/src/components/text-field/text-field.stories.ts
+++ b/packages/components/src/components/text-field/text-field.stories.ts
@@ -15,7 +15,9 @@ export default {
     caption: "Caption",
     required: true,
     optional: false,
+    icon: 'c-info-16'
   },
+
   argTypes: {
     size: {
       description: "Size options: s (36px) and m (40px) - default: m",
@@ -23,7 +25,7 @@ export default {
       control: { type: 'radio' },
     },
     onIfxInput: { action: 'ifxInput' },
-    iconName: {
+    icon: {
       options: Object.values(icons).map(i => i['name']),
       control: { type: 'select' }
     }
@@ -54,5 +56,4 @@ const DefaultTemplate = ({ error, disabled, success, size, placeholder, label, c
 
 
 export const Default = DefaultTemplate.bind({});
-
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Added a default icon on the text-field and tag components in storybook, and removed the icon control from the Card on storybook.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.23.14--canary.580.e3dc5548a8816aaa52809275f2eeeb3bc3988962.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.23.14--canary.580.e3dc5548a8816aaa52809275f2eeeb3bc3988962.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.23.14--canary.580.e3dc5548a8816aaa52809275f2eeeb3bc3988962.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
