### PR TITLE
Bugfix: Setting activeTabIndex from outside

### DIFF
--- a/examples/wrapper-components/vue-javascript/src/components/Tabs.vue
+++ b/examples/wrapper-components/vue-javascript/src/components/Tabs.vue
@@ -42,7 +42,7 @@ const activeTabIndex = ref(0);
 
 onMounted(() => {
   setTab();
-  setInterval(setTab, 20000);
+  setInterval(setTab, 5000);
 })
 
 function handleChange(event) {

--- a/packages/components-angular/projects/my-app/src/app/app.component.html
+++ b/packages/components-angular/projects/my-app/src/app/app.component.html
@@ -639,7 +639,7 @@
   <br />
 
   <h2>Tabs</h2>
-  <ifx-tabs (tabChange)="handleChange($event)" [tabIndex]="tabIndex" #ifxTabs orientation="horizontal">
+  <ifx-tabs (tabChange)="handleChange($event)" [activeTabIndex]="activeTabIndex" #ifxTabs orientation="horizontal">
     <ifx-tab header="tab header 1" disabled="false">tab 1 content</ifx-tab>
     <ifx-tab header="tab header 2" disabled="true">tab 2 content</ifx-tab>
     <ifx-tab header="tab header 3" disabled="false">tab 3 content</ifx-tab>

--- a/packages/components-angular/projects/my-app/src/app/app.component.ts
+++ b/packages/components-angular/projects/my-app/src/app/app.component.ts
@@ -10,7 +10,7 @@ export class AppComponent {
   title = 'my-app';
 
   progressValue = 10;
-  tabIndex = 0;
+  activeTabIndex = 0;
   checkboxChecked = false;
   checkboxError = false;
   checkboxDisabled = false;
@@ -38,7 +38,7 @@ export class AppComponent {
     const next = Math.floor(Math.random() * (3));
     console.log("set next active tab: ", next)
     if (this.ifxTabs) {
-      this.tabIndex = next;;
+      this.activeTabIndex = next;;
     }
   }
 

--- a/packages/components-angular/projects/my-app/src/index.html
+++ b/packages/components-angular/projects/my-app/src/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8">
   <title>MyApp</title>
-  <base href="/">
+  <base href="./">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/x-icon" href="./favicon.ico">
 </head>
+
 <body>
   <app-root></app-root>
 </body>
+
 </html>

--- a/packages/components/src/components/tabs/tabs.tsx
+++ b/packages/components/src/components/tabs/tabs.tsx
@@ -32,14 +32,8 @@ export class IfxTabs {
 
   @Watch('activeTabIndex')
   activeTabIndexChanged(newValue: number, oldValue: number) {
-    console.log("watch", newValue)
     if (newValue !== oldValue) {
       this.setActiveAndFocusedTab(newValue);
-
-
-      // if (this.isKeyboardEvent) {
-      //   this.internalFocusedTabIndex = newValue;
-      // }
     }
 
   }


### PR DESCRIPTION
…ocused tab index was updated

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
watch decorator added again and logic of internalActive and internalFocused tab index updated. This fixes the setting of the activeTabIndex from outside as well as the keyboard navigation of the component.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.43.8--canary.945.c767ef5fcc2418113df34b71df26815cda1aa273.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.43.8--canary.945.c767ef5fcc2418113df34b71df26815cda1aa273.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.43.8--canary.945.c767ef5fcc2418113df34b71df26815cda1aa273.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
