### PR TITLE
reset functionality added to button in combination with text field

### DIFF
--- a/examples/stencil-components/vanilla-cdn/index.html
+++ b/examples/stencil-components/vanilla-cdn/index.html
@@ -312,14 +312,15 @@
       <h2>Text Field</h2>
       <ifx-text-field id="text-field" error="false" disabled="false" size="m" icon="calendar-16" success="false"
         placeholder="Placeholder" caption="Caption" required="true" optional="false">Label</ifx-text-field>
+      <p>Standard text field</p>
+      <input type="text">test</input>
+      <br />
       <br />
       <ifx-button type="submit" theme="default" size="s" disabled="false" icon="false">
-        Submit text field
+        Submit form
       </ifx-button>
-
-      <input type="text">test</input>
       <ifx-button type="reset" variant="secondary" theme="default" size="s" disabled="false" icon="false">
-        Reset text field
+        Reset form
       </ifx-button>
     </form>
     <span id="textInputSpan"></span>

--- a/examples/stencil-components/vanilla-cdn/index.html
+++ b/examples/stencil-components/vanilla-cdn/index.html
@@ -313,6 +313,14 @@
       <ifx-text-field id="text-field" error="false" disabled="false" size="m" icon="calendar-16" success="false"
         placeholder="Placeholder" caption="Caption" required="true" optional="false">Label</ifx-text-field>
       <br />
+      <ifx-button type="submit" theme="default" size="s" disabled="false" icon="false">
+        Submit text field
+      </ifx-button>
+
+      <input type="text">test</input>
+      <ifx-button type="reset" variant="secondary" theme="default" size="s" disabled="false" icon="false">
+        Reset text field
+      </ifx-button>
     </form>
     <span id="textInputSpan"></span>
     <br />
@@ -460,6 +468,15 @@
     form.addEventListener('submit', () => {
       event.preventDefault();
       console.log('Form submitted. \nCheckbox value:', checked, '\nSwitchToggle value', switchChecked);
+    });
+
+    anotherForm.addEventListener('submit', () => {
+      event.preventDefault();
+      console.log('Form submitted. Text field value: ', textInputValue);
+    });
+    anotherForm.addEventListener('reset', () => {
+      event.preventDefault();
+      console.log('Form reset. Text field value: ', textInputValue);
     });
 
 

--- a/examples/wrapper-components/angular/src/app/app.component.html
+++ b/examples/wrapper-components/angular/src/app/app.component.html
@@ -629,6 +629,8 @@
   <br />
 
   <ifx-button type="submit">Submit</ifx-button>
+  <ifx-button variant="secondary" type="reset">Reset</ifx-button>
+
 </form>
 <span>Text field value: {{ textFieldValue }}</span>
 <br />

