### PR TITLE
Fixed the height and width of the switch container

### DIFF
--- a/packages/components/src/components/switch/switch.scss
+++ b/packages/components/src/components/switch/switch.scss
@@ -24,7 +24,7 @@
   outline: none;
 
   &:focus {
-    outline: 4px solid #0A8276;
+    outline: 4px solid tokens.$ifxColorOcean500;
     outline-offset: 2px;
   }
 
@@ -33,13 +33,13 @@
   }
 
   &:focus-visible {
-    outline: 2px solid #0A8276;
+    outline: 2px solid tokens.$ifxColorOcean500;
     outline-offset: 2px;
   }
 
   &.disabled {
     cursor: default;
-    border-color: #BFBBBB;
+    border-color: tokens.$ifxColorEngineering300;
   }
 
 
@@ -72,8 +72,8 @@
     transition: transform 0.3s ease, background-color 0.3s ease;
 
     &.disabled {
-      background-color: #BFBBBB;
-      border-color: #BFBBBB;
+      background-color: tokens.$ifxColorEngineering300;
+      border-color: tokens.$ifxColorEngineering300;
       cursor: default;
     }
   }
@@ -101,8 +101,8 @@
   border-color: tokens.$ifxColorOcean500;
 
   &.disabled {
-    background-color: #BFBBBB;
-    border-color: #BFBBBB;
+    background-color: tokens.$ifxColorEngineering300;
+    border-color: tokens.$ifxColorEngineering300;
     cursor: default;
   }
 }

--- a/packages/components/src/components/switch/switch.scss
+++ b/packages/components/src/components/switch/switch.scss
@@ -12,9 +12,10 @@
   display: flex;
   align-items: center;
   position: relative;
-  width: tokens.$ifxSpace500;
-  // gap: tokens.$ifxSpace200;
-  height: 20px;
+  // gap: tokens.$ifxSpace200;4
+  // Subtracting padding size from both height and width
+  width: (tokens.$ifxSpace500)-8px;
+  height: 16px;
   background-color: tokens.$ifxColorBaseWhite;
   border: 1px solid tokens.$ifxColorEngineering500;
   border-radius: 20px;
@@ -38,6 +39,7 @@
 
   &.disabled {
     cursor: default;
+    border-color: #BFBBBB;
   }
 
 
@@ -67,7 +69,7 @@
     height: tokens.$ifxSpace200;
     background-color: tokens.$ifxColorEngineering500;
     border-radius: 50%;
-    transition: transform 0.3s ease;
+    transition: transform 0.3s ease, background-color 0.3s ease;
 
     &.disabled {
       background-color: #BFBBBB;
@@ -77,7 +79,7 @@
   }
 
   .switch.checked {
-    transform: translateX(20px);
+    transform: translateX(16px);
     background-color: tokens.$ifxColorBaseWhite;
 
     &.disabled {


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
Inner circle had the correct dimensions of 16px, just fixed the height and width of the .container by subtracting the padding value(4px) from them. Also, changed the translateX of .switch value accordingly.

Related Issue
#950 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.44.3--canary.975.b06a769027e152ea03857c1cea7017e7446fee83.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.44.3--canary.975.b06a769027e152ea03857c1cea7017e7446fee83.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.44.3--canary.975.b06a769027e152ea03857c1cea7017e7446fee83.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
