### PR TITLE
Stepper: add e2e test file 

### DIFF
--- a/packages/components/src/components/stepper/stepper.e2e.ts
+++ b/packages/components/src/components/stepper/stepper.e2e.ts
@@ -1,0 +1,46 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ifx-stepper', () => {
+    let page;
+    let element;
+
+    beforeEach(async () => {
+        page = await newE2EPage();
+        await page.setContent(`<ifx-stepper>
+            <ifx-step>Step 1<ifx-step>
+            <ifx-step>Step 2<ifx-step>
+        </ifx-stepper>`);
+        element = await page.find('ifx-stepper');
+    });
+
+    it('should render', () => {
+        expect(element).toHaveClass('hydrated');
+    });
+
+    it('should have default active step set to 1', async () => {
+        const firstStep = await page.find('ifx-stepper > ifx-step >>> .active-indic')
+        expect(firstStep).toBeTruthy();
+    }) 
+
+    it('should change the active step', async () => {
+        element.setProperty('activeStep', 2);
+        await page.waitForChanges();
+        const secondStep = element.childNodes[1].getElementsByClassName('active-indic')
+        expect(secondStep).toBeTruthy();
+    }) 
+
+    it('should display step number when showNumber is set', async () => {
+        element.setProperty('showNumber', true);
+        await page.waitForChanges();
+        const firstStep = await page.find('ifx-stepper > ifx-step >>> .step-icon')
+        expect(firstStep.innerText).toEqual('1');
+    });
+    
+    it('compact variant', async () => {
+        element.setProperty('variant', 'compact');
+        await page.waitForChanges();
+        const compact = await page.find('ifx-stepper >>> .compact');
+        expect(compact).toBeTruthy();
+    })
+
+})


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Added e2e tests for ifx-stepper components.

Related Issue
#1190 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>21.9.0--canary.1250.c9a720ee7200ecc432aa6b03dbe7cf51897df51e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@21.9.0--canary.1250.c9a720ee7200ecc432aa6b03dbe7cf51897df51e.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@21.9.0--canary.1250.c9a720ee7200ecc432aa6b03dbe7cf51897df51e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
