### PR TITLE
Icon-button: size inconsistency

### DIFF
--- a/packages/components/src/components/icon-button/icon-button.scss
+++ b/packages/components/src/components/icon-button/icon-button.scss
@@ -5,6 +5,7 @@
 }
 
 .btn {
+  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

The size of the icon-button was inconsistent with and without an href. 
To fix it, I adjusted the box-sizing of both elements. 