### PR TITLE
Sidebar: inner content height is now flexible

### DIFF
--- a/packages/components/src/components/sidebar/sidebar.scss
+++ b/packages/components/src/components/sidebar/sidebar.scss
@@ -22,11 +22,11 @@
     flex-direction: column;
     align-items: center;
     padding: 0px;
-    flex: none;
+    flex: 1 1 auto; 
     order: 0;
-    flex-grow: 0;
     z-index: 0;
     width: 100%;
+    overflow-y: auto; 
 
     //max-height: 440px;
     //overflow-y: auto;
@@ -95,13 +95,10 @@
       flex-direction: column;
       align-items: flex-start;
       padding: 12px 32px;
-      flex: none;
+      flex: 1 1 auto; 
       order: 1;
-      flex-grow: 0;
       width: 100%;
-
-      max-height: 440px;
-      overflow-y: auto;
+      overflow-y: auto; 
 
       & ::slotted(*) {
         width: 100%;

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -11,15 +11,6 @@
 
   <style defer>
 
-    body { 
-      padding: 0;
-      margin: 0;
-    }
-
-    body, html { 
-      height: 100vh;
-    }
-
   </style>
 
   <script defer>
@@ -29,42 +20,6 @@
 </head>
 
 <body>
-
-  <ifx-sidebar application-name="Application Name">
-    <ifx-sidebar-item>
-      Header Section 1
-      <ifx-sidebar-item icon="image-16">
-        Menu Item 1
-        <ifx-sidebar-item active="true" is-action-item="false">
-          Sub Menu Item 1
-        </ifx-sidebar-item>
-        <ifx-sidebar-item is-action-item="true">Sub Menu Item 2</ifx-sidebar-item>
-        <ifx-sidebar-item is-action-item="true">Sub Menu Item 3</ifx-sidebar-item>
-      </ifx-sidebar-item>
-      <ifx-sidebar-item icon="image-16">Menu Item 2</ifx-sidebar-item>
-      <ifx-sidebar-item icon="image-16">Menu Item 3</ifx-sidebar-item>
-    </ifx-sidebar-item>
-    <ifx-sidebar-item>
-      Header Section 2
-      <ifx-sidebar-item icon="image-16">
-        Menu Item 1<ifx-sidebar-item>Sub Menu Item 1</ifx-sidebar-item>
-        <ifx-sidebar-item>Sub Menu Item 2</ifx-sidebar-item>
-        <ifx-sidebar-item>Sub Menu Item 3</ifx-sidebar-item>
-      </ifx-sidebar-item>
-      <ifx-sidebar-item icon="image-16">Menu Item 2</ifx-sidebar-item>
-      <ifx-sidebar-item icon="image-16">Menu Item 3</ifx-sidebar-item>
-    </ifx-sidebar-item>
-    <ifx-sidebar-item>
-      Header Section 3
-      <ifx-sidebar-item icon="image-16">
-        Menu Item 1<ifx-sidebar-item>Sub Menu Item 1</ifx-sidebar-item>
-        <ifx-sidebar-item>Sub Menu Item 2</ifx-sidebar-item>
-        <ifx-sidebar-item>Sub Menu Item 3</ifx-sidebar-item>
-      </ifx-sidebar-item>
-      <ifx-sidebar-item icon="image-16">Menu Item 2</ifx-sidebar-item>
-      <ifx-sidebar-item icon="image-16">Menu Item 3</ifx-sidebar-item>
-    </ifx-sidebar-item>
-  </ifx-sidebar>
 
 </body>
 

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -11,6 +11,15 @@
 
   <style defer>
 
+    body { 
+      padding: 0;
+      margin: 0;
+    }
+
+    body, html { 
+      height: 100vh;
+    }
+
   </style>
 
   <script defer>
@@ -20,6 +29,42 @@
 </head>
 
 <body>
+
+  <ifx-sidebar application-name="Application Name">
+    <ifx-sidebar-item>
+      Header Section 1
+      <ifx-sidebar-item icon="image-16">
+        Menu Item 1
+        <ifx-sidebar-item active="true" is-action-item="false">
+          Sub Menu Item 1
+        </ifx-sidebar-item>
+        <ifx-sidebar-item is-action-item="true">Sub Menu Item 2</ifx-sidebar-item>
+        <ifx-sidebar-item is-action-item="true">Sub Menu Item 3</ifx-sidebar-item>
+      </ifx-sidebar-item>
+      <ifx-sidebar-item icon="image-16">Menu Item 2</ifx-sidebar-item>
+      <ifx-sidebar-item icon="image-16">Menu Item 3</ifx-sidebar-item>
+    </ifx-sidebar-item>
+    <ifx-sidebar-item>
+      Header Section 2
+      <ifx-sidebar-item icon="image-16">
+        Menu Item 1<ifx-sidebar-item>Sub Menu Item 1</ifx-sidebar-item>
+        <ifx-sidebar-item>Sub Menu Item 2</ifx-sidebar-item>
+        <ifx-sidebar-item>Sub Menu Item 3</ifx-sidebar-item>
+      </ifx-sidebar-item>
+      <ifx-sidebar-item icon="image-16">Menu Item 2</ifx-sidebar-item>
+      <ifx-sidebar-item icon="image-16">Menu Item 3</ifx-sidebar-item>
+    </ifx-sidebar-item>
+    <ifx-sidebar-item>
+      Header Section 3
+      <ifx-sidebar-item icon="image-16">
+        Menu Item 1<ifx-sidebar-item>Sub Menu Item 1</ifx-sidebar-item>
+        <ifx-sidebar-item>Sub Menu Item 2</ifx-sidebar-item>
+        <ifx-sidebar-item>Sub Menu Item 3</ifx-sidebar-item>
+      </ifx-sidebar-item>
+      <ifx-sidebar-item icon="image-16">Menu Item 2</ifx-sidebar-item>
+      <ifx-sidebar-item icon="image-16">Menu Item 3</ifx-sidebar-item>
+    </ifx-sidebar-item>
+  </ifx-sidebar>
 
 </body>
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

The height of the wrapper that holds the sidebar-items is now flexible, and will adjust automatically to the viewport of the screen.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.38.8--canary.883.a676be5caf3c264e6d1ce0fc14cc8a525d722d90.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.38.8--canary.883.a676be5caf3c264e6d1ce0fc14cc8a525d722d90.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.38.8--canary.883.a676be5caf3c264e6d1ce0fc14cc8a525d722d90.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
