### PR TITLE
chore: bump copyright date to current year

### DIFF
--- a/packages/components/src/components/footer/footer.tsx
+++ b/packages/components/src/components/footer/footer.tsx
@@ -75,7 +75,7 @@ export class Footer {
 
             <div class="footer__base">
               <div class="footer__brand">
-                © 1999 - 2022 Infineon Technologies AG
+                © 1999 - 2024 Infineon Technologies AG
               </div>
               <div class="footer__buttons">
                 <ifx-link variant="menu" href={this.termsUrl} target={this.termsTarget}>Terms</ifx-link>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
This PR bumps the copyright line to the current year. This is observed in our DDS based footers on the OSTS Platform.