### PR TITLE
dependabot file updated to watch icons and tokens repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,15 +17,3 @@ updates:
     directory: "/packages/components-vue"
     schedule:
       interval: "daily"
-  - package-ecosystem: "git"
-    directory: "/packages/components"
-    schedule:
-      interval: "daily"
-    repository: "Infineon/Infineon-Icons"
-    branch: "master"
-  - package-ecosystem: "git"
-    directory: "/packages/components"
-    schedule:
-      interval: "daily"
-    repository: "Infineon/Infineon-Design-System-Tokens"
-    branch: "master"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,15 @@ updates:
     directory: "/packages/components-vue"
     schedule:
       interval: "daily"
+  - package-ecosystem: "git"
+    directory: "/packages/components"
+    schedule:
+      interval: "daily"
+    repository: "Infineon/Infineon-Icons"
+    branch: "master"
+  - package-ecosystem: "git"
+    directory: "/packages/components"
+    schedule:
+      interval: "daily"
+    repository: "Infineon/Infineon-Design-System-Tokens"
+    branch: "master"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     directory: "/packages/components-react"
     schedule:
       interval: "daily"
-   - package-ecosystem: "npm"
+  - package-ecosystem: "npm"
     directory: "/packages/components-vue"
     schedule:
       interval: "daily"

--- a/.github/workflows/target.yml
+++ b/.github/workflows/target.yml
@@ -32,6 +32,6 @@ jobs:
 
       - name: "do stuff"
         env:
-          VERSION: ${{ github.event }}
+          VERSION: ${{ github.event.client_payload.version }}
         run: |
           echo Now using Infineon-Icons version $VERSION

--- a/.github/workflows/target.yml
+++ b/.github/workflows/target.yml
@@ -2,9 +2,17 @@
 
 name: New Infineon-Icons release
 
-on:
-  repository_dispatch:
-    types: [infineon_icons_release]
+# on:
+#   repository_dispatch:
+#     types: [infineon_icons_release]
+
+on: #just for testing
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize # canary on new commit
+
 
 jobs:
   dostuff:

--- a/.github/workflows/target.yml
+++ b/.github/workflows/target.yml
@@ -1,0 +1,29 @@
+# file: target.yml
+
+name: New Infineon-Icons release
+
+on:
+  repository_dispatch:
+    types: [infineon_icons_release]
+
+jobs:
+  dostuff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org/"
+          cache: npm
+
+      # - run: npm ci
+
+      # - run: npm update @infineon/infineon-icons
+
+      - name: "do stuff"
+        env:
+          VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          echo Now using Infineon-Icons version $VERSION

--- a/.github/workflows/target.yml
+++ b/.github/workflows/target.yml
@@ -32,6 +32,6 @@ jobs:
 
       - name: "do stuff"
         env:
-          VERSION: ${{ github.event.client_payload.version }}
+          VERSION: ${{ github.event }}
         run: |
           echo Now using Infineon-Icons version $VERSION


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
dependabot.yml file updated to watch for changes in the Infineon-Icons and Infineon-Design-System-Tokens repository.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.25.1--canary.628.49237acde671d771c4c7646f4a2c9959fc10fa3e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.25.1--canary.628.49237acde671d771c4c7646f4a2c9959fc10fa3e.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.25.1--canary.628.49237acde671d771c4c7646f4a2c9959fc10fa3e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
