### PR TITLE
Alert: renamed variant secondary with success and aligned the variant design color

### DIFF
--- a/examples/wrapper-components/react-javascript/src/components/Alert/Alert.js
+++ b/examples/wrapper-components/react-javascript/src/components/Alert/Alert.js
@@ -4,7 +4,7 @@ import { IfxAlert } from '@infineon/infineon-design-system-react';
 function Alert() {
   return (
     <div >
-      <IfxAlert color="primary" icon="c-info-24">Attention! This is an alert message — check it out!</IfxAlert>
+      <IfxAlert variant="primary" icon="c-info-24">Attention! This is an alert message — check it out!</IfxAlert>
 
     </div>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -34483,7 +34483,7 @@
         "@infineon/design-system-tokens": "3.3.2",
         "@infineon/infineon-icons": "^1.1.8",
         "@popperjs/core": "^2.11.8",
-        "@stencil/core": "4.5.0",
+        "@stencil/core": "4.12.6",
         "@storybook/blocks": "^7.0.23",
         "@storybook/cli": "^7.0.20",
         "babel-prettier-parser": "^0.10.8",
@@ -34729,6 +34729,18 @@
         "@rollup/rollup-win32-ia32-msvc": "4.9.6",
         "@rollup/rollup-win32-x64-msvc": "4.9.6",
         "fsevents": "~2.3.2"
+      }
+    },
+    "packages/components/node_modules/@stencil/core": {
+      "version": "4.12.6",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.6.tgz",
+      "integrity": "sha512-15JO2TdaxGVKNdLZb/2TtDa+juj3XGD/V0y/disgdzYYSnajgSh06nwODfdHz9eTUh1Hisz+KIo857I1rCZrfg==",
+      "bin": {
+        "stencil": "bin/stencil"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "packages/components/node_modules/copy-webpack-plugin": {

--- a/packages/components/src/components/alert/alert.scss
+++ b/packages/components/src/components/alert/alert.scss
@@ -111,11 +111,11 @@
     }
   }
 
-  &.secondary {
-    border: 1px solid tokens.$ifxColorBerry500;
+  &.success {
+    border: 1px solid tokens.$ifxColorGreen500;
 
     & .icon-wrapper {
-      background-color: tokens.$ifxColorBerry500;
+      background-color: tokens.$ifxColorGreen500;
       color: tokens.$ifxColorBaseWhite;
     }
   }

--- a/packages/components/src/components/alert/alert.stories.ts
+++ b/packages/components/src/components/alert/alert.stories.ts
@@ -14,7 +14,7 @@ export default {
 
   argTypes: {
     variant: {
-      options: ['primary', 'secondary', 'danger', 'warning'],
+      options: ['primary', 'success', 'danger', 'warning'],
       control: { type: 'radio' },
     },
 

--- a/packages/components/src/components/alert/alert.tsx
+++ b/packages/components/src/components/alert/alert.tsx
@@ -7,7 +7,7 @@ import { Component, Prop, h, Event, EventEmitter } from '@stencil/core';
 })
 
 export class Alert {
-  @Prop() variant: 'primary' | 'secondary' | 'danger' | 'warning' | 'info' = 'primary';
+  @Prop() variant: 'primary' | 'success' | 'danger' | 'warning' | 'info' = 'primary';
   @Prop() icon: string;
   @Event() ifxClose: EventEmitter;
   @Prop() closable: boolean = true;

--- a/packages/components/src/components/alert/readme.md
+++ b/packages/components/src/components/alert/readme.md
@@ -7,11 +7,11 @@
 
 ## Properties
 
-| Property   | Attribute  | Description | Type                                                          | Default     |
-| ---------- | ---------- | ----------- | ------------------------------------------------------------- | ----------- |
-| `closable` | `closable` |             | `boolean`                                                     | `true`      |
-| `icon`     | `icon`     |             | `string`                                                      | `undefined` |
-| `variant`  | `variant`  |             | `"danger" \| "info" \| "primary" \| "secondary" \| "warning"` | `'primary'` |
+| Property   | Attribute  | Description | Type                                                        | Default     |
+| ---------- | ---------- | ----------- | ----------------------------------------------------------- | ----------- |
+| `closable` | `closable` |             | `boolean`                                                   | `true`      |
+| `icon`     | `icon`     |             | `string`                                                    | `undefined` |
+| `variant`  | `variant`  |             | `"danger" \| "info" \| "primary" \| "success" \| "warning"` | `'primary'` |
 
 
 ## Events

--- a/packages/components/src/components/select/single-select/readme.md
+++ b/packages/components/src/components/select/single-select/readme.md
@@ -76,6 +76,12 @@
 
 
 
+#### Parameters
+
+| Name | Type                      | Description |
+| ---- | ------------------------- | ----------- |
+| `fn` | `(callback: any) => void` |             |
+
 #### Returns
 
 Type: `Promise<this>`
@@ -136,6 +142,12 @@ Type: `Promise<this>`
 
 
 
+#### Parameters
+
+| Name        | Type      | Description |
+| ----------- | --------- | ----------- |
+| `valueOnly` | `boolean` |             |
+
 #### Returns
 
 Type: `Promise<string | string[]>`
@@ -155,6 +167,12 @@ Type: `Promise<void>`
 ### `hideDropdown(blurInput?: boolean) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name        | Type      | Description |
+| ----------- | --------- | ----------- |
+| `blurInput` | `boolean` |             |
 
 #### Returns
 
@@ -176,6 +194,13 @@ Type: `Promise<this>`
 
 
 
+#### Parameters
+
+| Name       | Type          | Description |
+| ---------- | ------------- | ----------- |
+| `item`     | `HTMLElement` |             |
+| `runEvent` | `boolean`     |             |
+
 #### Returns
 
 Type: `Promise<this>`
@@ -185,6 +210,12 @@ Type: `Promise<this>`
 ### `removeActiveItems(excludedId?: number) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name         | Type     | Description |
+| ------------ | -------- | ----------- |
+| `excludedId` | `number` |             |
 
 #### Returns
 
@@ -196,6 +227,12 @@ Type: `Promise<this>`
 
 
 
+#### Parameters
+
+| Name    | Type     | Description |
+| ------- | -------- | ----------- |
+| `value` | `string` |             |
+
 #### Returns
 
 Type: `Promise<this>`
@@ -205,6 +242,12 @@ Type: `Promise<this>`
 ### `removeHighlightedItems(runEvent?: boolean) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name       | Type      | Description |
+| ---------- | --------- | ----------- |
+| `runEvent` | `boolean` |             |
 
 #### Returns
 
@@ -216,6 +259,12 @@ Type: `Promise<this>`
 
 
 
+#### Parameters
+
+| Name    | Type                 | Description |
+| ------- | -------------------- | ----------- |
+| `value` | `string \| string[]` |             |
+
 #### Returns
 
 Type: `Promise<this>`
@@ -225,6 +274,15 @@ Type: `Promise<this>`
 ### `setChoices(choices: any[] | string, value: string, label: string, replaceChoices?: boolean) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name             | Type              | Description |
+| ---------------- | ----------------- | ----------- |
+| `choices`        | `string \| any[]` |             |
+| `value`          | `string`          |             |
+| `label`          | `string`          |             |
+| `replaceChoices` | `boolean`         |             |
 
 #### Returns
 
@@ -236,6 +294,12 @@ Type: `Promise<this>`
 
 
 
+#### Parameters
+
+| Name   | Type    | Description |
+| ------ | ------- | ----------- |
+| `args` | `any[]` |             |
+
 #### Returns
 
 Type: `Promise<this>`
@@ -245,6 +309,12 @@ Type: `Promise<this>`
 ### `showDropdown(focusInput?: boolean) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name         | Type      | Description |
+| ------------ | --------- | ----------- |
+| `focusInput` | `boolean` |             |
 
 #### Returns
 
@@ -265,6 +335,12 @@ Type: `Promise<this>`
 ### `unhighlightItem(item: HTMLElement) => Promise<this>`
 
 
+
+#### Parameters
+
+| Name   | Type          | Description |
+| ------ | ------------- | ----------- |
+| `item` | `HTMLElement` |             |
 
 #### Returns
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Replaced existing variant 'secondary' with 'success' and updated its color to align with the figma design.

Related Issue
#1055 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.55.1--canary.1062.9e86f606e7b8e5346c931b5235bfee97450e9b58.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.55.1--canary.1062.9e86f606e7b8e5346c931b5235bfee97450e9b58.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.55.1--canary.1062.9e86f606e7b8e5346c931b5235bfee97450e9b58.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
