### PR TITLE
single select now emits search value

### DIFF
--- a/packages/components-vue/lib/components.ts
+++ b/packages/components-vue/lib/components.ts
@@ -382,7 +382,8 @@ export const IfxSelect = /*@__PURE__*/ defineContainer<JSX.IfxSelect>('ifx-selec
   'ifxPlaceholderValue',
   'ifxOptions',
   'ifxSize',
-  'ifxSelect'
+  'ifxSelect',
+  'ifxInput'
 ]);
 
 

--- a/packages/components/src/components/select/single-select/Development.mdx
+++ b/packages/components/src/components/select/single-select/Development.mdx
@@ -18,6 +18,8 @@ import * as SelectStories from './select.stories';
 
 
 ## Notes
+
+### Options
 The Single Select component takes an array of objects in the following format as input:
 
 ```
@@ -42,3 +44,13 @@ The ``selected`` property can be used to predefine an option as selected.
 (``selected: true``)
 This property is only changed, when a new option is selected, as the single-select only allows for one selected option.
 However, the component only creates a shallow copy of the input array, so the original input array does not change.
+
+### Custom events
+
+This component emits two custom events:
+- ``ìfxInput`` 
+  - Accessing the detail property of this custom event returns the search string
+  - gets emitted every time the user types into the search field
+- ``ifxSelect`` 
+  - Accessing the detail property of this custom event returns an object, containing the ``value`` and ``label`` property of the selected option
+  - gets emitted when an item is selected

--- a/packages/components/src/components/select/single-select/readme.md
+++ b/packages/components/src/components/select/single-select/readme.md
@@ -66,6 +66,7 @@
 
 | Event       | Description | Type                            |
 | ----------- | ----------- | ------------------------------- |
+| `ifxInput`  |             | `CustomEvent<CustomEvent<any>>` |
 | `ifxSelect` |             | `CustomEvent<CustomEvent<any>>` |
 
 

--- a/packages/components/src/components/select/single-select/select.stories.ts
+++ b/packages/components/src/components/select/single-select/select.stories.ts
@@ -73,7 +73,13 @@ export default {
       control: { type: 'radio' },
     },
     searchPlaceholderValue: { control: { type: 'text' } },
-    onIfxSelect: { action: 'ifxSelect' },
+    onIfxSelect: {
+      action: 'ifxSelect',
+    },
+    onIfxInput: {
+      action: 'ifxInput',
+    },
+
     options: {
       description: 'Takes an array of objects in the following format',
     }
@@ -95,6 +101,8 @@ const DefaultTemplate = (args) => {
  </ifx-select>`
   setTimeout(() => {
     document.querySelector('ifx-select')?.addEventListener('ifxSelect', action('ifxSelect'));
+    document.querySelector('ifx-select')?.addEventListener('ifxInput', action('ifxInput'));
+
   }, 0);
 
   return template;

--- a/packages/components/src/components/select/single-select/select.tsx
+++ b/packages/components/src/components/select/single-select/select.tsx
@@ -81,6 +81,7 @@ export class Choices implements IChoicesProps, IChoicesMethods {
   @Prop() ifxDisabled: boolean = false;
   @Prop() ifxPlaceholderValue: string = "Placeholder";
   @Event() ifxSelect: EventEmitter<CustomEvent>;
+  @Event() ifxInput: EventEmitter<CustomEvent>;
   @Prop() ifxOptions: any[] | string;
   @Prop() ifxSize: string = 'medium (40px)';
   @State() ifxSelectedOption: any | null = null;
@@ -595,6 +596,8 @@ export class Choices implements IChoicesProps, IChoicesMethods {
         ));
 
         this.setChoices(this.ifxOptions, "value", "label", true)
+        //set custom event listener to listen for search input
+        self.addSearchEventListener(self, this.choice);
 
 
       } else if (this.type === 'multiple') { //not implemented right now
@@ -670,6 +673,19 @@ export class Choices implements IChoicesProps, IChoicesMethods {
     div.addEventListener('blur', function () {
       this.classList.remove('focus');
     });
+  }
+
+
+
+  private addSearchEventListener(self, choiceElement: ChoicesJs) {
+    choiceElement.passedElement.element.addEventListener(
+      'search',
+      function (event: CustomEvent) {
+        self.ifxInput.emit(event.detail.value)
+      },
+      false,
+    );
+    return choiceElement;
 
   }
 

--- a/packages/components/src/components/select/single-select/select.tsx
+++ b/packages/components/src/components/select/single-select/select.tsx
@@ -595,6 +595,7 @@ export class Choices implements IChoicesProps, IChoicesMethods {
         }
         ));
 
+        //set select options
         this.setChoices(this.ifxOptions, "value", "label", true)
         //set custom event listener to listen for search input
         self.addSearchEventListener(self, this.choice);


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
As per user request, the single select now emits the value typed into the search field embedded in the component
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.25.1--canary.625.330462acb07d7cb159b90631f8c32bb1ac502c24.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.25.1--canary.625.330462acb07d7cb159b90631f8c32bb1ac502c24.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.25.1--canary.625.330462acb07d7cb159b90631f8c32bb1ac502c24.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
