### PR TITLE
Card: disabled href when it's empty

### DIFF
--- a/packages/components/src/components/card/card.stories.ts
+++ b/packages/components/src/components/card/card.stories.ts
@@ -59,18 +59,16 @@ const DefaultTemplate = (args) =>
         </ifx-card-text>` : ""}
       ${args.button === 'button'
     ? `<ifx-card-links slot="buttons">
-          <ifx-button color="primary">Button</ifx-button>
-          <ifx-button color="secondary">Button</ifx-button>
-          <ifx-button color="primary">Button</ifx-button>
-          <ifx-button color="secondary">Button</ifx-button>
+          <ifx-button variant="primary">Button</ifx-button>
+          <ifx-button variant="secondary">Button</ifx-button>
           </ifx-card-links>` : ""}
       ${args.button === 'link'
     ? `<ifx-card-links slot="buttons">
-            <ifx-link color="primary" href="https://google.com" target="_blank" underline="false">
+            <ifx-link href="https://google.com" target="_blank">
               <ifx-icon icon="calendar16"></ifx-icon>
               Link
             </ifx-link>
-            <ifx-link color="primary" href="https://yahoo.com" target="_blank" underline="false">
+            <ifx-link href="https://yahoo.com" target="_blank">
               <ifx-icon icon="calendar16"></ifx-icon>
               Link
             </ifx-link>

--- a/packages/components/src/components/card/card.tsx
+++ b/packages/components/src/components/card/card.tsx
@@ -31,6 +31,10 @@ export class Card {
     if (!links) {
       this.noBtns = true;
     } else this.noBtns = false;
+
+    if(this.href.trim() === "") { 
+      this.href = undefined;
+    }
   }
 
   handleHovering() {
@@ -62,7 +66,7 @@ export class Card {
 
 
   private addEventListenersToHandleCustomFocusState() {
-    const element = this.el.shadowRoot.firstChild;
+    const element = this.el.shadowRoot;
     if (!element) {
       console.error('element not found');
       return;

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -21,6 +21,8 @@
 
 <body>
 
+  
+
 </body>
 
 </html>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Made the href on the Card body undefined if it's empty. This prevents empty redirection.
Also, made a small update to the focus state function. The referenced upperbody element was not being referenced correctly, so I just changed the query element, and now it's working as was intended.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.23.19--canary.615.a73a8bb641de3727218fabb590dfbed8aa61736c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.23.19--canary.615.a73a8bb641de3727218fabb590dfbed8aa61736c.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.23.19--canary.615.a73a8bb641de3727218fabb590dfbed8aa61736c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
