### PR TITLE
Accordion: added initial-collapse Prop on accordion-items

### DIFF
--- a/examples/wrapper-components/react-javascript/src/components/Accordion/Accordion.js
+++ b/examples/wrapper-components/react-javascript/src/components/Accordion/Accordion.js
@@ -11,19 +11,21 @@ function Accordion() {
     <div>
 
 
-      <IfxAccordion auto-collapse="true" onIfxItemOpen={handleItems}>
-        <IfxAccordionItem caption="How to be happy?">
-          I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.
-          I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.
-          I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.
-          I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.
-          I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.I have no idea. I have no idea.  I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea. I have no idea.
+      <IfxAccordion auto-collapse={true} onIfxItemOpen={handleItems}>
+        <IfxAccordionItem caption="Label" initialCollapse={false}>
+        Content for Item #1. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
         </IfxAccordionItem>
-        <IfxAccordionItem caption="How to be happy?">
-          I have no idea.
+        <IfxAccordionItem caption="Label">
+        Content for Item #2. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
         </IfxAccordionItem>
-        <IfxAccordionItem caption="How to be happy?">
-          I have no idea.
+        <IfxAccordionItem caption="Label">
+        Content for Item #3. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
         </IfxAccordionItem>
       </IfxAccordion>
     </div>

--- a/packages/components-vue/lib/components.ts
+++ b/packages/components-vue/lib/components.ts
@@ -16,6 +16,7 @@ export const IfxAccordion = /*@__PURE__*/ defineContainer<JSX.IfxAccordion>('ifx
 
 export const IfxAccordionItem = /*@__PURE__*/ defineContainer<JSX.IfxAccordionItem>('ifx-accordion-item', undefined, [
   'caption',
+  'initialCollapse',
   'ifxItemOpen',
   'ifxItemClose'
 ]);

--- a/packages/components/src/components/accordion/accordion.stories.tsx
+++ b/packages/components/src/components/accordion/accordion.stories.tsx
@@ -6,7 +6,8 @@ export default {
   tags: ['autodocs'],
 
   args: { 
-    autoCollapse: false
+    autoCollapse: false,
+    initialCollapse: true
   },
 
   argTypes: {
@@ -16,6 +17,16 @@ export default {
 
 const Template = (args) => {
   const accordionElement = document.createElement('ifx-accordion');
+  const initialItem = document.createElement('ifx-accordion-item');
+  initialItem.setAttribute('initialCollapse', `${args.initialCollapse}`);
+  initialItem.setAttribute('caption', `Label`);
+  initialItem.innerHTML = `
+  Content for Initial Item. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.
+`;
+  accordionElement.append(initialItem);
+  
   accordionElement.setAttribute('auto-collapse', args.autoCollapse)
   for (let i = 0; i < args.amountOfItems; i++) {
     const item = document.createElement('ifx-accordion-item');

--- a/packages/components/src/components/accordion/accordion.stories.tsx
+++ b/packages/components/src/components/accordion/accordion.stories.tsx
@@ -12,13 +12,16 @@ export default {
 
   argTypes: {
     amountOfItems: { control: 'number' },
+    initialCollapse: { 
+      description: 'If set on more than one accordion-item, auto-collapse must be false',
+    }
   },
 };
 
 const Template = (args) => {
   const accordionElement = document.createElement('ifx-accordion');
   const initialItem = document.createElement('ifx-accordion-item');
-  initialItem.setAttribute('initialCollapse', `${args.initialCollapse}`);
+  initialItem.setAttribute('initialCollapse', args.initialCollapse);
   initialItem.setAttribute('caption', `Label`);
   initialItem.innerHTML = `
   Content for Initial Item. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent volutpat, ligula eu aliquam bibendum, orci nisl cursus ipsum, nec egestas odio sapien eget neque.

--- a/packages/components/src/components/accordion/accordion.tsx
+++ b/packages/components/src/components/accordion/accordion.tsx
@@ -12,7 +12,6 @@ export class Accordion {
 
   @Listen('ifxItemOpen')
   async onItemOpen(event: CustomEvent) {
-    console.log('here', this.autoCollapse)
     if(this.autoCollapse) { 
       const items = Array.from(this.el.querySelectorAll('ifx-accordion-item'));
       for (const item of items) {

--- a/packages/components/src/components/accordion/accordionItem.tsx
+++ b/packages/components/src/components/accordion/accordionItem.tsx
@@ -8,6 +8,7 @@ import { Component, Prop, h, State, Event, EventEmitter, Method } from '@stencil
 })
 export class IfxAccordionItem {
   @Prop() caption: string;
+  @Prop() initialCollapse: boolean = true;
   @State() open: boolean = false;
   @Event() ifxItemOpen: EventEmitter;
   @Event() ifxItemClose: EventEmitter;
@@ -22,12 +23,27 @@ export class IfxAccordionItem {
     }
   }
 
-  componentDidUpdate() {
+  openAccordionItem() { 
     if (this.open) {
       this.contentEl.style.maxHeight = `${this.contentEl.scrollHeight}px`;
     } else {
       this.contentEl.style.maxHeight = '0';
     }
+  }
+
+  componentWillLoad() { 
+    if(!this.initialCollapse) { 
+      this.open = true;
+      this.ifxItemOpen.emit();
+    }
+  }
+
+  componentDidLoad() { 
+    this.openAccordionItem()
+  }
+
+  componentDidUpdate() {
+    this.openAccordionItem()
   }
 
   @Method()

--- a/packages/components/src/components/accordion/readme.md
+++ b/packages/components/src/components/accordion/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property  | Attribute | Description | Type     | Default     |
-| --------- | --------- | ----------- | -------- | ----------- |
-| `caption` | `caption` |             | `string` | `undefined` |
+| Property          | Attribute          | Description | Type      | Default     |
+| ----------------- | ------------------ | ----------- | --------- | ----------- |
+| `caption`         | `caption`          |             | `string`  | `undefined` |
+| `initialCollapse` | `initial-collapse` |             | `boolean` | `true`      |
 
 
 ## Events


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Updated the accordion, and added initial-collapse property to accordion-items.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.24.0--canary.617.e7123b3016273f6359220dbc910bca6650463ede.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.24.0--canary.617.e7123b3016273f6359220dbc910bca6650463ede.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.24.0--canary.617.e7123b3016273f6359220dbc910bca6650463ede.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
