### PR TITLE
Pagination: page number centered + padding increased

### DIFF
--- a/packages/components/src/components/pagination/pagination.scss
+++ b/packages/components/src/components/pagination/pagination.scss
@@ -136,6 +136,8 @@ ol {
 }
 
 li {
+  width: 32px;
+  height: 32px;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -143,14 +145,12 @@ li {
   border-radius: 100px;
 
   &:hover:not(.active) {
-    & a {
-      background-color: #EEEDED;
-    }
+    background-color: #EEEDED;
   }
 
   &:active:not(.active) {
+    background-color: #575352;
     & a {
-      background-color: #575352;
       color: #fff;
     }
   }
@@ -170,8 +170,6 @@ li {
   & a {
     text-decoration: none;
     display: flex;
-    width: 16px;
-    height: 16px;
     flex-direction: column;
     justify-content: center;
     color: #1D1D1D;

--- a/packages/components/src/components/pagination/pagination.scss
+++ b/packages/components/src/components/pagination/pagination.scss
@@ -122,6 +122,7 @@
 }
 
 a {
+  padding: 6px;
   border-radius: 100px;
 }
 
@@ -169,8 +170,8 @@ li {
   & a {
     text-decoration: none;
     display: flex;
-    width: 32px;
-    height: 32px;
+    width: 16px;
+    height: 16px;
     flex-direction: column;
     justify-content: center;
     color: #1D1D1D;

--- a/packages/components/src/components/pagination/pagination.scss
+++ b/packages/components/src/components/pagination/pagination.scss
@@ -122,7 +122,6 @@
 }
 
 a {
-  padding: 6px;
   border-radius: 100px;
 }
 
@@ -136,8 +135,6 @@ ol {
 }
 
 li {
-  width: 32px;
-  height: 32px;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -145,12 +142,14 @@ li {
   border-radius: 100px;
 
   &:hover:not(.active) {
-    background-color: #EEEDED;
+    & a {
+      background-color: #EEEDED;
+    }
   }
 
   &:active:not(.active) {
-    background-color: #575352;
     & a {
+      background-color: #575352;
       color: #fff;
     }
   }
@@ -170,6 +169,8 @@ li {
   & a {
     text-decoration: none;
     display: flex;
+    width: 32px;
+    height: 32px;
     flex-direction: column;
     justify-content: center;
     color: #1D1D1D;
@@ -178,6 +179,7 @@ li {
     font-style: normal;
     font-weight: 400;
     line-height: 20px;
+    align-items: center;
   }
 }
 

--- a/packages/components/src/components/pagination/pagination.scss
+++ b/packages/components/src/components/pagination/pagination.scss
@@ -122,7 +122,7 @@
 }
 
 a {
-  padding: 6px;
+  padding: 8px;
   border-radius: 100px;
 }
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Updated css of pagination to center a page in number in li tag.

Related Issue
#1231

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>21.10.2--canary.1252.1808667703f508e37e81fa2a14f6db9153c4db81.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@21.10.2--canary.1252.1808667703f508e37e81fa2a14f6db9153c4db81.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@21.10.2--canary.1252.1808667703f508e37e81fa2a14f6db9153c4db81.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
