### PR TITLE
Revert "Bump @types/jest from 27.5.2 to 29.5.6 in /packages/components"

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -63,7 +63,7 @@
     "@storybook/html-webpack5": "^7.0.20",
     "@storybook/manager-api": "^7.0.24",
     "@storybook/testing-library": "^0.2.2",
-    "@types/jest": "^29.5.6",
+    "@types/jest": "^27.5.2",
     "@types/node": "^16.18.11",
     "babel-loader": "^9.1.3",
     "jest": "^29.7.0",


### PR DESCRIPTION
Reverts Infineon/infineon-design-system-stencil#636
not compatible with current stencil version