### PR TITLE
Enhancement: Webex notification on new version release

### DIFF
--- a/.github/workflows/shipit_master_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_master_and_example_apps_deployment.yml
@@ -242,6 +242,6 @@ jobs:
       - name: Send Notification
         run: |
           VERSION=${{ needs.stencil-library-release.outputs.VERSION }}
-          WEBEX_MESSAGE="**VERSION UPDATE**\nA new version has been released: [$VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION) Click to see what's included in this release."
+          WEBEX_MESSAGE="**VERSION UPDATE**\nA new version has been released: [$VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION)\nFollow the link to see what's included in this release."
           curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"markdown\":\"$WEBEX_MESSAGE\"}"
         shell: bash

--- a/.github/workflows/shipit_master_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_master_and_example_apps_deployment.yml
@@ -242,6 +242,6 @@ jobs:
       - name: Send Notification
         run: |
           VERSION=${{ needs.stencil-library-release.outputs.VERSION }}
-          MESSAGE="New package release - Version: $VERSION"
-          curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"text\":\"$WEBEX_MESSAGE\"}"
+          WEBEX_MESSAGE="**VERSION UPDATE** A new version has been released: [$VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION)"
+          curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"markdown\":\"$WEBEX_MESSAGE\"}"
         shell: bash

--- a/.github/workflows/shipit_master_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_master_and_example_apps_deployment.yml
@@ -241,5 +241,7 @@ jobs:
     steps:
       - name: Send Notification
         run: |
+          VERSION=${{ needs.stencil-library-release.outputs.VERSION }}
+          MESSAGE="New package release - Version: $VERSION"
           curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"text\":\"$WEBEX_MESSAGE\"}"
         shell: bash

--- a/.github/workflows/shipit_master_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_master_and_example_apps_deployment.yml
@@ -39,6 +39,7 @@ jobs:
           VERSION=$(auto shipit --dry-run --quiet)
           echo "Publishing: $VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "WEBEX_MESSAGE=New package release - Version: $VERSION" >> $GITHUB_ENV
           auto shipit
 
       - name: Sleep for 10 seconds #needed because we had runtime issues where the wrappers are not getting the newest version
@@ -233,4 +234,12 @@ jobs:
             pr-preview-angular-example/
             pr-preview-vanilla-example/
           force: false
-  
+
+  webex-notification:
+    needs: [stencil-library-release, deploy-master-vue, deploy-master-react, deploy-master-angular, deploy-master-vanilla]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Notification
+        run: |
+          curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"text\":\"$WEBEX_MESSAGE\"}"
+        shell: bash

--- a/.github/workflows/shipit_master_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_master_and_example_apps_deployment.yml
@@ -235,7 +235,7 @@ jobs:
             pr-preview-vanilla-example/
           force: false
 
-  webex-notification:
+  send-webex-notification:
     needs: [stencil-library-release, deploy-master-vue, deploy-master-react, deploy-master-angular, deploy-master-vanilla]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/shipit_master_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_master_and_example_apps_deployment.yml
@@ -239,7 +239,7 @@ jobs:
     needs: [stencil-library-release, deploy-master-vue, deploy-master-react, deploy-master-angular, deploy-master-vanilla]
     runs-on: ubuntu-latest
     steps:
-      - name: Send Notification
+      - name: Send Webex Notification
         run: |
           VERSION=${{ needs.stencil-library-release.outputs.VERSION }}
           WEBEX_MESSAGE="**VERSION UPDATE**\nA new version has been released: [$VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION)\nFollow the link to see what's included in this release."

--- a/.github/workflows/shipit_master_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_master_and_example_apps_deployment.yml
@@ -242,6 +242,6 @@ jobs:
       - name: Send Notification
         run: |
           VERSION=${{ needs.stencil-library-release.outputs.VERSION }}
-          WEBEX_MESSAGE="**VERSION UPDATE** A new version has been released: [$VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION)"
+          WEBEX_MESSAGE="**VERSION UPDATE**\nA new version has been released: [$VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION) Click to see what's included in this release."
           curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"markdown\":\"$WEBEX_MESSAGE\"}"
         shell: bash

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -261,14 +261,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-  webex-notification:
-    needs: [stencil-library-release, deploy-preview-vue, deploy-preview-react, deploy-preview-angular, deploy-preview-vanilla, update-pr-comment]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send Notification
-        run: |
-          VERSION=20.50.3
-          CANARY_VERSION=${{ needs.stencil-library-release.outputs.CANARY_VERSION }}
-          WEBEX_MESSAGE="**VERSION UPDATE**\nA new version has been released: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION)\nFollow the link to see what's included in this release."
-          curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"markdown\":\"$WEBEX_MESSAGE\"}"
-        shell: bash
+  # webex-notification: commented out and left in here as a reference for testing
+  #   needs: [stencil-library-release, deploy-preview-vue, deploy-preview-react, deploy-preview-angular, deploy-preview-vanilla, update-pr-comment]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Send Notification
+  #       run: |
+  #         VERSION=20.50.3
+  #         CANARY_VERSION=${{ needs.stencil-library-release.outputs.CANARY_VERSION }}
+  #         WEBEX_MESSAGE="**VERSION UPDATE**\nA new version has been released: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION)\nFollow the link to see what's included in this release."
+  #         curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"markdown\":\"$WEBEX_MESSAGE\"}"
+  #       shell: bash

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -268,6 +268,7 @@ jobs:
       - name: Send Notification
         run: |
           CANARY_VERSION=${{ needs.stencil-library-release.outputs.CANARY_VERSION }}
