### PR TITLE
Navbar: restored old changes regarding profile image hover and username

### DIFF
--- a/examples/wrapper-components/react-javascript/src/components/Navbar/Navbar.js
+++ b/examples/wrapper-components/react-javascript/src/components/Navbar/Navbar.js
@@ -63,12 +63,7 @@ function Navbar() {
       </IfxNavbarItem>
     </IfxNavbarItem>
 
-    <IfxNavbarProfile slot="right-item" user-name='Tihomir Yanchev' image-url='' show-label="true" href="" target="_blank">
-      User
-      <IfxNavbarItem>Item</IfxNavbarItem>
-      <IfxNavbarItem>Item</IfxNavbarItem>
-      <IfxNavbarItem>Item</IfxNavbarItem>
-      <IfxNavbarItem>Item</IfxNavbarItem>
+    <IfxNavbarProfile slot="right-item" user-name='' image-url='' show-label="true" href="" target="_blank">
     </IfxNavbarProfile>
   </IfxNavbar>
   );

--- a/packages/components/src/components/navigation/navbar/Development.mdx
+++ b/packages/components/src/components/navigation/navbar/Development.mdx
@@ -1,4 +1,11 @@
-import { Meta, Primary, Controls, Story } from '@storybook/blocks'; 
+import { Meta, Primary, Controls, Story } from '@storybook/blocks';
 import * as NavbarStories from './navbar.stories';
 
-# Navbar v-2
+ <Meta of={NavbarStories} />
+# Navbar
+
+<Primary />
+
+## Props
+
+<Controls />

--- a/packages/components/src/components/navigation/navbar/Development.mdx
+++ b/packages/components/src/components/navigation/navbar/Development.mdx
@@ -1,0 +1,4 @@
+import { Meta, Primary, Controls, Story } from '@storybook/blocks'; 
+import * as NavbarStories from './navbar.stories';
+
+# Navbar v-2

--- a/packages/components/src/components/navigation/navbar/navbar-item.scss
+++ b/packages/components/src/components/navigation/navbar/navbar-item.scss
@@ -53,8 +53,11 @@
     color: tokens.$ifxColorOcean500;
     cursor: pointer;
 
+    & .username__tooltip { 
+      display: block;
+    }
+
     & .navbar__container-right-content-navigation-item-icon-wrapper { 
-      
       & .initials__wrapper { 
         cursor: pointer;
         background-color: tokens.$ifxColorOcean600;

--- a/packages/components/src/components/navigation/navbar/navbar.stories.ts
+++ b/packages/components/src/components/navigation/navbar/navbar.stories.ts
@@ -4,7 +4,7 @@ export default {
   title: 'Components/Navigation/Navbar',
   args: {
     applicationName: 'Application name',
-    hideLabel: false,
+    hideLabel: true,
     navbarItemTarget: '_blank',
     navbarItemHref: '',
     searchBarIsOpen: false,
@@ -15,6 +15,8 @@ export default {
     searchBarPosition: 'left',
     hideOnMobile: true,
     profileImageUrl: "",
+    userName: "",
+    profileLabel: ""
   },
   argTypes: {
     icon: {
@@ -36,8 +38,8 @@ export default {
 const DefaultTemplate = args =>
   `<ifx-navbar  show-logo-and-appname="${args.showLogoAndAppname}" application-name="${args.applicationName}" fixed="${args.fixed}" logo-href="${args.logoHref}" logo-href-target="${args.logoHrefTarget}">
   <ifx-navbar-item icon="${args.icon}" slot="left-item" target="" href="" >
-    Menu Item 1
-    <ifx-navbar-item icon="image-16">
+    Menu Item
+    <ifx-navbar-item icon="">
       Layer 1 Nested Item 1
       <ifx-navbar-item>
         Layer 2 Nested Item 2
@@ -67,8 +69,8 @@ const DefaultTemplate = args =>
 
   </ifx-navbar-item>
 
-  <ifx-navbar-item href="${args.navbarItemHref}" target="${args.navbarItemTarget}" slot="left-item" icon="image-16" show-label="${args.hideLabel}">
-    Menu Item 2
+  <ifx-navbar-item href="${args.navbarItemHref}" target="${args.navbarItemTarget}" slot="left-item" icon="" show-label="${args.hideLabel}">
+    Menu Item
   </ifx-navbar-item>
 
   <ifx-navbar-item slot="left-item">
@@ -80,14 +82,11 @@ const DefaultTemplate = args =>
   <ifx-search-bar slot="search-bar-${args.searchBarPosition}" is-open="${args.searchBarIsOpen}"></ifx-search-bar>
 
   <ifx-navbar-item slot="right-item" target="_blank" href="http://google.com" hide-on-mobile="${args.hideOnMobile}" show-label="true" icon="image-16">
-    Right Item
   </ifx-navbar-item>
-  <ifx-navbar-item slot="right-item" hide-on-mobile="true" show-label='true' icon="image-16">
-    Right Item
-    <ifx-navbar-item>Right Item</ifx-navbar-item>
+  <ifx-navbar-item slot="right-item" hide-on-mobile="true" show-label='false' icon="image-16">
   </ifx-navbar-item>
 
-  <ifx-navbar-profile user-name="${args.userName}" slot="right-item" image-url="${args.profileImageUrl}" show-label="true" href="" target="_blank"></ifx-navbar-profile>
+  <ifx-navbar-profile user-name="${args.userName}" slot="right-item" image-url="${args.profileImageUrl}" show-label="true" href="" target="_blank">${args.profileLabel}</ifx-navbar-profile>
 </ifx-navbar>`;
 
 export const Default = DefaultTemplate.bind({});


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

On hover over profile image, user name shows up as a hint, and on hover over the initials, background-color changes.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>23.2.1--canary.1356.9a42999413fd2f3f978757b53e02be6aa035e428.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@23.2.1--canary.1356.9a42999413fd2f3f978757b53e02be6aa035e428.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@23.2.1--canary.1356.9a42999413fd2f3f978757b53e02be6aa035e428.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
