### PR TITLE
Multiselect: implemented search-enabled prop

### DIFF
--- a/packages/components-vue/lib/components.ts
+++ b/packages/components-vue/lib/components.ts
@@ -260,6 +260,7 @@ export const IfxMultiselect = /*@__PURE__*/ defineContainer<JSX.IfxMultiselect>(
   'label',
   'placeholder',
   'maxItemCount',
+  'searchEnabled',
   'ifxSelect',
   'ifxMultiselectIsOpen'
 ]);

--- a/packages/components/src/components/select/multi-select/multiselect.stories.ts
+++ b/packages/components/src/components/select/multi-select/multiselect.stories.ts
@@ -36,13 +36,12 @@ export default {
     size: "m",
     batchSize: 10,
     maxItemCount: 10,
+    searchEnabled: true,
     error: false,
     errorMessage: 'Some error',
     label: '',
     disabled: false,
     placeholder: 'Placeholder'
-
-
   },
   argTypes: {
     size: {
@@ -71,6 +70,11 @@ export default {
       name: 'Disabled',
       options: [true, false],
       control: { type: 'radio' },
+    },
+    searchEnabled: {
+      name: 'Enable search',
+      options: [true, false],
+      control: { type: 'radio' }
     },
     error: {
       name: 'Error',
@@ -117,7 +121,8 @@ const DefaultTemplate = (args) => {
   error-message='${args.errorMessage}'
   label='${args.label}'
   placeholder='${args.placeholder}'
-  disabled='${args.disabled}'>
+  disabled='${args.disabled}'
+  search-enabled='${args.searchEnabled}'>
 </ifx-multiselect>`;
 
   setTimeout(() => {

--- a/packages/components/src/components/select/multi-select/multiselect.tsx
+++ b/packages/components/src/components/select/multi-select/multiselect.tsx
@@ -44,7 +44,7 @@ export class Multiselect {
   @State() isLoading: boolean = false;
   @State() loadedOptions: Option[] = [];
   @State() filteredOptions: Option[] = [];
-
+  @Prop() searchEnabled: boolean = true
 
 
   @Event() ifxSelect: EventEmitter;
@@ -488,7 +488,7 @@ export class Multiselect {
             <div class="ifx-multiselect-dropdown-menu"
               onScroll={(event) => this.handleScroll(event)}
               style={{ '--dynamic-z-index': this.zIndex.toString() }}>
-              <input type="text" role="textbox" class="search-input" onInput={(event) => this.handleSearch(event.target)} placeholder="Search..."></input>
+              {this.searchEnabled && <input type="text" role="textbox" class="search-input" onInput={(event) => this.handleSearch(event.target)} placeholder="Search..."></input>}
               {this.filteredOptions.map((option, index) => this.renderOption(option, index))}
               {this.isLoading && <div>Loading more options...</div>}
             </div>

--- a/packages/components/src/components/select/multi-select/readme.md
+++ b/packages/components/src/components/select/multi-select/readme.md
@@ -7,17 +7,18 @@
 
 ## Properties
 
-| Property       | Attribute        | Description | Type              | Default           |
-| -------------- | ---------------- | ----------- | ----------------- | ----------------- |
-| `batchSize`    | `batch-size`     |             | `number`          | `50`              |
-| `disabled`     | `disabled`       |             | `boolean`         | `false`           |
-| `error`        | `error`          |             | `boolean`         | `false`           |
-| `errorMessage` | `error-message`  |             | `string`          | `"Error"`         |
-| `label`        | `label`          |             | `string`          | `""`              |
-| `maxItemCount` | `max-item-count` |             | `number`          | `undefined`       |
-| `options`      | `options`        |             | `any[] \| string` | `undefined`       |
-| `placeholder`  | `placeholder`    |             | `string`          | `""`              |
-| `size`         | `size`           |             | `string`          | `'medium (40px)'` |
+| Property        | Attribute        | Description | Type              | Default           |
+| --------------- | ---------------- | ----------- | ----------------- | ----------------- |
+| `batchSize`     | `batch-size`     |             | `number`          | `50`              |
+| `disabled`      | `disabled`       |             | `boolean`         | `false`           |
+| `error`         | `error`          |             | `boolean`         | `false`           |
+| `errorMessage`  | `error-message`  |             | `string`          | `"Error"`         |
+| `label`         | `label`          |             | `string`          | `""`              |
+| `maxItemCount`  | `max-item-count` |             | `number`          | `undefined`       |
+| `options`       | `options`        |             | `any[] \| string` | `undefined`       |
+| `placeholder`   | `placeholder`    |             | `string`          | `""`              |
+| `searchEnabled` | `search-enabled` |             | `boolean`         | `true`            |
+| `size`          | `size`           |             | `string`          | `'medium (40px)'` |
 
 
 ## Events


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
Implemented search-enabled prop with default prop value set to true, when set to false, removes the search input box.

Related Issue
#1023 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.52.0--canary.1037.c5043797892f5da1ae2c57ba71d8bcbd3a3755e1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.52.0--canary.1037.c5043797892f5da1ae2c57ba71d8bcbd3a3755e1.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.52.0--canary.1037.c5043797892f5da1ae2c57ba71d8bcbd3a3755e1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
