### PR TITLE
Icon preview: out of sync with the icon library

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "23.4.2",
+  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+  "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33415,7 +33415,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+      "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -33476,7 +33476,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+      "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -33487,7 +33487,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+        "@infineon/infineon-design-system-angular": "^23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -33507,7 +33507,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+      "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33516,16 +33516,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
+        "@infineon/infineon-design-system-stencil": "^23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+      "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
+        "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -33538,11 +33538,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+      "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
+        "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33415,7 +33415,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "23.4.2",
+      "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -33476,7 +33476,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "23.4.2",
+      "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -33487,7 +33487,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "*",
+        "@infineon/infineon-design-system-angular": "^23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -33507,7 +33507,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "23.4.2",
+      "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33516,16 +33516,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^23.4.2"
+        "@infineon/infineon-design-system-stencil": "^23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "23.4.2",
+      "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.4.2"
+        "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -33538,11 +33538,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "23.4.2",
+      "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.4.2"
+        "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33415,7 +33415,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+      "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -33476,7 +33476,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+      "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -33487,7 +33487,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+        "@infineon/infineon-design-system-angular": "^23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -33507,7 +33507,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+      "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33516,16 +33516,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
+        "@infineon/infineon-design-system-stencil": "^23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+      "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
+        "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -33538,11 +33538,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+      "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
+        "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2982,9 +2982,9 @@
       "link": true
     },
     "node_modules/@infineon/infineon-icons": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-icons/-/infineon-icons-2.1.0.tgz",
-      "integrity": "sha512-pjz4uw/Qxw8J4lo/tf9NAsw525c2s97um8FjFnQUhc5b4j63/ZMKjdXig4tSQG36Ha20F73Cac8SdhhsefLwwg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-icons/-/infineon-icons-2.1.1.tgz",
+      "integrity": "sha512-8PX8/3bkAck0EdQlbFqzJE/IcYB5QbFJ21MWqk2RO4oAXf2HLaqBfUXs8xvXfYBtPMH1VAKr6OT6lKHg+Am1YQ==",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10"
       }
@@ -33419,7 +33419,7 @@
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-icons": "^2.1.0",
+        "@infineon/infineon-icons": "^2.1.1",
         "@popperjs/core": "^2.11.8",
         "@stencil/core": "4.12.6",
         "@storybook/cli": "^8.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33415,7 +33415,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+      "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -33476,7 +33476,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+      "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -33487,7 +33487,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+        "@infineon/infineon-design-system-angular": "^23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -33507,7 +33507,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+      "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33516,16 +33516,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
+        "@infineon/infineon-design-system-stencil": "^23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+      "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
+        "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -33538,11 +33538,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+      "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
+        "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2982,9 +2982,9 @@
       "link": true
     },
     "node_modules/@infineon/infineon-icons": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-icons/-/infineon-icons-1.1.8.tgz",
-      "integrity": "sha512-cXFnFbHi59osaY5vHUarkaMQwF3yYNAZB/nXe79r69FSvTfFHkLDO8Zizi2VmooGKm1X5ionhT0wPX8ZQrwgzQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-icons/-/infineon-icons-2.1.0.tgz",
+      "integrity": "sha512-pjz4uw/Qxw8J4lo/tf9NAsw525c2s97um8FjFnQUhc5b4j63/ZMKjdXig4tSQG36Ha20F73Cac8SdhhsefLwwg==",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10"
       }
@@ -33419,7 +33419,7 @@
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-icons": "^1.1.8",
+        "@infineon/infineon-icons": "^2.1.0",
         "@popperjs/core": "^2.11.8",
         "@stencil/core": "4.12.6",
         "@storybook/cli": "^8.0.9",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+    "@infineon/infineon-design-system-angular": "^23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+    "@infineon/infineon-design-system-angular": "^23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+  "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+    "@infineon/infineon-design-system-angular": "^23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "23.4.2",
