### PR TITLE
Card: Card is clickable even without href

### DIFF
--- a/packages/components/src/components/card/card.tsx
+++ b/packages/components/src/components/card/card.tsx
@@ -35,7 +35,7 @@ export class Card {
 
     if (this.href.trim() === "") {
       this.internalHref = undefined;
-    }
+    } else this.internalHref = this.href;
   }
 
   handleClassList(el, type, className) {

--- a/packages/components/src/components/card/card.tsx
+++ b/packages/components/src/components/card/card.tsx
@@ -13,6 +13,7 @@ export class Card {
   @State() alignment: string;
   @State() noImg: boolean;
   @Prop() href: string = "";
+  @State() internalHref: string = ""
   @Prop() target: string = "_self";
 
   @Listen('imgPosition')
@@ -32,8 +33,8 @@ export class Card {
       this.noBtns = true;
     } else this.noBtns = false;
 
-    if (this.href && this.href?.trim() === "") {
-      this.href = undefined;
+    if (this.href.trim() === "") {
+      this.internalHref = undefined;
     }
   }
 
@@ -120,12 +121,12 @@ export class Card {
 
           {this.direction === 'horizontal' &&
             <div class="horizontal">
-              <a class={`card-img ${this.noImg ? 'noImage' : ""}`} href={this.href}>
+              <a class={`card-img ${this.noImg ? 'noImage' : ""}`} href={this.internalHref}>
                 <slot name="img" />
               </a>
 
               <div class='lower__body-wrapper'>
-                <a class='upper-body' href={this.href}>
+                <a class='upper-body' href={this.internalHref}>
                   <slot />
                 </a>
                 <div>
@@ -136,7 +137,7 @@ export class Card {
 
           {this.direction === 'vertical' &&
             <div class="vertical">
-              <a class='upper__body-wrapper' href={this.href} target={this.target}>
+              <a class='upper__body-wrapper' href={this.internalHref} target={this.target}>
                 <div class={`card-img ${this.noImg ? 'noImage' : ""}`}>
                   <slot name="img" />
                 </div>

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -20,7 +20,7 @@
 </head>
 
 <body>
-
+  
 </body>
 
 </html>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

I removed **this.href** from the condition which makes the **href** undefined when it's empty or non existent, and I also added an **internalHref** to replace the **this.href** prop. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.39.3--canary.902.3e5fc8d276be89fd06f8603cce691fe68c8b68e9.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.39.3--canary.902.3e5fc8d276be89fd06f8603cce691fe68c8b68e9.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.39.3--canary.902.3e5fc8d276be89fd06f8603cce691fe68c8b68e9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
