### PR TITLE
Feature for multiselect - placeholder prop now modifiable

### DIFF
--- a/packages/components-vue/lib/components.ts
+++ b/packages/components-vue/lib/components.ts
@@ -244,6 +244,7 @@ export const IfxMultiselect = /*@__PURE__*/ defineContainer<JSX.IfxMultiselect>(
   'error',
   'errorMessage',
   'label',
+  'placeholder',
   'maxItemCount',
   'ifxSelect',
   'ifxMultiselectIsOpen'

--- a/packages/components/src/components/select/multi-select/Development.mdx
+++ b/packages/components/src/components/select/multi-select/Development.mdx
@@ -24,6 +24,7 @@ The Multi Select component takes an array of objects in the following format as 
 const options = [{
   value: "a",
   label: "option a",
+  placeholder: "Placeholder",
   selected: false,
   children: [
     {

--- a/packages/components/src/components/select/multi-select/multiselect.stories.ts
+++ b/packages/components/src/components/select/multi-select/multiselect.stories.ts
@@ -39,6 +39,7 @@ export default {
     errorMessage: 'Some error',
     label: '',
     disabled: false,
+    placeholder: 'Placeholder'
 
 
   },
@@ -66,6 +67,7 @@ export default {
     },
     errorMessage: { control: 'text' },
     label: { control: 'text' },
+    placeholder: { control: 'text' },
     options: {
       description: 'Takes an array of objects in the following format',
     },
@@ -81,6 +83,7 @@ const DefaultTemplate = (args) => {
   error='${args.error}'
   error-message='${args.errorMessage}'
   label='${args.label}'
+  placeholder='${args.placeholder}'
   disabled='${args.disabled}'>
 </ifx-multiselect>`;
 

--- a/packages/components/src/components/select/multi-select/multiselect.tsx
+++ b/packages/components/src/components/select/multi-select/multiselect.tsx
@@ -17,6 +17,7 @@ export class Multiselect {
   @Prop() errorMessage: string = "Error";
   @Prop() label: string = "";
   @State() persistentSelectedOptions: Option[] = [];
+  @Prop() placeholder: string = "";
   @State() listOfOptions: Option[] = [];
   @State() dropdownOpen = false;
   @State() dropdownFlipped: boolean;
@@ -422,7 +423,7 @@ export class Multiselect {
           `}
             onClick={this.disabled ? undefined : () => this.toggleDropdown()}
           >
-            {this.persistentSelectedOptions.length > 0 ? selectedOptionsLabels : 'Placeholder'}
+            {this.persistentSelectedOptions.length > 0 ? selectedOptionsLabels : this.placeholder}
           </div>
           {this.dropdownOpen && (
             <div class="ifx-multiselect-dropdown-menu" style={{ '--dynamic-z-index': this.zIndex.toString() }}>

--- a/packages/components/src/components/select/multi-select/readme.md
+++ b/packages/components/src/components/select/multi-select/readme.md
@@ -15,6 +15,7 @@
 | `label`        | `label`          |             | `string`          | `""`              |
 | `maxItemCount` | `max-item-count` |             | `number`          | `undefined`       |
 | `options`      | `options`        |             | `any[] \| string` | `undefined`       |
+| `placeholder`  | `placeholder`    |             | `string`          | `""`              |
 | `size`         | `size`           |             | `string`          | `'medium (40px)'` |
 
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Placeholder is not a modifiable property for the multiselect component on Storybook.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.23.15--canary.595.bd7a55e58b6c9c10638afe7ab856b6fe40ad09ee.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.23.15--canary.595.bd7a55e58b6c9c10638afe7ab856b6fe40ad09ee.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.23.15--canary.595.bd7a55e58b6c9c10638afe7ab856b6fe40ad09ee.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
