### PR TITLE
Modal: height is made adjust-to-content, and not fixed

### DIFF
--- a/packages/components/src/components/modal/modal.scss
+++ b/packages/components/src/components/modal/modal.scss
@@ -114,6 +114,8 @@
   min-height: 56px;
   box-sizing: border-box;
   flex: 1;
+  max-height: 70vh; 
+  overflow-y: auto; 
 
   // & slot[name=content] {
   //   display: -webkit-box;

--- a/packages/components/src/components/modal/modal.scss
+++ b/packages/components/src/components/modal/modal.scss
@@ -13,6 +13,7 @@
   width: 100%;
   height: 100%;
   z-index: 1000;
+  overflow-y: auto;
 }
 
 .modal-container.open {
@@ -39,7 +40,7 @@
   left: 50%;
   transform: translate(-50%, -50%);
   width: 90%;
-  height: 218px;
+  min-height: 218px;
   background-color: #fff;
   border-radius: tokens.$ifxBorderRadiusNone;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
@@ -53,7 +54,7 @@
 @media screen and (min-width: 768px) {
   .modal-content-container {
     width: 540px;
-    height: 220px;
+    min-height: 220px;
   }
 }
 
@@ -110,17 +111,17 @@
 
 .modal-body {
   padding: 16px 24px;
-  height: 56px;
+  min-height: 56px;
   box-sizing: border-box;
   flex: 1;
 
-  & slot[name=content] {
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+  // & slot[name=content] {
+  //   display: -webkit-box;
+  //   -webkit-line-clamp: 1;
+  //   -webkit-box-orient: vertical;
+  //   overflow: hidden;
+  //   text-overflow: ellipsis;
+  // }
 }
 
 .modal-footer {

--- a/packages/components/src/components/modal/modal.tsx
+++ b/packages/components/src/components/modal/modal.tsx
@@ -76,7 +76,6 @@ export class IfxModal {
 
   open() {
     this.showModal = true;
-    console.log("attempt focus")
     try {
       const anim = animationTo(this.modalContainer, KEYFRAMES.fadeIn, {
         duration: 200,


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Modal height is not fixed anymore. It is now adjusted to content. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.37.2--canary.843.8eb7988eb4ffd2b81ab3469aa399b2369a1c6444.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.37.2--canary.843.8eb7988eb4ffd2b81ab3469aa399b2369a1c6444.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.37.2--canary.843.8eb7988eb4ffd2b81ab3469aa399b2369a1c6444.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
