### PR TITLE
Using CSS Custom Properties to enable overwriting the default font

### DIFF
--- a/examples/wrapper-components/react-javascript/src/App.scss
+++ b/examples/wrapper-components/react-javascript/src/App.scss
@@ -3,4 +3,5 @@
 
 div {
   background-color: tokens.$ifxColorBaseWhite;
+  // --ifx-font-family: 'Arial black'; //overwrite default font
 }

--- a/examples/wrapper-components/vue-javascript/src/assets/base.scss
+++ b/examples/wrapper-components/vue-javascript/src/assets/base.scss
@@ -1,8 +1,8 @@
 @use "@infineon/design-system-tokens/dist/tokens";
 
 
-/* exemplary semantic color variables for this project */
 
 div {
   background-color: tokens.$ifxColorBaseWhite;
+  // --ifx-font-family: 'Arial black'; //overwrite default font
 }

--- a/packages/components/src/global/font.scss
+++ b/packages/components/src/global/font.scss
@@ -1,5 +1,9 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 
+:root {
+  --ifx-font-family: tokens.$ifxFontFamilyBody;
+}
+
 * {
-  font-family: tokens.$ifxFontFamilyBody;
+  font-family: var(--ifx-font-family);
 }

--- a/packages/components/src/global/font.scss
+++ b/packages/components/src/global/font.scss
@@ -5,5 +5,5 @@
 }
 
 * {
-  font-family: var(--ifx-font-family);
+  font-family: var(--ifx-font-family), sans-serif;
 }

--- a/packages/components/src/stories/setup-and-installation/GettingStarted.stories.mdx
+++ b/packages/components/src/stories/setup-and-installation/GettingStarted.stories.mdx
@@ -135,3 +135,15 @@ defineCustomElementIfxIcon(window);
 ```
 
 <p align="right"><a href="#tableContent">back to top</a></p>
+
+
+## <h2 id="font">Custom font</h2>
+
+It is recommended to use the default font (Source Sans 3). 
+However, if your application requires a custom font, it is possible to override the default one using CSS custom properties.
+
+In this case, ``--ifx-font-family`` is a CSS custom property. 
+If the user doesn't set ``--ifx-font-family``, the font family will default to ``tokens.$ifxFontFamilyBody``.
+
+
+<p align="right"><a href="#tableContent">back to top</a></p>

--- a/packages/components/src/stories/setup-and-installation/GettingStarted.stories.mdx
+++ b/packages/components/src/stories/setup-and-installation/GettingStarted.stories.mdx
@@ -139,7 +139,7 @@ defineCustomElementIfxIcon(window);
 
 ## <h2 id="font">Custom font</h2>
 
-It is recommended to use the default font (Source Sans 3). 
+It is recommended to use the default font-family (Source Sans 3). 
 However, if your application requires a custom font, it is possible to override the default one using CSS custom properties.
 
 In this case, ``--ifx-font-family`` is a CSS custom property. 

--- a/packages/components/src/stories/setup-and-installation/GettingStarted.stories.mdx
+++ b/packages/components/src/stories/setup-and-installation/GettingStarted.stories.mdx
@@ -143,7 +143,7 @@ It is recommended to use the default font-family (Source Sans 3).
 However, if your application requires a custom font, it is possible to override the default one using CSS custom properties.
 
 In this case, ``--ifx-font-family`` is a CSS custom property. 
-If the user doesn't set ``--ifx-font-family``, the font family will default to ``tokens.$ifxFontFamilyBody``.
+If the user doesn't set ``--ifx-font-family`` in the global stylesheet, the font family will default to ``tokens.$ifxFontFamilyBody``.
 
 
 <p align="right"><a href="#tableContent">back to top</a></p>


### PR DESCRIPTION
… the user

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Using custom css properties (ifx-font-family) to allow the user to overwrite the default font.

e.g.: in Vue:
For instance, if the Stencil components are all within a certain class (my-app), we can do the following:

```
.my-app {
    --ifx-font-family: Times New Roman;
}
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.38.1--canary.857.4776c3acc5b671cff94df6564063e083bc748c29.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.38.1--canary.857.4776c3acc5b671cff94df6564063e083bc748c29.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.38.1--canary.857.4776c3acc5b671cff94df6564063e083bc748c29.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
