### PR TITLE
Icon component: removed error message when no icon specified

### DIFF
--- a/packages/components/src/components/icon/infineonIconStencil.tsx
+++ b/packages/components/src/components/icon/infineonIconStencil.tsx
@@ -57,10 +57,12 @@ export class InfineonIconStencil {
       const SVG = this.getSVG(svgPath)
       this.consoleError.emit(false)
       return SVG;
-    } else {
+    } else if(this.icon !== "") {
       console.error('Icon not found!')
       this.consoleError.emit(true)
-      return ""
+      return;
+    }  else { 
+      return;
     }
   }
 

--- a/packages/components/src/components/navigation/navbar/navbar-item.scss
+++ b/packages/components/src/components/navigation/navbar/navbar-item.scss
@@ -16,20 +16,6 @@
   font-size: 16px;
   color: tokens.$ifxColorBaseBlack;
 
-  & .username__tooltip { 
-    display: none;
-    position: absolute;
-    top: 35px;
-    right: 0;
-    text-wrap: nowrap;
-    padding: 1px 5px;
-    font-size: 13px;
-    font-family: "Source Sans 3";
-    background-color: black;
-    color: #fff;
-    z-index: 99;
-  }
-
   &.hide { 
     display: none;
   }
@@ -76,6 +62,7 @@
   }
 
   & .navbar__container-right-content-navigation-item-icon-wrapper {
+    position: relative;
     display: flex;
     flex-direction: row;
     justify-content: center;
@@ -85,6 +72,26 @@
     flex: none;
     order: 0;
     flex-grow: 0;
+
+    & .username__tooltip { 
+      display: none;
+      position: absolute;
+      top: 35px;
+      right: 0;
+      text-wrap: nowrap;
+      padding: 1px 5px;
+      font-size: 13px;
+      font-family: "Source Sans 3";
+      background-color: black;
+      color: #fff;
+      z-index: 99;
+    }
+
+    &:hover { 
+      & .username__tooltip { 
+        display: block;
+      }
+    }
 
     & .initials__wrapper { 
       display: flex;

--- a/packages/components/src/components/navigation/navbar/navbar-profile.tsx
+++ b/packages/components/src/components/navigation/navbar/navbar-profile.tsx
@@ -175,14 +175,14 @@ export class NavbarProfile {
   }
 
 
-
   render() {
     return (
       <div class="container">
         <a href={this.internalHref} target={this.target} onClick={() => this.toggleItemMenu()} class=   {`navbar__item ${!this.showLabel ? 'removeLabel' : ""} ${this.hasChildNavItems ? 'isParent' : ""}`}>
           <div class="inner__content-wrapper">
             <div class={`navbar__container-right-content-navigation-item-icon-wrapper`}>
-             
+             {this.userName.trim() !== "" && <div class='username__tooltip'>{this.userName}</div>}
+
              {this.internalImageUrl.type !== 'initials' && 
               <img src={ this.internalImageUrl.type === 'url' ? this.internalImageUrl.value : `data:image/svg+xml,${encodeURIComponent(this.defaultProfileImage)}`} alt={this.alt} />}
 
@@ -196,7 +196,7 @@ export class NavbarProfile {
               <slot onSlotchange={() => this.setProfileGap()} />
             </span>
           </div>
-          {this.userName.trim() !== "" && <div class='username__tooltip'>{this.userName}</div>}
+          {/* {this.userName.trim() !== "" && <div class='username__tooltip'>{this.userName}</div>} */}
         </a>
         
         {this.hasChildNavItems && <ul class='navbar-menu rightSideItemMenu'> <slot name="first__layer" /> </ul>}


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

When empty strings are passed to the `icon` prop of the ifx-icon component, no error message will appear. Only when incorrect icon name is passed.
This PR also contains minor changes to the username popover of the navbar-profile component. The username wrapper was re-positioned.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>23.3.0--canary.1358.fd8d6e0dd509121d6477ad498bc6999db968b6e1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@23.3.0--canary.1358.fd8d6e0dd509121d6477ad498bc6999db968b6e1.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@23.3.0--canary.1358.fd8d6e0dd509121d6477ad498bc6999db968b6e1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
