### PR TITLE
Navbar: fixed bug affecting the search-bar's isOpen prop on initial load

### DIFF
--- a/packages/components/src/components/navbar/navbar.tsx
+++ b/packages/components/src/components/navbar/navbar.tsx
@@ -110,7 +110,7 @@ export class Navbar {
     }
   }
 
-  hideNavComponents() {
+  getNavComponents() {
     const searchBarRightWrapper = this.el.shadowRoot.querySelector('.navbar__container-right-content-navigation-item-search-bar-icon-wrapper')
     const searchBarLeftWrapper = this.el.shadowRoot.querySelector('.navbar__container-left-content-navigation-item-search-bar')
     const rightSideSlot = searchBarRightWrapper.querySelector('slot');
@@ -121,6 +121,12 @@ export class Navbar {
     const leftMenuItems = this.el.querySelectorAll('[slot="left-item"]');
     const rightMenuItems = this.el.querySelectorAll('[slot="right-item"]');
     const topRowWrapper = this.el.shadowRoot.querySelector('.navbar__sidebar-top-row-wrapper')
+    
+    return {rightSideSlot, leftSideSlot, rightAssignedNodes, leftAssignedNodes, navbarProfile, leftMenuItems, rightMenuItems, topRowWrapper};
+  }
+
+  hideNavComponents() {
+    const { rightAssignedNodes, leftAssignedNodes, navbarProfile, leftMenuItems, rightMenuItems, topRowWrapper } = this.getNavComponents();
     
     if(rightAssignedNodes.length !== 0) { 
       this.searchBarIsOpen = 'right'
@@ -147,10 +153,7 @@ export class Navbar {
   }
 
   showNavComponents() {
-    const navbarProfile = this.el.querySelector('ifx-navbar-profile');
-    const leftMenuItems = this.el.querySelectorAll('[slot="left-item"]');
-    const rightMenuItems = this.el.querySelectorAll('[slot="right-item"]');
-    const topRowWrapper = this.el.shadowRoot.querySelector('.navbar__sidebar-top-row-wrapper')
+    const { navbarProfile, leftMenuItems, rightMenuItems, topRowWrapper } = this.getNavComponents();
     this.searchBarIsOpen = undefined;
     
     navbarProfile.showComponent()
@@ -266,7 +269,6 @@ export class Navbar {
 
   componentDidLoad() {
     this.setItemMenuPosition()
-    this.adjustSearchBarWidth();
     this.addEventListenersToHandleCustomFocusState();
   }
 
@@ -292,18 +294,6 @@ export class Navbar {
       this.internalLogoHrefTarget = this.logoHrefTarget;
     }else{
       this.internalLogoHrefTarget = '_self';
-    }
-  }
-
-  getSearchBar(){
-    const searchBar = this.el.querySelector('ifx-search-bar');
-    return searchBar;
-  }
-
-  adjustSearchBarWidth() {
-    const searchBar = this.getSearchBar();
-    if(searchBar.isOpen) {
-      this.hideNavComponents();
     }
   }
 

--- a/packages/components/src/components/navbar/navbar.tsx
+++ b/packages/components/src/components/navbar/navbar.tsx
@@ -109,65 +109,77 @@ export class Navbar {
       }
     }
   }
-  
 
-  @Listen('ifxSearchBarIsOpen')
-  handleSearchBarToggle(event: CustomEvent) {
+  hideNavComponents() {
     const searchBarRightWrapper = this.el.shadowRoot.querySelector('.navbar__container-right-content-navigation-item-search-bar-icon-wrapper')
     const searchBarLeftWrapper = this.el.shadowRoot.querySelector('.navbar__container-left-content-navigation-item-search-bar')
     const rightSideSlot = searchBarRightWrapper.querySelector('slot');
     const leftSideSlot = searchBarLeftWrapper.querySelector('slot');
     const rightAssignedNodes = rightSideSlot.assignedNodes();
     const leftAssignedNodes = leftSideSlot.assignedNodes();
-    const navbarProfile = this.el.querySelector('ifx-navbar-profile')
-    const leftMenuItems = this.el.querySelectorAll('[slot="left-item"]')
-    const rightMenuItems = this.el.querySelectorAll('[slot="right-item"]')
+    const navbarProfile = this.el.querySelector('ifx-navbar-profile');
+    const leftMenuItems = this.el.querySelectorAll('[slot="left-item"]');
+    const rightMenuItems = this.el.querySelectorAll('[slot="right-item"]');
     const topRowWrapper = this.el.shadowRoot.querySelector('.navbar__sidebar-top-row-wrapper')
-   
-    if(event.detail) { 
-      if(rightAssignedNodes.length !== 0) { 
-        this.searchBarIsOpen = 'right'
-      } else if(leftAssignedNodes.length !== 0) {
-        this.searchBarIsOpen = 'left'
+    
+    if(rightAssignedNodes.length !== 0) { 
+      this.searchBarIsOpen = 'right'
+    } else if(leftAssignedNodes.length !== 0) {
+      this.searchBarIsOpen = 'left'
+    }
+    navbarProfile.hideComponent()
+    
+    for(let l = 0; l < leftMenuItems.length; l++) { 
+      if(!topRowWrapper.classList.contains('expand')) {
+        leftMenuItems[l].hideComponent()
       }
-      
-      navbarProfile.hideComponent()
-
-      for(let l = 0; l < leftMenuItems.length; l++) { 
-        if(!topRowWrapper.classList.contains('expand')) {
-          leftMenuItems[l].hideComponent()
-        }
-      }
-
-      for(let r = 0; r < rightMenuItems.length; r++) { 
-        if(topRowWrapper.classList.contains('expand')) {
-          if(!rightMenuItems[r].hideOnMobile) { 
-            rightMenuItems[r].hideComponent()
-          }
-        } else { 
+    }
+  
+    for(let r = 0; r < rightMenuItems.length; r++) { 
+      if(topRowWrapper.classList.contains('expand')) {
+        if(!rightMenuItems[r].hideOnMobile) { 
           rightMenuItems[r].hideComponent()
         }
+      } else { 
+        rightMenuItems[r].hideComponent()
       }
+    }
+  }
 
-    } else if(!event.detail) {
-      this.searchBarIsOpen = undefined;
-      navbarProfile.showComponent()
-
-      for(let l = 0; l < leftMenuItems.length; l++) { 
-        if(!topRowWrapper.classList.contains('expand')) {
-          leftMenuItems[l].showComponent()
-        }
+  showNavComponents() {
+    const navbarProfile = this.el.querySelector('ifx-navbar-profile');
+    const leftMenuItems = this.el.querySelectorAll('[slot="left-item"]');
+    const rightMenuItems = this.el.querySelectorAll('[slot="right-item"]');
+    const topRowWrapper = this.el.shadowRoot.querySelector('.navbar__sidebar-top-row-wrapper')
+    this.searchBarIsOpen = undefined;
+    
+    navbarProfile.showComponent()
+    
+    for(let l = 0; l < leftMenuItems.length; l++) { 
+      if(!topRowWrapper.classList.contains('expand')) {
+        leftMenuItems[l].showComponent()
       }
-
-      for(let r = 0; r < rightMenuItems.length; r++) { 
-        if(topRowWrapper.classList.contains('expand')) {
-          if(!rightMenuItems[r].hideOnMobile) { 
-            rightMenuItems[r].showComponent()
-          }
-        } else { 
+    }
+  
+    for(let r = 0; r < rightMenuItems.length; r++) { 
+      if(topRowWrapper.classList.contains('expand')) {
+        if(!rightMenuItems[r].hideOnMobile) { 
           rightMenuItems[r].showComponent()
         }
+      } else { 
+        rightMenuItems[r].showComponent()
       }
+    }
+  }
+  
+  
+  @Listen('ifxSearchBarIsOpen')
+  handleSearchBarToggle(event: CustomEvent) {
+   
+    if(event.detail) { 
+      this.hideNavComponents();
+    } else if(!event.detail) {
+      this.showNavComponents();
     }
   }
 
@@ -254,6 +266,7 @@ export class Navbar {
 
   componentDidLoad() {
     this.setItemMenuPosition()
+    this.adjustSearchBarWidth();
     this.addEventListenersToHandleCustomFocusState();
   }
 
@@ -282,6 +295,18 @@ export class Navbar {
     }
   }
 
+  getSearchBar(){
+    const searchBar = this.el.querySelector('ifx-search-bar');
+    return searchBar;
+  }
+
+  adjustSearchBarWidth() {
+    const searchBar = this.getSearchBar();
+    if(searchBar.isOpen) {
+      this.hideNavComponents();
+    }
+  }
+
   componentWillLoad() {
     this.RemoveSpaceOnStorybookSnippet()
     const dropdownMenu = this.el.querySelector('ifx-navbar-menu')
@@ -291,6 +316,7 @@ export class Navbar {
     }
     this.handleLogoHrefAndTarget();
 
+    
     const mediaQueryList = window.matchMedia('(max-width: 800px)');
     mediaQueryList.addEventListener('change', (e) => this.moveNavItemsToSidebar(e));
   }
@@ -299,19 +325,19 @@ export class Navbar {
     const searchBarLeftWrapper = this.el.shadowRoot.querySelector('.navbar__container-left-content-navigation-item-search-bar')
     return searchBarLeftWrapper;
   }
-
+  
   moveNavItemsToSidebar(e) {
     const topRowWrapper = this.el.shadowRoot.querySelector('.navbar__sidebar-top-row-wrapper')
     if (e.matches) {
       /* The viewport is 800px wide or less */
       topRowWrapper.classList.add('expand')
-
+      
       //hide body scroll if sidebar was opened
       const crossIcon = this.el.shadowRoot.querySelector('.navbar__cross-icon')
       if(crossIcon.classList.contains('show')) { 
         this.handleBodyScroll('hide')
       }
-
+      
       //move search bar to right-side
       const searchBarLeft = this.el.querySelector('[slot="search-bar-left"]')
       if(searchBarLeft) { 
@@ -341,9 +367,9 @@ export class Navbar {
         } else { 
           if(rightMenuItems[i].hideOnMobile) { 
             rightMenuItems[i].setAttribute('slot', 'mobile-menu-bottom')
-  
+            
             rightMenuItems[i].toggleChildren('add')
-
+            
             rightMenuItems[i].showLabel = true;
             if(this.searchBarIsOpen) { 
               rightMenuItems[i].showComponent()
@@ -387,15 +413,15 @@ export class Navbar {
         rightMenuItems[i].setAttribute('slot', 'right-item')
 
           rightMenuItems[i].toggleChildren('remove')
-
+          
           const showLabel = rightMenuItems[i].getAttribute('show-label');
           rightMenuItems[i].setAttribute('show-label', showLabel)
           if(this.searchBarIsOpen) { 
             rightMenuItems[i].hideComponent()
           }
+        }
       }
     }
-  }
 
   RemoveSpaceOnStorybookSnippet() { 
     let parent = this.el.parentElement;
@@ -406,6 +432,7 @@ export class Navbar {
       }
     }
   }
+  
 
   render() {
     return (

--- a/packages/components/src/components/search-bar/search-bar.tsx
+++ b/packages/components/src/components/search-bar/search-bar.tsx
@@ -36,6 +36,7 @@ export class SearchBar {
 
   componentWillLoad() {
     this.setInitialState();
+    this.ifxSearchBarIsOpen.emit(this.internalState)
   }
 
   handleInput(event: CustomEvent) {


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Created a new ```getNavComponents()``` function, which returns an object containing the siblings of the search-bar. 
Using this function and de-structuring, {rightSideSlot, leftSideSlot, rightAssignedNodes, leftAssignedNodes, navbarProfile, leftMenuItems, rightMenuItems, topRowWrapper} - constants can be extracted. This reduces code repetition.

And using event emission of ```internalState``` in search-bar component, to prevent changing state when component is loaded.

Related Issue
#1227
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>21.9.1--canary.1236.3ce35e16b7e34b687f6448e294b667380db13343.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@21.9.1--canary.1236.3ce35e16b7e34b687f6448e294b667380db13343.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@21.9.1--canary.1236.3ce35e16b7e34b687f6448e294b667380db13343.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
