### PR TITLE
Bugfix: Version is null when sending webex notification

### DIFF
--- a/.github/workflows/shipit_master_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_master_and_example_apps_deployment.yml
@@ -5,11 +5,10 @@ on:
     branches:
      - master
  
-env:
-  VERSION: ''
-
 jobs:
   stencil-library-release:
+    outputs:
+      VERSION: ${{ steps.build.outputs.VERSION }}
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')" # job will not run, if triggered via ship-it
     steps:
@@ -39,6 +38,8 @@ jobs:
           VERSION=$(auto shipit --dry-run --quiet)
           echo "Publishing: $VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Set version as Github Env and Github Output: $VERSION"
           echo "WEBEX_MESSAGE=New package release - Version: $VERSION" >> $GITHUB_ENV
           auto shipit
 
@@ -50,6 +51,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: | 
+          echo "VERSION: $VERSION"
           echo "Installing Stencil library for Angular, Vue and React: $VERSION"
           lerna version $VERSION --no-git-tag-version --y
           cd packages/components-angular/projects/component-library


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Bugfix: Version added as Github Output during the deployment action so it can be later retrieved by the send-webex-notification job
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.53.1--canary.1040.4708b2ad215b507132e329a5fa189eb355500a97.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.53.1--canary.1040.4708b2ad215b507132e329a5fa189eb355500a97.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.53.1--canary.1040.4708b2ad215b507132e329a5fa189eb355500a97.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