--- a/examples/wrapper-components/react-javascript/src/components/TextField/TextField.js
+++ b/examples/wrapper-components/react-javascript/src/components/TextField/TextField.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IfxTextField } from '@infineon/infineon-design-system-react';
+import { IfxButton, IfxTextField } from '@infineon/infineon-design-system-react';
 
 function TextField() {
 
@@ -9,7 +9,15 @@ function TextField() {
 
   return (
     <div>
-      <IfxTextField onIfxInput={handleInput} />
+      <form id="another-form">
+        <IfxTextField onIfxInput={handleInput} />
+        <IfxButton type="submit" theme="default" size="s" disabled="false" icon="false">
+          Submit form
+        </IfxButton>
+        <IfxButton type="reset" variant="secondary" theme="default" size="s" disabled="false" icon="false">
+          Reset form
+        </IfxButton>
+      </form>
     </div>
   );
 }

--- a/examples/wrapper-components/vue-javascript/src/components/TextField.vue
+++ b/examples/wrapper-components/vue-javascript/src/components/TextField.vue
@@ -1,14 +1,22 @@
 <template>
   <div>
-
-    <h2>Text field</h2>
-    <div>
-      <ifx-text-field v-model="inputValue" error="false" disabled="false" success="false" placeholder="Placeholder"
-        caption="">Label</ifx-text-field>
-    </div>
-    <p>Text field value: {{ inputValue }}</p>
-    <br />
-    <br />
+    <form id="another-form">
+      <h2>Text field</h2>
+      <div>
+        <ifx-text-field v-model="inputValue" error="false" disabled="false" success="false" placeholder="Placeholder"
+          caption="">Label</ifx-text-field>
+        <br />
+        <ifx-button type="submit" theme="default" size="s" disabled="false" icon="false">
+          Submit form
+        </ifx-button>
+        <ifx-button type="reset" variant="secondary" theme="default" size="s" disabled="false" icon="false">
+          Reset form
+        </ifx-button>
+      </div>
+      <p>Text field value: {{ inputValue }}</p>
+      <br />
+      <br />
+    </form>
   </div>
 </template>
 
@@ -19,7 +27,7 @@ let inputValue = ref("");
 
 onMounted(() => {
   updateTextInput();
-  setInterval(updateTextInput, 10000);
+  setInterval(updateTextInput, 50000);
 })
 
 function updateTextInput() {

--- a/packages/components-angular/projects/my-app/src/app/app.component.html
+++ b/packages/components-angular/projects/my-app/src/app/app.component.html
@@ -629,6 +629,8 @@
   <br />
 
   <ifx-button type="submit">Submit</ifx-button>
+  <ifx-button variant="secondary" type="reset">Reset</ifx-button>
+
 </form>
 <span>Text field value: {{ textFieldValue }}</span>
 <br />

--- a/packages/components/src/components/button/button.stories.ts
+++ b/packages/components/src/components/button/button.stories.ts
@@ -32,7 +32,7 @@ export default {
       control: { type: 'radio' },
     },
     type: {
-      options: ['submit', 'button', 'reset'],
+      options: ['button', 'submit', 'reset'],
       control: { type: 'radio' },
     },
     size: {

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -19,7 +19,7 @@ export class Button {
   @Element() el;
 
   private focusableElement: HTMLElement;
-  private nativeButton: HTMLButtonElement;
+  private nativeButton: HTMLButtonElement | HTMLInputElement;
 
   @Watch('href')
   setInternalHref(newValue: string) {
@@ -61,10 +61,17 @@ export class Button {
       if (this.el.href) {
         this.el.internalHref = undefined;
       }
-      this.nativeButton = document.createElement('button');
-      this.nativeButton.type = this.type;
-      this.nativeButton.style.display = 'none';
-      this.el.closest('form').appendChild(this.nativeButton);
+      if (this.type === "reset") {
+        this.nativeButton = document.createElement('input'); //use a hidden input type reset element instead, so standard inputm fields are also included in the reset function
+        this.nativeButton.type = 'reset';
+        this.nativeButton.style.display = 'none';
+        this.el.closest('form').appendChild(this.nativeButton);
+      } else {
+        this.nativeButton = document.createElement('button');
+        this.nativeButton.type = this.type;
+        this.nativeButton.style.display = 'none';
+        this.el.closest('form').appendChild(this.nativeButton);
+      }
     } else {
       this.internalHref = this.href;
     }
@@ -72,8 +79,21 @@ export class Button {
 
   handleClick() {
     if (this.nativeButton) {
-      this.nativeButton.click();
+      if (this.type = 'reset') {
+        this.resetClickHandler(); //this will reset all ifx-text-fields within a form
+      }
+      this.nativeButton.click(); //clicking the nativeButton on type reset will include standard input type text as well
+
     }
+  }
+
+
+  resetClickHandler() {
+    const formElement = this.el.closest('form');
+    const customElements = formElement.querySelectorAll('ifx-text-field');
+    customElements.forEach(element => {
+      element.reset();
+    });
   }
 
   // handleFocus(event: FocusEvent) { // the anchor element should not be focusable when it's disabled

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -61,17 +61,12 @@ export class Button {
       if (this.el.href) {
         this.el.internalHref = undefined;
       }
-      if (this.type === "reset") {
-        this.nativeButton = document.createElement('input'); //use a hidden input type reset element instead, so standard inputm fields are also included in the reset function
-        this.nativeButton.type = 'reset';
-        this.nativeButton.style.display = 'none';
-        this.el.closest('form').appendChild(this.nativeButton);
-      } else {
-        this.nativeButton = document.createElement('button');
-        this.nativeButton.type = this.type;
-        this.nativeButton.style.display = 'none';
-        this.el.closest('form').appendChild(this.nativeButton);
-      }
+     
+      this.nativeButton = document.createElement('button');
+      this.nativeButton.type = this.type;
+      this.nativeButton.style.display = 'none';
+      this.el.closest('form').appendChild(this.nativeButton);
+    
     } else {
       this.internalHref = this.href;
     }
@@ -79,7 +74,7 @@ export class Button {
 
   handleClick() {
     if (this.nativeButton) {
-      if (this.type = 'reset') {
+      if (this.type === 'reset') {
         this.resetClickHandler(); //this will reset all ifx-text-fields within a form
       }
       this.nativeButton.click(); //clicking the nativeButton on type reset will include standard input type text as well

--- a/packages/components/src/components/text-field/readme.md
+++ b/packages/components/src/components/text-field/readme.md
@@ -29,6 +29,19 @@
 | `ifxInput` |             | `CustomEvent<String>` |
 
 
+## Methods
+
+### `reset() => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/components/src/components/text-field/text-field.tsx
+++ b/packages/components/src/components/text-field/text-field.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Event, Element, Prop, EventEmitter, Watch } from '@stencil/core';
+import { Component, h, Event, Element, Prop, EventEmitter, Watch, Method } from '@stencil/core';
 
 @Component({
   tag: 'ifx-text-field',
@@ -21,6 +21,8 @@ export class TextField {
   @Prop() success: boolean = false;
   @Prop() disabled: boolean = false;
   @Event() ifxInput: EventEmitter<String>;
+  // @Prop({ reflect: true })
+  // resetOnSubmit: boolean = false;
 
 
   @Watch('value')
@@ -28,6 +30,12 @@ export class TextField {
     if (newValue !== this.inputElement.value) {
       this.inputElement.value = newValue;
     }
+  }
+
+  @Method()
+  async reset() {
+    this.value = '';
+    this.inputElement.value = '';
   }
 
 

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-  
+
 </body>
 
 </html>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
When setting the button type to 'reset', the reset button clears all ifx-text-fields or standard input fields within the same form.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.30.0--canary.670.3a2d8cc0a673f39459c737833fcd8313c76d4b5c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.30.0--canary.670.3a2d8cc0a673f39459c737833fcd8313c76d4b5c.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.30.0--canary.670.3a2d8cc0a673f39459c737833fcd8313c76d4b5c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
