### PR TITLE
Dropdown: dropdown-item value emitted from parent dropdown

### DIFF
--- a/examples/wrapper-components/react-javascript/src/components/Dropdown/Dropdown.js
+++ b/examples/wrapper-components/react-javascript/src/components/Dropdown/Dropdown.js
@@ -7,11 +7,11 @@ function Dropdown() {
     console.log('selected dropdown option', e.detail)
   }
   return (
-    <IfxDropdown placement="bottom-start" no-close-on-menu-click="true">
+    <IfxDropdown onIfxDropdownItem={handleValue} placement="bottom-start" no-close-on-menu-click="true">
     <IfxDropdownTriggerButton icon="calendar16">
       dropdown
     </IfxDropdownTriggerButton>
-    <IfxDropdownMenu size="l" onIfxDropdownMenu={handleValue}>
+    <IfxDropdownMenu size="l">
      <IfxDropdownHeader>Header Text</IfxDropdownHeader>
       <IfxDropdownItem>Menu Item</IfxDropdownItem>
       <IfxDropdownSeparator></IfxDropdownSeparator>

--- a/packages/components-vue/lib/components.ts
+++ b/packages/components-vue/lib/components.ts
@@ -140,8 +140,7 @@ export const IfxDropdownItem = /*@__PURE__*/ defineContainer<JSX.IfxDropdownItem
 export const IfxDropdownMenu = /*@__PURE__*/ defineContainer<JSX.IfxDropdownMenu>('ifx-dropdown-menu', undefined, [
   'isOpen',
   'size',
-  'menuSize',
-  'ifxDropdownMenuItem'
+  'menuSize'
 ]);
 
 

--- a/packages/components/src/components/dropdown/dropdown-menu/dropdown-menu.tsx
+++ b/packages/components/src/components/dropdown/dropdown-menu/dropdown-menu.tsx
@@ -8,24 +8,17 @@ import { Component, h, Prop, Element, State, Event, EventEmitter, Listen } from 
 })
 
 export class DropdownMenu {
+  @Element() el;
   @Prop() isOpen: boolean = false;
   @Prop() size: string = 'l'
   @State() hideTopPadding: boolean = false;
-  @Element() el;
-
-  @Event() menuSize: EventEmitter;
   @State() filteredItems: HTMLIfxDropdownItemElement[] = [];
-  @Event() ifxDropdownMenuItem: EventEmitter<CustomEvent>;
-
+  @Event() menuSize: EventEmitter;
+ 
   @Listen('ifxInput')
   handleMenuFilter(event: CustomEvent) {
     const searchValue = event.detail;
     this.filterDropdownItems(searchValue)
-  }
-
-  @Listen('ifxDropdownItem')
-  handleDropdownItemValueEmission(event: CustomEvent) {
-    this.ifxDropdownMenuItem.emit(event.detail)
   }
 
   filterDropdownItems(searchValue: string) {

--- a/packages/components/src/components/dropdown/dropdown-menu/readme.md
+++ b/packages/components/src/components/dropdown/dropdown-menu/readme.md
@@ -15,10 +15,9 @@
 
 ## Events
 
-| Event                 | Description | Type                            |
-| --------------------- | ----------- | ------------------------------- |
-| `ifxDropdownMenuItem` |             | `CustomEvent<CustomEvent<any>>` |
-| `menuSize`            |             | `CustomEvent<any>`              |
+| Event      | Description | Type               |
+| ---------- | ----------- | ------------------ |
+| `menuSize` |             | `CustomEvent<any>` |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/dropdown/dropdown.stories.ts
+++ b/packages/components/src/components/dropdown/dropdown.stories.ts
@@ -78,13 +78,13 @@ export default {
       action: 'ifxClose',
       description: 'Custom event emitted when dropdown closes'
     },
-    ifxDropdownMenuItem: {
-      action: 'ifxDropdownMenuItem',
+    ifxDropdownItem: {
+      action: 'ifxDropdownItem',
       description: 'Custom event emitted when an item is selected',
       table: {
         type: {
           summary: 'Framework integration',
-          detail: 'React: onIfxDropdownMenuItem={handleChange}\nVue:@ifxDropdownMenuItem="handleChange"\nAngular:(ifxDropdownMenuItem)="handleChange()"\nVanillaJs:.addEventListener("ifxDropdownMenuItem", (event) => {//handle change});',
+          detail: 'React: onIfxDropdownItem={handleChange}\nVue:@ifxDropdownItem="handleChange"\nAngular:(ifxDropdownItem)="handleChange()"\nVanillaJs:.addEventListener("ifxDropdownItem", (event) => {//handle change});',
         },
       },
     }
@@ -110,11 +110,10 @@ const DefaultTemplate = (args) => {
 </ifx-dropdown>`;
 
   const dropdown = wrapper.querySelector('ifx-dropdown') as HTMLElement;
-  const dropdownMenu = dropdown.querySelector('ifx-dropdown-menu');
 
   dropdown.addEventListener('ifxOpen', action('ifxOpen'));
   dropdown.addEventListener('ifxClose', action('ifxClose'));
-  dropdownMenu.addEventListener('ifxDropdownMenuItem', action('ifxDropdownMenuItem'));
+  dropdown.addEventListener('ifxDropdownItem', action('ifxDropdownItem'));
 
   return wrapper;
 };
@@ -145,11 +144,10 @@ const LabelTriggerTemplate = (args) => {
   </ifx-dropdown>`;
 
   const dropdown = wrapper.querySelector('ifx-dropdown') as HTMLElement;
-  const dropdownMenu = dropdown.querySelector('ifx-dropdown-menu');
-
+ 
   dropdown.addEventListener('ifxOpen', action('ifxOpen'));
   dropdown.addEventListener('ifxClose', action('ifxClose'));
-  dropdownMenu.addEventListener('ifxDropdownMenuItem', action('ifxDropdownMenuItem'));
+  dropdown.addEventListener('ifxDropdownItem', action('ifxDropdownItem'));
 
   return wrapper;
 };

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -28,39 +28,29 @@ export type Placement =
 })
 
 export class Dropdown {
+  @Element() el;
   @Prop() placement: Placement = 'bottom-start';
-
-  // isOpen prop
   @Prop() defaultOpen: boolean = false;
-  // internal state for isOpen prop
-  @State() internalIsOpen: boolean = false;
-
-  // isOpen prop
   @Prop() noAppendToBody: boolean = false;
-
-  // Custom events for opening and closing dropdown
   @Event() ifxOpen: EventEmitter;
   @Event() ifxClose: EventEmitter;
   @Event() ifxDropdown: EventEmitter;
-
-  // determine if dropdown is disabled
   @Prop() disabled: boolean;
-
   @Prop() noCloseOnOutsideClick: boolean = false;
   @Prop() noCloseOnMenuClick: boolean = false;
-
-  // Reference to host element
-  @Element() el;
-  // Dropdown trigger and menu
+  @State() internalIsOpen: boolean = false;
   @State() trigger: HTMLElement;
   @State() menu: HTMLElement
   // Popper instance for positioning
   popperInstance: any;
 
 
+  @Listen('ifxDropdownItem')
+  handleDropdownMenuEventsReemission(event: CustomEvent) { 
+    this.ifxDropdown.emit(event.detail)
+  }
 
   componentWillLoad() {
-    //maybe not needed
     this.updateSlotContent();
     this.watchHandlerIsOpen(this.defaultOpen, this.internalIsOpen);
   }
@@ -83,13 +73,10 @@ export class Dropdown {
     }
   }
 
-
   @Listen('slotchange')
   watchHandlerSlot() {
     this.updateSlotContent();
   }
-
-
 
   // handling assignment of trigger and menu
   updateSlotContent() {
@@ -107,9 +94,9 @@ export class Dropdown {
       }
       // Get new menu and add to body
       this.menu = this.el.querySelector('ifx-dropdown-menu');
-
+     
       // event handler for closing dropdown on menu click
-      document.body.append(this.menu);
+      //document.body.append(this.menu);
     } else {
       this.menu = this.el.querySelector('ifx-dropdown-menu');
 
@@ -183,13 +170,6 @@ export class Dropdown {
       this.ifxOpen.emit();
     }
   }
-
-  //emitted by and listening to it from the dropdown menu right now
-  // @Listen('ifxDropdownMenu')
-  // handleDropdownMenuEvents(event: CustomEvent) {
-  //   this.ifxDropdown.emit(event.detail)
-  //   console.log('Selected item received in higher-level parent:');
-  // }
 
   @Listen('mousedown', { target: 'document' })
   handleOutsideClick(event: MouseEvent) {


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Dropdown-item value is now emitted from the parent dropdown, and not dropdown-menu. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.23.14--canary.588.0934163fb2e394a2404a39e030c90b21e5bae695.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.23.14--canary.588.0934163fb2e394a2404a39e030c90b21e5bae695.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.23.14--canary.588.0934163fb2e394a2404a39e030c90b21e5bae695.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
