### PR TITLE
fixed border-radius for select-component

### DIFF
--- a/packages/components/src/components/select/single-select/select.scss
+++ b/packages/components/src/components/select/single-select/select.scss
@@ -46,7 +46,7 @@
     display: flex;
     align-items: center;
     border: 1px solid #8D8786;
-    border-radius: 2.5px;
+    border-radius: 1px;
     font-weight: 400;
     font-style: normal;
 


### PR DESCRIPTION
Description
border-radius of the select-input was incorrect

Related Issue
#586 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.23.16--canary.591.2bbddb10211f8bf01f8100019e7eb643ce8b161b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.23.16--canary.591.2bbddb10211f8bf01f8100019e7eb643ce8b161b.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.23.16--canary.591.2bbddb10211f8bf01f8100019e7eb643ce8b161b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
