### PR TITLE
added size description to remaining components in storybook

### DIFF
--- a/packages/components/src/components/button/button.stories.ts
+++ b/packages/components/src/components/button/button.stories.ts
@@ -36,6 +36,7 @@ export default {
       control: { type: 'radio' },
     },
     size: {
+      description: "Size options: xs (32px) s (36px),  m (40px), l (48px) - default: m",
       options: ['xs', 's', 'm', 'l'],
       control: { type: 'radio' },
     },

--- a/packages/components/src/components/checkbox/checkbox.stories.ts
+++ b/packages/components/src/components/checkbox/checkbox.stories.ts
@@ -14,6 +14,7 @@ export default {
 
   argTypes: {
     size: {
+      description: "Size options: s (21px) and m (25px) - default: m",
       options: ['s', 'm'],
       control: { type: 'radio' },
     },

--- a/packages/components/src/components/dropdown/dropdown.stories.ts
+++ b/packages/components/src/components/dropdown/dropdown.stories.ts
@@ -45,7 +45,7 @@ export default {
     },
     label: { description: 'The visible name or label for the dropdown button' },
     size: {
-      description: 'The size of the dropdown. Accepted values are "s" for small and "m" for medium',
+      description: "Font Size options: s (14px) and m (16px) - default: m",
       options: ['s', 'm'],
       control: { type: 'radio' },
     },

--- a/packages/components/src/components/icon-button/icon-button.stories.ts
+++ b/packages/components/src/components/icon-button/icon-button.stories.ts
@@ -25,6 +25,7 @@ export default {
     },
 
     size: {
+      description: "Size options: s (24px), m (40px) and l (48px) - default: m",
       options: ['s', 'm', 'l'],
       control: { type: 'radio' },
     },

--- a/packages/components/src/components/link/link.stories.ts
+++ b/packages/components/src/components/link/link.stories.ts
@@ -16,6 +16,7 @@ export default {
       control: { type: 'radio' }
     },
     size: {
+      description: "Font Size options: s (14px), m (16px), l (18px), xl (20px) - default: m",
       options: ['s', 'm', 'l', 'xl'],
       control: { type: 'radio' }
     },


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Added size description to the following components in storybook: 
- button 
- checkbox 
- dropdown 
- icon button 
- link 
- radio button
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.23.14--canary.582.8eb2b01679cfe3ed49b975737022fcfb51e6d3da.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.23.14--canary.582.8eb2b01679cfe3ed49b975737022fcfb51e6d3da.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.23.14--canary.582.8eb2b01679cfe3ed49b975737022fcfb51e6d3da.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
