### PR TITLE
Search-field: implement ```placeholder``` prop to customize placeholder text

### DIFF
--- a/packages/components/src/components/search-field/readme.md
+++ b/packages/components/src/components/search-field/readme.md
@@ -7,12 +7,13 @@
 
 ## Properties
 
-| Property         | Attribute          | Description | Type      | Default |
-| ---------------- | ------------------ | ----------- | --------- | ------- |
-| `disabled`       | `disabled`         |             | `boolean` | `false` |
-| `showDeleteIcon` | `show-delete-icon` |             | `boolean` | `false` |
-| `size`           | `size`             |             | `string`  | `'l'`   |
-| `value`          | `value`            |             | `string`  | `''`    |
+| Property         | Attribute          | Description | Type      | Default       |
+| ---------------- | ------------------ | ----------- | --------- | ------------- |
+| `disabled`       | `disabled`         |             | `boolean` | `false`       |
+| `placeholder`    | `placeholder`      |             | `string`  | `"Search..."` |
+| `showDeleteIcon` | `show-delete-icon` |             | `boolean` | `false`       |
+| `size`           | `size`             |             | `string`  | `'l'`         |
+| `value`          | `value`            |             | `string`  | `''`          |
 
 
 ## Events

--- a/packages/components/src/components/search-field/search-field.stories.ts
+++ b/packages/components/src/components/search-field/search-field.stories.ts
@@ -15,6 +15,10 @@ export default {
       options: ['s', 'm'],
       control: { type: 'radio' },
     },
+    placeholder: {
+      description: 'Place holder text - default value: "Search..."',
+      control: { type: 'text'}
+    },
     ifxInput: {
       action: 'ifxInput',
       description: 'Custom event',
@@ -29,11 +33,12 @@ export default {
   },
 };
 
-const DefaultTemplate = ({ disabled, size, showDeleteIcon }) => {
+const DefaultTemplate = ({ disabled, size, showDeleteIcon, placeholder }) => {
   const element = document.createElement('ifx-search-field');
   element.setAttribute('size', size);
   element.setAttribute('disabled', disabled);
   element.setAttribute('show-delete-icon', showDeleteIcon);
+  if(placeholder != undefined) element.setAttribute('placeholder', placeholder);
   element.addEventListener('ifxInput', action('ifxInput'));
 
   return element;

--- a/packages/components/src/components/search-field/search-field.tsx
+++ b/packages/components/src/components/search-field/search-field.tsx
@@ -21,6 +21,7 @@ export class SearchField {
   @Prop() disabled: boolean = false;
   @Prop() size: string = 'l';
   @State() isFocused: boolean = false;
+  @Prop() placeholder: string = "Search...";
 
   @Listen('mousedown', { target: 'document' })
   handleOutsideClick(event: MouseEvent) {
@@ -75,7 +76,7 @@ export class SearchField {
             ref={(el) => (this.inputElement = el)}
             type="text"
             onInput={() => this.handleInput()}
-            placeholder="Search..."
+            placeholder={this.placeholder}
             disabled={this.disabled}
             value={this.value} // bind the value property to input element
           />


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Implemented placeholder prop which allows customizing the placeholder text of search-field component. The default value of the prop is "Search...".

Related Issue
#1288 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>21.12.0--canary.1292.5569397a7466563f1ecc2487990e8d651e2fb9f4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@21.12.0--canary.1292.5569397a7466563f1ecc2487990e8d651e2fb9f4.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@21.12.0--canary.1292.5569397a7466563f1ecc2487990e8d651e2fb9f4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
