### PR TITLE
1041 enhancement skip canary release creation when workflow is triggered by dependabot secrets not accessible

### DIFF
--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -11,6 +11,8 @@ jobs:
   stencil-library-release:
     outputs:
       CANARY_VERSION: ${{ steps.build.outputs.CANARY_VERSION }}
+      SKIP_REMAINING: ${{ steps.build.outputs.SKIP_REMAINING }}
+
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')" # job will not run, if triggered via ship-it
     steps:
@@ -33,25 +35,29 @@ jobs:
         id: build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: github.actor != 'dependabot[bot]'
         run: | 
           npm install --scope=@infineon/infineon-design-system-stencil
           npm run build:components
-          cd packages/components
-          CANARY_VERSION=$(auto shipit --dry-run --quiet)
-          echo "Publishing: $CANARY_VERSION"
-          echo "CANARY_VERSION=$CANARY_VERSION" >> $GITHUB_ENV
-          echo "CANARY_VERSION=$CANARY_VERSION" >> $GITHUB_OUTPUT
-          echo "Set Canary version as Github Env and Github Output: $CANARY_VERSION"
-          echo "WEBEX_MESSAGE=New package release - Version: $CANARY_VERSION" >> $GITHUB_ENV
-
-          auto shipit
+          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+            echo "Skipping creation of a canary release due to workflow trigger being a Dependabot PR"
+            echo "SKIP_REMAINING=true"" >> $GITHUB_OUTPUT
+          else 
+            cd packages/components
+            CANARY_VERSION=$(auto shipit --dry-run --quiet)
+            echo "CANARY_VERSION=$CANARY_VERSION" >> $GITHUB_ENV
+            echo "CANARY_VERSION=$CANARY_VERSION" >> $GITHUB_OUTPUT
+            echo "WEBEX_MESSAGE=New package release - Version: $CANARY_VERSION" >> $GITHUB_ENV
+            echo "Publishing: $CANARY_VERSION"
+            auto shipit
+          fi
 
       - name: Sleep for 10 seconds #needed because we had runtime issues where the wrappers are not getting the newest version
+        if: steps.build.outputs.SKIP_REMAINING == 'false'
         run: sleep 10s
         shell: bash
 
       - name: Update Dependencies in Angular, Vue and React packages
+        if: steps.build.outputs.SKIP_REMAINING == 'false'
         id: update-wrapper-dependencies
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -68,6 +74,7 @@ jobs:
           npm install @infineon/infineon-design-system-stencil@$CANARY_VERSION
      
       - name: Build and deploy Angular, Vue and React packages
+        if: steps.build.outputs.SKIP_REMAINING == 'false'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -85,6 +92,7 @@ jobs:
   #deploy gh-pages previews for example applications:
   deploy-preview-vue:
     needs: stencil-library-release  
+    if: needs.stencil-library-release.outputs.SKIP_REMAINING == 'false'
     runs-on: ubuntu-latest
     outputs:
       deployment-url: ${{ steps.preview.outputs.deployment-url }}
@@ -120,6 +128,7 @@ jobs:
   
   deploy-preview-react:
     needs: stencil-library-release  
+    if: needs.stencil-library-release.outputs.SKIP_REMAINING == 'false'
     runs-on: ubuntu-latest
     outputs:
       deployment-url: ${{ steps.preview.outputs.deployment-url }}
@@ -153,6 +162,7 @@ jobs:
    
   deploy-preview-angular:
     needs: stencil-library-release  
+    if: needs.stencil-library-release.outputs.SKIP_REMAINING == 'false'
     outputs:
       deployment-url: ${{ steps.preview.outputs.deployment-url }}
     runs-on: ubuntu-latest
@@ -187,6 +197,7 @@ jobs:
           
   deploy-preview-vanilla:
     needs: stencil-library-release  
