### PR TITLE
Modal: Close button is now removable

### DIFF
--- a/examples/wrapper-components/react-javascript/src/components/Modal/Modal.js
+++ b/examples/wrapper-components/react-javascript/src/components/Modal/Modal.js
@@ -15,7 +15,7 @@ function Modal() {
 
   return (
     <div>
-      <IfxModal ref={modalRef} caption="Modal Title" variant="default" close-on-overlay-click="false">
+      <IfxModal ref={modalRef} caption="Modal Title" variant="default" closeOnOverlayClick="true"  showCloseButton='false'>
         <div slot="content">
           <span>Hello. Welcome. What a pleasure it is to have you.</span>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34483,7 +34483,7 @@
         "@infineon/design-system-tokens": "3.3.2",
         "@infineon/infineon-icons": "^1.1.8",
         "@popperjs/core": "^2.11.8",
-        "@stencil/core": "4.5.0",
+        "@stencil/core": "4.12.6",
         "@storybook/blocks": "^7.0.23",
         "@storybook/cli": "^7.0.20",
         "babel-prettier-parser": "^0.10.8",
@@ -34729,6 +34729,18 @@
         "@rollup/rollup-win32-ia32-msvc": "4.9.6",
         "@rollup/rollup-win32-x64-msvc": "4.9.6",
         "fsevents": "~2.3.2"
+      }
+    },
+    "packages/components/node_modules/@stencil/core": {
+      "version": "4.12.6",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.6.tgz",
+      "integrity": "sha512-15JO2TdaxGVKNdLZb/2TtDa+juj3XGD/V0y/disgdzYYSnajgSh06nwODfdHz9eTUh1Hisz+KIo857I1rCZrfg==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "packages/components/node_modules/copy-webpack-plugin": {

--- a/packages/components-vue/lib/components.ts
+++ b/packages/components-vue/lib/components.ts
@@ -245,6 +245,7 @@ export const IfxModal = /*@__PURE__*/ defineContainer<JSX.IfxModal>('ifx-modal',
   'alertIcon',
   'okButtonLabel',
   'cancelButtonLabel',
+  'showCloseButton',
   'ifxModalOpen',
   'ifxModalClose'
 ]);

--- a/packages/components/src/components/modal/modal.scss
+++ b/packages/components/src/components/modal/modal.scss
@@ -110,6 +110,10 @@
   cursor: pointer;
 }
 
