### PR TITLE
Progress bar: fixed bug where label text looked broken

### DIFF
--- a/packages/components/src/components/progress-bar/progress-bar.tsx
+++ b/packages/components/src/components/progress-bar/progress-bar.tsx
@@ -27,8 +27,8 @@ export class ProgressBar {
   render() {
     return (
       <div aria-label='a progress bar' aria-value={this.value}  class={`progress-bar ${this.size}`}>
-        <div class="progress" style={{ width: `${this.internalValue}%` }}>
-          {this.showLabel && this.size !== "s" && <span class="label">{`${this.internalValue}%`}</span>}
+        <div class="progress" style={{ width: `${this.internalValue === 0 ? 0 : Math.max(2, this.internalValue)}%` }}>
+          {this.showLabel && this.size !== "s" && this.internalValue !== 0 && <span class="label">{`${this.internalValue}%`}</span>}
         </div>
       </div>
     );


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Fixed the tagged issue by:
1) Hiding text when value is 0
2) Filling progress by 2% when value is 1 to avoid text overflow.

Related Issue
#1012 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>20.57.2--canary.1121.5ffabe97bbdb767c0fa69c578516c9b80247fb92.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@20.57.2--canary.1121.5ffabe97bbdb767c0fa69c578516c9b80247fb92.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@20.57.2--canary.1121.5ffabe97bbdb767c0fa69c578516c9b80247fb92.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
