### PR TITLE
Navbar: Remove hamburger menu in mobile view if menu items are not present

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+  "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "23.6.0",
+  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -14620,7 +14620,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -33415,7 +33414,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+      "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -33476,7 +33475,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+      "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -33487,7 +33486,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+        "@infineon/infineon-design-system-angular": "^23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -33505,9 +33504,34 @@
         "typescript": "~5.4.4"
       }
     },
+    "packages/components-angular/node_modules/@infineon/infineon-design-system-stencil": {
+      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0.tgz",
+      "integrity": "sha512-OWnh+ttT48yPCxibLgo6q0nuNO9LZIiNqkTfP/igdMsSolnLdATLsK3I/qJDq1A1Z5qi0OjJhE8JloRkEhAYHg==",
+      "peer": true,
+      "dependencies": {
+        "@infineon/design-system-tokens": "3.3.2",
+        "@infineon/infineon-icons": "^2.1.1",
+        "@popperjs/core": "^2.11.8",
+        "@stencil/core": "4.12.6",
+        "@storybook/cli": "^8.0.9",
+        "@storybook/test": "^8.0.9",
+        "babel-prettier-parser": "^0.10.8",
+        "classnames": "^2.3.2",
+        "i": "^0.3.7",
+        "npm": "^10.2.1",
+        "npm-run-all": "^4.1.5",
+        "prettier-standalone": "^1.3.1-0"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.4.5",
+        "ag-grid-community": "^30.0.6",
+        "choices.js": "^10.2.0"
+      }
+    },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+      "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33521,11 +33545,11 @@
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+      "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0"
+        "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -33538,11 +33562,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+      "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0"
+        "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33415,7 +33415,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "23.6.0",
+      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -33476,7 +33476,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "23.6.0",
+      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -33487,7 +33487,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^23.6.0",
+        "@infineon/infineon-design-system-angular": "^23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -33507,7 +33507,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "23.6.0",
+      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33516,16 +33516,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^23.6.0"
+        "@infineon/infineon-design-system-stencil": "^23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "23.6.0",
+      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.6.0"
+        "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -33538,11 +33538,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "23.6.0",
+      "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "23.6.0"
+        "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "23.6.0",
+  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^23.6.0",
+    "@infineon/infineon-design-system-angular": "^23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+  "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+    "@infineon/infineon-design-system-angular": "^23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+  "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "23.6.0",
+  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^23.6.0"
+    "@infineon/infineon-design-system-stencil": "^23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "23.6.0",
+  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.6.0"
+    "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+  "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0"
+    "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+  "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0"
+    "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "23.6.0",
+  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "23.6.0"
+    "@infineon/infineon-design-system-stencil": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "23.6.0",
+  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "23.6.1--canary.1377.f92894458cec734ecb9d0c89f1ddd12d3e7f6701.0",
+  "version": "23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/navigation/navbar/navbar.tsx
+++ b/packages/components/src/components/navigation/navbar/navbar.tsx
@@ -277,6 +277,12 @@ export class Navbar {
     this.addEventListenersToHandleCustomFocusState();
 
     const mediaQueryList = this.getMediaQueryList()
+        
+    const menuItems = this.el.querySelectorAll('ifx-navbar-item')
+    if (!menuItems.length) {
+      const burgerIconWrapper = this.el.shadowRoot.querySelector('.navbar__burger-icon-wrapper')
+      burgerIconWrapper.classList.add('hide');
+    }
 
     if (mediaQueryList.matches) {
       this.moveNavItemsToSidebar();
@@ -316,8 +322,8 @@ export class Navbar {
     if (!leftMenuItems.length && !dropdownMenu) {
       this.hasLeftMenuItems = false;
     }
-    this.handleLogoHrefAndTarget();
 
+    this.handleLogoHrefAndTarget();
     const mediaQueryList = window.matchMedia('(max-width: 800px)');
     mediaQueryList.addEventListener('change', (e) => this.moveNavItemsToSidebar(e));
   }
@@ -335,11 +341,11 @@ export class Navbar {
   
     if (matches) {
       /* The viewport is 800px wide or less */
-      topRowWrapper.classList.add('expand')
+      topRowWrapper?.classList.add('expand')
       
       //hide body scroll if sidebar was opened
       const crossIcon = this.el.shadowRoot.querySelector('.navbar__cross-icon')
-      if(crossIcon.classList.contains('show')) { 
+      if(crossIcon?.classList.contains('show')) { 
         this.handleBodyScroll('hide')
       }
       
@@ -385,7 +391,7 @@ export class Navbar {
       
     } else {
       /* The viewport is more than 800px wide */
-      topRowWrapper.classList.remove('expand')
+      topRowWrapper?.classList.remove('expand')
 
       //show body scroll 
       this.handleBodyScroll('show')


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
If the `ifx-navbar-item`s are not present in the navbar component, the hamburger menu icon for mobile view will not be rendered now. 

Related Issue
#1308 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@23.6.1--canary.1377.e0b2fc0dc0c8c6e5ac93a39dcb8521c3026916f3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
