### PR TITLE
Navbar: mobile functionality added on initial mobile version

### DIFF
--- a/examples/wrapper-components/react-javascript/src/components/MultiSelect/MultiSelect.js
+++ b/examples/wrapper-components/react-javascript/src/components/MultiSelect/MultiSelect.js
@@ -158,7 +158,6 @@ function App() {
     console.log('ifxSelect event emitted with value:', e.detail);
   }
 
-
   return (
     <div>
       <IfxMultiselect options={options} batchSize={20}

--- a/packages/components/src/components/navbar/navbar.tsx
+++ b/packages/components/src/components/navbar/navbar.tsx
@@ -110,7 +110,7 @@ export class Navbar {
     }
   }
 
-  getNavComponents() {
+  getWrappers() {
     const searchBarRightWrapper = this.el.shadowRoot.querySelector('.navbar__container-right-content-navigation-item-search-bar-icon-wrapper')
     const searchBarLeftWrapper = this.el.shadowRoot.querySelector('.navbar__container-left-content-navigation-item-search-bar')
     const rightSideSlot = searchBarRightWrapper.querySelector('slot');
@@ -125,8 +125,8 @@ export class Navbar {
     return {rightSideSlot, leftSideSlot, rightAssignedNodes, leftAssignedNodes, navbarProfile, leftMenuItems, rightMenuItems, topRowWrapper};
   }
 
-  hideNavComponents() {
-    const { rightAssignedNodes, leftAssignedNodes, navbarProfile, leftMenuItems, rightMenuItems, topRowWrapper } = this.getNavComponents();
+  hideNavItems() {
+    const { rightAssignedNodes, leftAssignedNodes, navbarProfile, leftMenuItems, rightMenuItems, topRowWrapper } = this.getWrappers();
     
     if(rightAssignedNodes.length !== 0) { 
       this.searchBarIsOpen = 'right'
@@ -152,8 +152,8 @@ export class Navbar {
     }
   }
 
-  showNavComponents() {
-    const { navbarProfile, leftMenuItems, rightMenuItems, topRowWrapper } = this.getNavComponents();
+  showNavItems() {
+    const { navbarProfile, leftMenuItems, rightMenuItems, topRowWrapper } = this.getWrappers();
     this.searchBarIsOpen = undefined;
     
     navbarProfile.showComponent()
@@ -180,9 +180,9 @@ export class Navbar {
   handleSearchBarToggle(event: CustomEvent) {
    
     if(event.detail) { 
-      this.hideNavComponents();
+      this.hideNavItems();
     } else if(!event.detail) {
-      this.showNavComponents();
+      this.showNavItems();
     }
   }
 
@@ -318,7 +318,6 @@ export class Navbar {
     }
     this.handleLogoHrefAndTarget();
 
-    
     const mediaQueryList = window.matchMedia('(max-width: 800px)');
     mediaQueryList.addEventListener('change', (e) => this.moveNavItemsToSidebar(e));
   }
@@ -329,7 +328,7 @@ export class Navbar {
     return searchBarLeftWrapper;
   }
   
-  moveNavItemsToSidebar(e) {
+  moveNavItemsToSidebar(e?: MediaQueryListEvent) {
     const topRowWrapper = this.el.shadowRoot.querySelector('.navbar__sidebar-top-row-wrapper')
     const mediaQueryList = this.getMediaQueryList();
     const matches = e ? e.matches : mediaQueryList.matches;
@@ -438,8 +437,9 @@ export class Navbar {
       }
     }
   }
-  
 
+
+  
   render() {
     return (
       <div aria-label='a navigation navbar' class={`navbar__wrapper ${this.fixed ? 'fixed' : ""}`}>

--- a/packages/components/src/components/navbar/navbar.tsx
+++ b/packages/components/src/components/navbar/navbar.tsx
@@ -252,9 +252,20 @@ export class Navbar {
     }
   }
 
+  getMediaQueryList() { 
+    const mediaQueryList = window.matchMedia('(max-width: 800px)');
+    return mediaQueryList;
+  }
+
   componentDidLoad() {
     this.setItemMenuPosition()
     this.addEventListenersToHandleCustomFocusState();
+
+    const mediaQueryList = this.getMediaQueryList()
+
+    if (mediaQueryList.matches) {
+      this.moveNavItemsToSidebar();
+    }
   }
 
   handleMobileMenuBottom(e) { 
@@ -282,6 +293,7 @@ export class Navbar {
     }
   }
 
+ 
   componentWillLoad() {
     this.RemoveSpaceOnStorybookSnippet()
     const dropdownMenu = this.el.querySelector('ifx-navbar-menu')
@@ -290,22 +302,25 @@ export class Navbar {
       this.hasLeftMenuItems = false;
     }
     this.handleLogoHrefAndTarget();
-
-    const mediaQueryList = window.matchMedia('(max-width: 800px)');
+  
+    const mediaQueryList = this.getMediaQueryList();
     mediaQueryList.addEventListener('change', (e) => this.moveNavItemsToSidebar(e));
   }
+  
 
   getSearchBarLeftWrapper() { 
     const searchBarLeftWrapper = this.el.shadowRoot.querySelector('.navbar__container-left-content-navigation-item-search-bar')
     return searchBarLeftWrapper;
   }
 
-  moveNavItemsToSidebar(e) {
+  moveNavItemsToSidebar(e?: MediaQueryListEvent) {
     const topRowWrapper = this.el.shadowRoot.querySelector('.navbar__sidebar-top-row-wrapper')
-    if (e.matches) {
+    const mediaQueryList = this.getMediaQueryList();
+    const matches = e ? e.matches : mediaQueryList.matches;
+  
+    if (matches) {
       /* The viewport is 800px wide or less */
       topRowWrapper.classList.add('expand')
-
       //hide body scroll if sidebar was opened
       const crossIcon = this.el.shadowRoot.querySelector('.navbar__cross-icon')
       if(crossIcon.classList.contains('show')) { 

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -11,6 +11,11 @@
 
   <style defer>
 
+    body { 
+      padding: 0;
+      margin: 0;
+    }
+
   </style>
 
   <script defer>
@@ -20,6 +25,68 @@
 </head>
 
 <body>
+
+  <ifx-navbar  show-logo-and-appname="true" application-name="Application name" fixed="undefined" logo-href="http://google.com" logo-href-target="_self">
+    <ifx-navbar-item icon="calendar16" slot="left-item" target="" href="" >
+      Menu Item 1
+      <ifx-navbar-item icon="calendar16">
+        Layer 1 Nested Item 1
+        <ifx-navbar-item>
+          Layer 2 Nested Item 2
+          <ifx-navbar-item href="http://google.com" target="_blank">Link Layer 3 Nested Item 1</ifx-navbar-item>
+          <ifx-navbar-item>Layer 3 Nested Item 2</ifx-navbar-item>
+          <ifx-navbar-item>Layer 3 Nested Item 3</ifx-navbar-item>
+          <ifx-navbar-item>Layer 3 Nested Item 4</ifx-navbar-item>
+        </ifx-navbar-item>
+        <ifx-navbar-item >Layer 2 Nested Item 3</ifx-navbar-item>
+        <ifx-navbar-item>Layer 2 Nested Item 4</ifx-navbar-item>
+        <ifx-navbar-item>Layer 2 Nested Item 5</ifx-navbar-item>
+      </ifx-navbar-item>
+  
+      <ifx-navbar-item>
+        Layer 1 Nested Item 2
+        <ifx-navbar-item>Layer 2 Item 1</ifx-navbar-item>
+        <ifx-navbar-item>Layer 2 Item 2</ifx-navbar-item>
+        <ifx-navbar-item>Layer 2 Item 3</ifx-navbar-item>
+      </ifx-navbar-item>
+  
+      <ifx-navbar-item>Nested Item 3</ifx-navbar-item>
+  
+      <ifx-navbar-item>
+        Layer 1 Nested Item 4
+        <ifx-navbar-item>Nested Item 4</ifx-navbar-item>
+      </ifx-navbar-item>
+  
+    </ifx-navbar-item>
+  
+    <ifx-navbar-item href="" target="_blank" slot="left-item" icon="calendar16" show-label="false">
+      Menu Item 2
+    </ifx-navbar-item>
+  
+    <ifx-navbar-item slot="left-item">
+      More
+      <ifx-navbar-item>Item1</ifx-navbar-item>
+      <ifx-navbar-item>Item2</ifx-navbar-item>
+    </ifx-navbar-item>
+  
+    <ifx-search-bar slot="search-bar-left" is-open="false"></ifx-search-bar>
+  
+    <ifx-navbar-item slot="right-item" target="_blank" href="http://google.com" hide-on-mobile="true" show-label="false" icon="cartf16">
+      Right Item
+    </ifx-navbar-item>
+    <ifx-navbar-item slot="right-item" hide-on-mobile="true" show-label='true' icon="airplane16">
+      Right Item
+      <ifx-navbar-item>Right Item</ifx-navbar-item>
+    </ifx-navbar-item>
+  
+    <ifx-navbar-profile slot="right-item" image-url="" show-label="true" href="" target="_blank">
+      User
+      <ifx-navbar-item>Item</ifx-navbar-item>
+      <ifx-navbar-item>Item</ifx-navbar-item>
+      <ifx-navbar-item>Item</ifx-navbar-item>
+      <ifx-navbar-item>Item</ifx-navbar-item>
+    </ifx-navbar-profile>
+  </ifx-navbar>
 
 </body>
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

The mobile responsiveness and its associated functionality was not working when the initial load is on a mobile resolution. 
I added a condition during load time that checks if the screen resolution is mobile, and if yes, I invoke the callBack function that is attached to the window event listener, which triggers the associated mobile functionality. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>21.9.2--canary.1253.4a57c2174f86428a5786d9fb11b4d8a1a60235d9.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@21.9.2--canary.1253.4a57c2174f86428a5786d9fb11b4d8a1a60235d9.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@21.9.2--canary.1253.4a57c2174f86428a5786d9fb11b4d8a1a60235d9.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
