### PR TITLE
Date-picker: changed width to 100% and added height options s and l

### DIFF
--- a/packages/components/src/components/date-picker/date-picker.scss
+++ b/packages/components/src/components/date-picker/date-picker.scss
@@ -1,8 +1,7 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 
   :host { 
-    display: inline-block;
-    width: 100%;
+    display: block;
   }
 
   .date__picker-input { 

--- a/packages/components/src/components/date-picker/date-picker.scss
+++ b/packages/components/src/components/date-picker/date-picker.scss
@@ -2,6 +2,7 @@
 
   :host { 
     display: inline-block;
+    width: 100%;
   }
 
   .date__picker-input { 
@@ -11,6 +12,8 @@
     cursor: pointer;
     border-radius: 1px;
     border: 1px solid tokens.$ifxColorEngineering400;
+    height: 100%;
+    
 
     &.firefox__classes { 
       padding: 8px 16px;
@@ -86,13 +89,12 @@
     align-self: stretch;
     background: tokens.$ifxColorBaseWhite;
     position: relative;
-
-    &.large { 
-      width: 400px;
+    &.large {
+      height: 40px;
     }
-
-    &.small { 
-      width: 173px;
+  
+    &.small {
+      height: 36px;
     }
 
     &.disabled { 

--- a/packages/components/src/components/date-picker/date-picker.stories.ts
+++ b/packages/components/src/components/date-picker/date-picker.stories.ts
@@ -12,7 +12,7 @@ export default {
   },
   argTypes: {
     size: {
-      description: 'Size options: small (173px) and large (400px) - default: small',
+      description: 'Size options: Height small  (36px) and Height large (40px) - default: small',
       options: ['s', 'l'],
       control: { type: 'radio' },
     },


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Width of the date-picker is now 100%.
Size prop takes value 's' and 'l' to adjust height of the date-picker to 36px and 40px respectively.

Related Issue
#1230 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>21.9.3--canary.1279.5819d691cb5a3746040b3bf0628cf91e9706b01b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@21.9.3--canary.1279.5819d691cb5a3746040b3bf0628cf91e9706b01b.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@21.9.3--canary.1279.5819d691cb5a3746040b3bf0628cf91e9706b01b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
