### PR TITLE
Bugfix: Multiselect options: handling of parent - child relationship

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -17,13 +17,15 @@ export class Checkbox {
   @Prop() size: string = 'm';
   @State() internalValue: boolean;
   @Prop() indeterminate: boolean = false;
+  @State() internalIndeterminate: boolean;
+
   @Event({ bubbles: true, composed: true }) ifxChange: EventEmitter;
 
   handleCheckbox() {
     if (!this.disabled) {
       if (this.inputElement.indeterminate) {
         this.internalValue = true;
-        this.indeterminate = false;
+        this.internalIndeterminate = false;
       } else {
         this.internalValue = !this.internalValue;
       }
@@ -41,6 +43,14 @@ export class Checkbox {
   }
 
 
+  @Watch('indeterminate')
+  indeterminateChanged(newValue: boolean, oldValue: boolean) {
+    if (newValue !== oldValue) {
+      this.internalIndeterminate = newValue;
+      this.inputElement.indeterminate = this.internalIndeterminate; // update the checkbox's indeterminate property
+    }
+  }
+
   handleKeydown(event) {
     // Keycode 32 corresponds to the Space key, 13 corresponds to the Enter key
     if (event.keyCode === 32 || event.keyCode === 13) {
@@ -51,10 +61,11 @@ export class Checkbox {
 
   componentWillLoad() {
     this.internalValue = this.value;
+    this.internalIndeterminate = this.indeterminate;
   }
 
   componentDidRender() {
-    this.inputElement.indeterminate = this.indeterminate;
+    this.inputElement.indeterminate = this.internalIndeterminate;
   }
 
   getCheckedClassName() {


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description

- Bugfix for correctly displaying indeterminate symbol when a parent with children has only some of its children selected
- Removed unnecessary code
- Emitting only the options at the bottom level:
    - Option a > emitting option a when selected
    - Option b (with option b1 and b2) > emitting option b1 and/or b2 when selected, not the parent b itself
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.45.1--canary.978.3d9126d16c1999a0260752d25788bfa18847d4f1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.45.1--canary.978.3d9126d16c1999a0260752d25788bfa18847d4f1.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.45.1--canary.978.3d9126d16c1999a0260752d25788bfa18847d4f1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
