### PR TITLE
Bugfix: prevent click dom event from button when disabled

### DIFF
--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "20.44.1--canary.952.ef26122f343bda06639a1a121612a92548dea562.0",
+    "@infineon/infineon-design-system-vue": "^20.44.1--canary.952.ef26122f343bda06639a1a121612a92548dea562.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^3.0.1",
     "vite": "^5.0.12",

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, Host, Method, Element, Watch, State, Listen } from '@stencil/core';
+import { Component, Prop, h, Host, Method, Element, Listen, State, Watch } from '@stencil/core';
 import classNames from 'classnames';
 
 @Component({
@@ -6,7 +6,6 @@ import classNames from 'classnames';
   styleUrl: 'button.scss',
   shadow: true,
 })
-
 export class Button {
   @Prop() variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
   @Prop() theme: 'default' | 'danger' | 'inverse' = 'default';
@@ -32,14 +31,14 @@ export class Button {
     this.focusableElement.focus();
   }
 
-  insertNativeButton() { 
+  insertNativeButton() {
     this.nativeButton = document.createElement('button');
     this.nativeButton.type = this.type;
     this.nativeButton.style.display = 'none';
     this.el.closest('form').appendChild(this.nativeButton);
   }
 
-  handleFormAndInternalHref() { 
+  handleFormAndInternalHref() {
     if (this.el.closest('form')) {
       if (this.el.href) {
         this.el.internalHref = undefined;
@@ -50,29 +49,36 @@ export class Button {
     }
   }
 
-  handleButtonWidth(){
-    if(this.fullWidth){
+  handleButtonWidth() {
+    if (this.fullWidth) {
       this.el.style.setProperty('--bw', '100%');
-    }else{
+    } else {
       this.el.style.setProperty('--bw', 'fit-content');
     }
   }
 
   componentWillLoad() {
-   this.handleFormAndInternalHref()
+    this.handleFormAndInternalHref()
   }
-  
-  componentWillRender(){  
+
+  componentWillRender() {
     this.handleButtonWidth()
   }
 
-  handleClick() {
-    if (!this.disabled) {
-      if (this.nativeButton) {
-        if (this.type === 'reset') {
-          this.resetClickHandler(); //this will reset all ifx-text-fields within a form
+  handleClick = (ev: Event) => {
+    if (this.el.shadowRoot) {
+      const parentForm = this.el.closest('form');
+      if (parentForm) {
+        ev.preventDefault();
+
+        const fakeButton = document.createElement('button');
+        if (this.type) {
+          fakeButton.type = this.type;
         }
-        this.nativeButton.click(); //clicking the nativeButton on type reset will include standard input type text as well
+        fakeButton.style.display = 'none';
+        parentForm.appendChild(fakeButton);
+        fakeButton.click();
+        fakeButton.remove();
       }
     }
   }
@@ -87,13 +93,19 @@ export class Button {
 
   @Listen('keydown')
   handleKeyDown(ev: KeyboardEvent) {
-    if (ev.key === 'Enter') {
-      this.handleClick();
+    if (ev.key === 'Enter' && !this.disabled) {
+      this.handleClick(ev as unknown as MouseEvent);
+    }
+  }
+
+  @Listen('click', { capture: true })
+  handleHostClick(event: Event) {
+    if (this.disabled === true) {
+      event.stopImmediatePropagation();
     }
   }
 
   handleFocus(event: FocusEvent) {
-    // the anchor element should not be focusable when it's disabled
     if (this.disabled) {
       event.preventDefault();
       this.focusableElement.blur();
@@ -109,7 +121,7 @@ export class Button {
           class={this.getClassNames()}
           href={!this.disabled ? this.internalHref : undefined}
           target={this.target}
-          onClick={this.handleClick.bind(this)}
+          onClick={this.handleClick}
           rel={this.target === '_blank' ? 'noopener noreferrer' : undefined}
           onFocus={(event) => this.handleFocus(event)}
           aria-disabled={this.disabled}

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -71,14 +71,19 @@ export class Button {
       if (parentForm) {
         ev.preventDefault();
 
-        const fakeButton = document.createElement('button');
-        if (this.type) {
-          fakeButton.type = this.type;
+        if (this.type === 'reset') {
+          // If the button type is 'reset', manually reset all custom form fields
+          this.resetClickHandler(); //this will reset all ifx-text-fields within a form
+        } else {
+          const fakeButton = document.createElement('button');
+          if (this.type) {
+            fakeButton.type = this.type;
+          }
+          fakeButton.style.display = 'none';
+          parentForm.appendChild(fakeButton);
+          fakeButton.click();
+          fakeButton.remove();
         }
-        fakeButton.style.display = 'none';
-        parentForm.appendChild(fakeButton);
-        fakeButton.click();
-        fakeButton.remove();
       }
     }
   }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Stopping event propagation within a Stencil component's Shadow DOM does not affect the event's propagation in the lighter DOM of the parent component. Therefore, even if the event's propagation is stopped within the Stencil component, it will still propagate outside of it, triggering any listeners attached in the parent component.
The solution is to use capturing event listeners on the host element itself and stop immediate propagation, preventing the event from reaching the parent component.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.44.3--canary.977.9e881285d4ef5bd094dc476cd9cf3784e33fb64a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.44.3--canary.977.9e881285d4ef5bd094dc476cd9cf3784e33fb64a.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.44.3--canary.977.9e881285d4ef5bd094dc476cd9cf3784e33fb64a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