+  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "*",
+    "@infineon/infineon-design-system-angular": "^23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
+    "@infineon/infineon-design-system-stencil": "^23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+  "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
+    "@infineon/infineon-design-system-stencil": "^23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
+    "@infineon/infineon-design-system-stencil": "^23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "23.4.2",
+  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^23.4.2"
+    "@infineon/infineon-design-system-stencil": "^23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+  "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
+    "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
+    "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
+    "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "23.4.2",
+  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.4.2"
+    "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
+    "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "23.4.2",
+  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.4.2"
+    "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0"
+    "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+  "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0"
+    "@infineon/infineon-design-system-stencil": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "23.4.2",
+  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "23.4.3--canary.1364.30dc2c96cb279a0ea0e2c13f0d8be871cfb5b6cd.0",
+  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-icons": "^1.1.8",
+    "@infineon/infineon-icons": "^2.1.0",
     "@popperjs/core": "^2.11.8",
     "@stencil/core": "4.12.6",
     "@storybook/cli": "^8.0.9",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "23.4.3--canary.1364.d95fc62de8f3c0364e6a1709cc944c8c1bd992c1.0",
+  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-icons": "^2.1.0",
+    "@infineon/infineon-icons": "^2.1.1",
     "@popperjs/core": "^2.11.8",
     "@stencil/core": "4.12.6",
     "@storybook/cli": "^8.0.9",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "23.5.0--canary.1364.7dd7da2e89f47bb4c16671c5e6658340111660db.0",
+  "version": "23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/icons-preview/icons-preview.scss
+++ b/packages/components/src/components/icons-preview/icons-preview.scss
@@ -11,10 +11,9 @@
   padding: 20px;
   color: white;
   font-family: monospace;
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
-  width: 100%;
   z-index: 99;
 
   & button {

--- a/packages/components/src/components/icons-preview/icons-preview.scss
+++ b/packages/components/src/components/icons-preview/icons-preview.scss
@@ -11,7 +11,11 @@
   padding: 20px;
   color: white;
   font-family: monospace;
-  position: relative;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 99;
 
   & button {
     position: absolute;
@@ -74,7 +78,7 @@
 
     &.copied {
       &::after {
-        z-index: 1000;
+        z-index: 50;
         content: 'copied!';
         position: absolute;
         top: 0;

--- a/packages/components/src/components/stepper/Development.mdx
+++ b/packages/components/src/components/stepper/Development.mdx
@@ -21,7 +21,9 @@ const incrementStep = () => {
   const myStepper = document.getElementById('myStepper')
   if('some form condition') { 
     const steps = myStepper.querySelectorAll('ifx-step')
-    steps[myStepper.activeStep-1].complete = true; 
+    if(steps[myStepper.activeStep-1]) {
+      steps[myStepper.activeStep-1].complete = true;
+    } 
     myStepper.activeStep++;
   }
 }
@@ -52,7 +54,9 @@ const incrementStep = () => {
   const myStepper = document.getElementById('myStepper')
   if('some form condition') { 
     const steps = myStepper.querySelectorAll('ifx-step')
-    steps[myStepper.activeStep-1].complete = true; 
+    if(steps[myStepper.activeStep-1]) {
+      steps[myStepper.activeStep-1].complete = true;
+    } 
     setActiveStep(activeStep+1)
   }
 }

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -20,7 +20,6 @@
 </head>
 
 <body>
-
 </body>
 
 </html>

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -21,8 +21,6 @@
 
 <body>
 
-  <ifx-icons-preview></ifx-icons-preview>
-
 </body>
 
 </html>

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -21,6 +21,8 @@
 
 <body>
 
+  <ifx-icons-preview></ifx-icons-preview>
+
 </body>
 
 </html>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

- synced the Icon preview component with the latest version of the icon library 
- made the html snippet position sticky
- fixed the view-replacement-16 icon



<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@23.5.0--canary.1364.c07d0a3883bba8c2252966e190d61f7d64568df1.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