-          WEBEX_MESSAGE="New package release - Version: $CANARY_VERSION"
+          WEBEX_MESSAGE="New package release - Version: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v20.50.3)
+          "
           curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"text\":\"$WEBEX_MESSAGE\"}"
         shell: bash

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -265,7 +265,7 @@ jobs:
   #   needs: [stencil-library-release, deploy-preview-vue, deploy-preview-react, deploy-preview-angular, deploy-preview-vanilla, update-pr-comment]
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - name: Send Notification
+  #     - name: Send Webex Notification
   #       run: |
   #         VERSION=20.50.3
   #         CANARY_VERSION=${{ needs.stencil-library-release.outputs.CANARY_VERSION }}

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -43,6 +43,8 @@ jobs:
           echo "CANARY_VERSION=$CANARY_VERSION" >> $GITHUB_ENV
           echo "CANARY_VERSION=$CANARY_VERSION" >> $GITHUB_OUTPUT
           echo "Set Canary version as Github Env and Github Output: $CANARY_VERSION"
+          echo "WEBEX_MESSAGE=New package release - Version: $CANARY_VERSION" >> $GITHUB_ENV
+
           auto shipit
 
       - name: Sleep for 10 seconds #needed because we had runtime issues where the wrappers are not getting the newest version
@@ -258,3 +260,12 @@ jobs:
             }
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  webex-notification:
+    needs: [stencil-library-release, deploy-preview-vue, deploy-preview-react, deploy-preview-angular, deploy-preview-vanilla, update-pr-comment]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Notification
+        run: |
+          curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"text\":\"$WEBEX_MESSAGE\"}"
+        shell: bash

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -269,6 +269,6 @@ jobs:
         run: |
           VERSION=20.50.3
           CANARY_VERSION=${{ needs.stencil-library-release.outputs.CANARY_VERSION }}
-          WEBEX_MESSAGE="**VERSION UPDATE**\nA new version has been released: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION) Click to see what's included in this release."
+          WEBEX_MESSAGE="**VERSION UPDATE**\nA new version has been released: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION)\nFollow the link to see what's included in this release."
           curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"markdown\":\"$WEBEX_MESSAGE\"}"
         shell: bash

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -268,7 +268,6 @@ jobs:
       - name: Send Notification
         run: |
           CANARY_VERSION=${{ needs.stencil-library-release.outputs.CANARY_VERSION }}
-          WEBEX_MESSAGE="New package release - Version: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v20.50.3)
-          "
-          curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"text\":\"$WEBEX_MESSAGE\"}"
+          WEBEX_MESSAGE="**VERSION UPDATE** A new version has been released: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v20.50.3)"
+          curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"markdown\":\"$WEBEX_MESSAGE\"}"
         shell: bash

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -261,7 +261,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
-  # webex-notification: commented out and left in here as a reference for testing
+  # send-webex-notification: commented out and left in here as a reference for testing
   #   needs: [stencil-library-release, deploy-preview-vue, deploy-preview-react, deploy-preview-angular, deploy-preview-vanilla, update-pr-comment]
   #   runs-on: ubuntu-latest
   #   steps:

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -267,7 +267,8 @@ jobs:
     steps:
       - name: Send Notification
         run: |
+          VERSION=20.50.3
           CANARY_VERSION=${{ needs.stencil-library-release.outputs.CANARY_VERSION }}
-          WEBEX_MESSAGE="**VERSION UPDATE** A new version has been released: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v20.50.3)"
+          WEBEX_MESSAGE="**VERSION UPDATE** A new version has been released: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION)"
           curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"markdown\":\"$WEBEX_MESSAGE\"}"
         shell: bash

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -267,5 +267,7 @@ jobs:
     steps:
       - name: Send Notification
         run: |
+          CANARY_VERSION=${{ needs.stencil-library-release.outputs.CANARY_VERSION }}
+          WEBEX_MESSAGE="New package release - Version: $CANARY_VERSION"
           curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"text\":\"$WEBEX_MESSAGE\"}"
         shell: bash

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -269,6 +269,6 @@ jobs:
         run: |
           VERSION=20.50.3
           CANARY_VERSION=${{ needs.stencil-library-release.outputs.CANARY_VERSION }}
-          WEBEX_MESSAGE="**VERSION UPDATE** A new version has been released: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION)"
+          WEBEX_MESSAGE="**VERSION UPDATE**\nA new version has been released: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION) Click to see what's included in this release."
           curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"markdown\":\"$WEBEX_MESSAGE\"}"
         shell: bash


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Every time after a successful deployment to master, the newly added webex integration will make sure that a bot sends a message in our webex space, notifying users of a new version.
At this stage, this PR includes a test, that is also triggered when a commit to this PR is made, that is sent to a test webex space.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.53.0--canary.1033.2d7cae7ea09921016ac53c63cfc11a3fcef3c6e6.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.53.0--canary.1033.2d7cae7ea09921016ac53c63cfc11a3fcef3c6e6.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.53.0--canary.1033.2d7cae7ea09921016ac53c63cfc11a3fcef3c6e6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
