### PR TITLE
Tootlip: fix arrow alignment 

### DIFF
--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -148,54 +148,54 @@
 
   // For 'top' placement
   &[data-placement="top"]>.tooltip-arrow-svg {
-    bottom: -8px;
+    bottom: -7px;
     left: 50%;
     transform: rotate(180deg) translateX(-50%);
   }
 
   // For 'top-start' placement
   &[data-placement="top-start"]>.tooltip-arrow-svg {
-    bottom: -8px;
+    bottom: -7px;
     left: 10px; // Adjust as needed
     transform: rotate(180deg)
   }
 
   // For 'top-end' placement
   &[data-placement="top-end"]>.tooltip-arrow-svg {
-    bottom: -8px;
+    bottom: -7px;
     right: 10px; // Adjust as needed
     transform: rotate(180deg);
   }
 
   // For 'bottom' placement
   &[data-placement="bottom"]>.tooltip-arrow-svg {
-    top: -8px;
+    top: -7px;
     left: 50%;
     transform: translateX(-50%);
   }
 
   // For 'bottom-start' placement
   &[data-placement="bottom-start"]>.tooltip-arrow-svg {
-    top: -8px;
+    top: -7px;
     left: 10px; // Adjust as needed
   }
 
   // For 'bottom-end' placement
   &[data-placement="bottom-end"]>.tooltip-arrow-svg {
-    top: -8px;
+    top: -7px;
     right: 10px; // Adjust as needed
   }
 
   // For 'left' placement
   &[data-placement="left"]>.tooltip-arrow-svg {
-    right: -4px;
+    right: -3px;
     top: 50%;
     transform: rotate(90deg) translateY(-50%) translateX(-50%);
   }
 
   // For 'right' placement
   &[data-placement="right"]>.tooltip-arrow-svg {
-    left: -4px;
+    left: -3px;
     top: 50%;
     transform: rotate(270deg) translateY(-50%) translateX(50%);
   }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Fix arrow alignment of tooltip by adjusting css properties.

Related Issue
#1199
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>21.7.4--canary.1200.9c16818a23caa1dcb9672a4c68f2a062d1d56208.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@21.7.4--canary.1200.9c16818a23caa1dcb9672a4c68f2a062d1d56208.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@21.7.4--canary.1200.9c16818a23caa1dcb9672a4c68f2a062d1d56208.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