+    if: needs.stencil-library-release.outputs.SKIP_REMAINING == 'false'
     runs-on: ubuntu-latest
     outputs:
       deployment-url: ${{ steps.preview.outputs.deployment-url }}

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -46,6 +46,7 @@ jobs:
             CANARY_VERSION=$(auto shipit --dry-run --quiet)
             echo "CANARY_VERSION=$CANARY_VERSION" >> $GITHUB_ENV
             echo "CANARY_VERSION=$CANARY_VERSION" >> $GITHUB_OUTPUT
+            echo "SKIP_REMAINING='false'" >> $GITHUB_OUTPUT
             echo "WEBEX_MESSAGE=New package release - Version: $CANARY_VERSION" >> $GITHUB_ENV
             echo "Publishing: $CANARY_VERSION"
             auto shipit

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -33,7 +33,7 @@ jobs:
         id: build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+        if: github.actor != 'dependabot[bot]'
         run: | 
           npm install --scope=@infineon/infineon-design-system-stencil
           npm run build:components

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -40,7 +40,7 @@ jobs:
           npm run build:components
           if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
             echo "Skipping creation of a canary release due to workflow trigger being a Dependabot PR"
-            echo "SKIP_REMAINING=true"" >> $GITHUB_OUTPUT
+            echo "SKIP_REMAINING=true" >> $GITHUB_OUTPUT
           else 
             cd packages/components
             CANARY_VERSION=$(auto shipit --dry-run --quiet)
@@ -271,15 +271,3 @@ jobs:
             }
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-
-  # send-webex-notification: commented out and left in here as a reference for testing
-  #   needs: [stencil-library-release, deploy-preview-vue, deploy-preview-react, deploy-preview-angular, deploy-preview-vanilla, update-pr-comment]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Send Webex Notification
-  #       run: |
-  #         VERSION=20.50.3
-  #         CANARY_VERSION=${{ needs.stencil-library-release.outputs.CANARY_VERSION }}
-  #         WEBEX_MESSAGE="**VERSION UPDATE**\nA new version has been released: [$CANARY_VERSION](https://github.com/Infineon/infineon-design-system-stencil/releases/tag/v$VERSION)\nFollow the link to see what's included in this release."
-  #         curl https://webexapis.com/v1/messages -X POST -H "Authorization: Bearer ${{ secrets.WEBEX_TOKEN }}" -H "Content-Type: application/json" -d "{\"roomId\":\"${{ secrets.WEBEX_ROOM_ID }}\",\"markdown\":\"$WEBEX_MESSAGE\"}"
-  #       shell: bash

--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -40,7 +40,7 @@ jobs:
           npm run build:components
           if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
             echo "Skipping creation of a canary release due to workflow trigger being a Dependabot PR"
-            echo "SKIP_REMAINING=true" >> $GITHUB_OUTPUT
+            echo "SKIP_REMAINING='true'" >> $GITHUB_OUTPUT
           else 
             cd packages/components
             CANARY_VERSION=$(auto shipit --dry-run --quiet)
@@ -51,9 +51,11 @@ jobs:
             auto shipit
           fi
 
+
       - name: Sleep for 10 seconds #needed because we had runtime issues where the wrappers are not getting the newest version
-        if: steps.build.outputs.SKIP_REMAINING == 'false'
-        run: sleep 10s
+        run: |
+          echo "Skip Remaining: ${{ steps.build.outputs.SKIP_REMAINING }}"  
+          sleep 10s
         shell: bash
 
       - name: Update Dependencies in Angular, Vue and React packages


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Since secrets like the NPM_TOKEN are not accessible to outside contributors like dependabot, the workflows triggered on a dependabot PR always.
Add a simple check, if the PR is created by dependabot, and in that case, simply skip the attempt to create a new canary release.
Dependabot PRs need to be reviewed anyways and there is no need that a canary deployment is attempted, as it will fail anyways.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.54.0--canary.1042.f17485f37762ce1f810a1a7c0ea85ee186c59fb5.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.54.0--canary.1042.f17485f37762ce1f810a1a7c0ea85ee186c59fb5.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.54.0--canary.1042.f17485f37762ce1f810a1a7c0ea85ee186c59fb5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
