### PR TITLE
Bugfix: status padding should be removed when border prop is false

### DIFF
--- a/examples/stencil-components/vanilla-cdn/index.html
+++ b/examples/stencil-components/vanilla-cdn/index.html
@@ -278,7 +278,11 @@
     <br />
     <br />
 
-
+    <h2>Status</h2>
+    <ifx-status label="Status with border" color="orange" border="true" />
+    <ifx-status label="Status without border" color="orange" border="false" />
+    <br />
+    <br />
 
 
     <h2>Tabs</h2>

--- a/examples/wrapper-components/react-javascript/src/components/Status/Status.js
+++ b/examples/wrapper-components/react-javascript/src/components/Status/Status.js
@@ -4,8 +4,10 @@ import { IfxStatus } from '@infineon/infineon-design-system-react';
 function Status() {
   return (
     <div>
-      <IfxStatus label="text" color="orange" border="true"></IfxStatus>
-    </div>
+      <IfxStatus label="Status without border" color="red" border="false"></IfxStatus>
+      <br />
+      <IfxStatus label="Status with border" color="orange" border="true"></IfxStatus>
+    </div >
   );
 }
 

--- a/examples/wrapper-components/vue-javascript/src/components/Status.vue
+++ b/examples/wrapper-components/vue-javascript/src/components/Status.vue
@@ -3,7 +3,8 @@
   <div>
     <h2>Status</h2>
     <div>
-      <ifx-status label="text" color="orange" border="true"/>
+      <ifx-status label="Status with border" color="orange" border="true" />
+      <ifx-status label="Status without border" color="orange" border="false" />
     </div>
     <br />
     <br />

--- a/packages/components-angular/projects/my-app/src/app/app.component.html
+++ b/packages/components-angular/projects/my-app/src/app/app.component.html
@@ -597,6 +597,13 @@
 <br />
 <br />
 
+<h2>Status</h2>
+<ifx-status [label]="Status with border" [color]="orange" [border]="true" />
+<ifx-status [label]="Status without border" [color]="orange" [border]="false" />
+<br />
+<br />
+
+
 <h2>Table</h2>
 <ifx-basic-table row-height='default'
   cols='[{"headerName":"Make","field":"make","sortable":true,"sort":"desc","unSortIcon":true},{"headerName":"Model","field":"model","sortable":true,"unSortIcon":true},{"headerName":"Price","field":"price"},{"headerName":"Age","field":"age"}]'

--- a/packages/components/src/components/status/status.scss
+++ b/packages/components/src/components/status/status.scss
@@ -11,27 +11,11 @@
   align-items: center;
   padding: 0 tokens.$ifxSpace100;
   border-radius: tokens.$ifxBorderRadiusRound;
-}
 
-.text {
-  margin: 0;
-  padding-left: tokens.$ifxSpace50;
-  font-style: normal;
-  font-weight: tokens.$ifxFontWeightSemibold;
-  font-size: tokens.$ifxFontSizeM;
-  line-height: tokens.$ifxLineHeightS;
-  display: inline;
-  color: tokens.$ifxColorBaseBlack;
-}
+  &.no-border {
+    padding: 0; // Remove padding when border is not present
+  }
 
-.dot {
-  display: inline-block;
-  width: tokens.$ifxSize100;
-  height: tokens.$ifxSize100;
-  border-radius: tokens.$ifxBorderRadiusRound;
-}
-
-.container {
   &.border-orange {
     border: tokens.$ifxBorderWidth12 solid tokens.$ifxColorOrange500;
   }
@@ -59,7 +43,28 @@
   &.border-berry {
     border: tokens.$ifxBorderWidth12 solid tokens.$ifxColorBerry500;
   }
+
+
 }
+
+.text {
+  margin: 0;
+  padding-left: tokens.$ifxSpace50;
+  font-style: normal;
+  font-weight: tokens.$ifxFontWeightSemibold;
+  font-size: tokens.$ifxFontSizeM;
+  line-height: tokens.$ifxLineHeightS;
+  display: inline;
+  color: tokens.$ifxColorBaseBlack;
+}
+
+.dot {
+  display: inline-block;
+  width: tokens.$ifxSize100;
+  height: tokens.$ifxSize100;
+  border-radius: tokens.$ifxBorderRadiusRound;
+}
+
 
 .dot {
   &.orange {

--- a/packages/components/src/components/status/status.tsx
+++ b/packages/components/src/components/status/status.tsx
@@ -7,16 +7,15 @@ import { Component, h, Prop } from '@stencil/core';
 })
 
 export class Status {
-
   @Prop() label: string;
   @Prop() border: boolean = false;
   @Prop() color: 'orange' | 'ocean' | 'grey' | 'light-grey' | 'red' | 'green' | 'berry' = 'orange';
 
   render() {
-    const borderClass = this.border ? `border-${this.color}` : '';
+    const containerClass = this.border ? `container border-${this.color}` : 'container no-border';
 
     return (
-      <div aria-label="a status indicator" aria-value={this.label} class={`container ${borderClass}`}>
+      <div aria-label="a status indicator" aria-value={this.label} class={containerClass}>
         <span class={`dot ${this.color}`}></span>
         <p class="text">{this.label}</p>
       </div>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
When the border prop in the Status component is set to false, a condition has been added, making sure the padding is removed, so the component aligns nicely when used with other elements.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.34.6--canary.770.b615daae6ee1b3a286d61fbd4300aa614e5f5938.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.34.6--canary.770.b615daae6ee1b3a286d61fbd4300aa614e5f5938.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.34.6--canary.770.b615daae6ee1b3a286d61fbd4300aa614e5f5938.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