+.modal-close-button {
+  margin-right: -8px;
+}
+
 .modal-body {
   padding: 16px 24px;
   min-height: 56px;

--- a/packages/components/src/components/modal/modal.stories.ts
+++ b/packages/components/src/components/modal/modal.stories.ts
@@ -31,6 +31,10 @@ export default {
       control: 'boolean',
       description: 'Close the modal when clicking outside the window',
     },
+    showCloseButton: {
+      control: 'boolean',
+      description: "Show or hide close button 'x'",
+    },
     alertIcon: {
       options: Object.keys(icons),
       control: { type: 'select' },
@@ -65,6 +69,7 @@ export default {
 
 const Template = ({
   caption,
+  showCloseButton,
   closeOnOverlayClick,
   variant,
   alertIcon
@@ -77,6 +82,7 @@ const Template = ({
     modal.setAttribute('alert-icon', alertIcon);
   }
   modal.setAttribute('close-on-overlay-click', closeOnOverlayClick);
+  modal.setAttribute('show-close-button', showCloseButton);
 
   modal.addEventListener('ifxModalOpen', action('ifxModalOpen'));
   modal.addEventListener('ifxModalClose', action('ifxModalClose'));
@@ -129,6 +135,7 @@ const Template = ({
 export const Default = Template.bind({});
 Default.args = {
   caption: 'Modal Title',
+  showCloseButton: true,
   closeOnOverlayClick: false,
   variant: 'default',
 };

--- a/packages/components/src/components/modal/modal.tsx
+++ b/packages/components/src/components/modal/modal.tsx
@@ -31,6 +31,8 @@ export class IfxModal {
 
   @State() slotButtonsPresent: boolean = false;
 
+  @Prop() showCloseButton: boolean = true;
+
   private modalContainer: HTMLElement;
   private focusableElements: HTMLElement[] = [];
   private closeButton: HTMLButtonElement | HTMLIfxIconButtonElement;
@@ -191,8 +193,11 @@ export class IfxModal {
             <div class="modal-content">
               <div class="modal-header">
                 <h2>{this.caption}</h2>
-                <ifx-icon-button ref={(el) => (this.closeButton = el)} icon="cross-24" variant="tertiary" onClick={() => this.doBeforeClose('CLOSE_BUTTON')}
-                ></ifx-icon-button>
+                { 
+                  this.showCloseButton && 
+                  <ifx-icon-button class = 'modal-close-button' ref={(el) => (this.closeButton = el)} icon="cross-24" variant="tertiary" onClick={() => this.doBeforeClose('CLOSE_BUTTON') }>
+                  </ifx-icon-button>
+                }
               </div>
               <div class="modal-body">
                 <slot name="content" /*onSlotchange={() => console.log('slots children modified')}*/ />

--- a/packages/components/src/components/modal/readme.md
+++ b/packages/components/src/components/modal/readme.md
@@ -15,6 +15,7 @@
 | `closeOnOverlayClick` | `close-on-overlay-click` |             | `boolean`                                      | `true`          |
 | `okButtonLabel`       | `ok-button-label`        |             | `string`                                       | `'OK'`          |
 | `opened`              | `opened`                 |             | `boolean`                                      | `false`         |
+| `showCloseButton`     | `show-close-button`      |             | `boolean`                                      | `true`          |
 | `variant`             | `variant`                |             | `"alert-brand" \| "alert-danger" \| "default"` | `'default'`     |
 
 

--- a/packages/components/src/components/select/single-select/readme.md
+++ b/packages/components/src/components/select/single-select/readme.md
@@ -76,6 +76,12 @@
 
 
 
+#### Parameters
+
+| Name | Type                      | Description |
+| ---- | ------------------------- | ----------- |
+| `fn` | `(callback: any) => void` |             |
+
 #### Returns
 
 Type: `Promise<this>`
@@ -136,6 +142,12 @@ Type: `Promise<this>`
 
 
 
+#### Parameters
+
+| Name        | Type      | Description |
+| ----------- | --------- | ----------- |
+| `valueOnly` | `boolean` |             |
+
 #### Returns
 
 Type: `Promise<string | string[]>`
@@ -155,6 +167,12 @@ Type: `Promise<void>`
 ### `hideDropdown(blurInput?: boolean) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name        | Type      | Description |
+| ----------- | --------- | ----------- |
+| `blurInput` | `boolean` |             |
 
 #### Returns
 
@@ -176,6 +194,13 @@ Type: `Promise<this>`
 
 
 
+#### Parameters
+
+| Name       | Type          | Description |
+| ---------- | ------------- | ----------- |
+| `item`     | `HTMLElement` |             |
+| `runEvent` | `boolean`     |             |
+
 #### Returns
 
 Type: `Promise<this>`
@@ -185,6 +210,12 @@ Type: `Promise<this>`
 ### `removeActiveItems(excludedId?: number) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name         | Type     | Description |
+| ------------ | -------- | ----------- |
+| `excludedId` | `number` |             |
 
 #### Returns
 
@@ -196,6 +227,12 @@ Type: `Promise<this>`
 
 
 
+#### Parameters
+
+| Name    | Type     | Description |
+| ------- | -------- | ----------- |
+| `value` | `string` |             |
+
 #### Returns
 
 Type: `Promise<this>`
@@ -205,6 +242,12 @@ Type: `Promise<this>`
 ### `removeHighlightedItems(runEvent?: boolean) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name       | Type      | Description |
+| ---------- | --------- | ----------- |
+| `runEvent` | `boolean` |             |
 
 #### Returns
 
@@ -216,6 +259,12 @@ Type: `Promise<this>`
 
 
 
+#### Parameters
+
+| Name    | Type                 | Description |
+| ------- | -------------------- | ----------- |
+| `value` | `string \| string[]` |             |
+
 #### Returns
 
 Type: `Promise<this>`
@@ -225,6 +274,15 @@ Type: `Promise<this>`
 ### `setChoices(choices: any[] | string, value: string, label: string, replaceChoices?: boolean) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name             | Type              | Description |
+| ---------------- | ----------------- | ----------- |
+| `choices`        | `string \| any[]` |             |
+| `value`          | `string`          |             |
+| `label`          | `string`          |             |
+| `replaceChoices` | `boolean`         |             |
 
 #### Returns
 
@@ -236,6 +294,12 @@ Type: `Promise<this>`
 
 
 
+#### Parameters
+
+| Name   | Type    | Description |
+| ------ | ------- | ----------- |
+| `args` | `any[]` |             |
+
 #### Returns
 
 Type: `Promise<this>`
@@ -245,6 +309,12 @@ Type: `Promise<this>`
 ### `showDropdown(focusInput?: boolean) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name         | Type      | Description |
+| ------------ | --------- | ----------- |
+| `focusInput` | `boolean` |             |
 
 #### Returns
 
@@ -265,6 +335,12 @@ Type: `Promise<this>`
 ### `unhighlightItem(item: HTMLElement) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name   | Type          | Description |
+| ------ | ------------- | ----------- |
+| `item` | `HTMLElement` |             |
 
 #### Returns
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
The close button (x) on modal is removable using show-close-button prop.
Also adjusted the padding of close button to match the figma design.

Related Issue
#1054 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.56.0--canary.1059.f263c66cc324d7d74173ef63805bd926b4c10b17.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.56.0--canary.1059.f263c66cc324d7d74173ef63805bd926b4c10b17.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.56.0--canary.1059.f263c66cc324d7d74173ef63805bd926b4c10b17.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
