### PR TITLE
Progress bar: aligned progress bar height with the figma design

### DIFF
--- a/examples/wrapper-components/react-javascript/src/components/ProgressBar/ProgressBar.js
+++ b/examples/wrapper-components/react-javascript/src/components/ProgressBar/ProgressBar.js
@@ -17,8 +17,13 @@ function ProgressBar() {
   };
 
   return (
-    <div style={{ '--ifx-font-family': '"Arial black"' }}>
+    <div>
+      Small
+      <IfxProgressBar value={progressValue} size="s" ></IfxProgressBar>
+      <br/>
+      Medium
       <IfxProgressBar value={progressValue} size="m" showLabel={true}></IfxProgressBar>
+      <br/>
       <IfxButton onClick={updateProgressOnClick} theme='default' target="_blank">
         Update Progress
       </IfxButton>

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+  "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.0.0",
+  "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.0.1",
+  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33415,7 +33415,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.0.0",
+      "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -33476,7 +33476,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.0.0",
+      "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -33487,7 +33487,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.0.0",
+        "@infineon/infineon-design-system-angular": "^24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -33507,7 +33507,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.0.0",
+      "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33516,16 +33516,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.0.0"
+        "@infineon/infineon-design-system-stencil": "^24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.0.0",
+      "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.0.0"
+        "@infineon/infineon-design-system-stencil": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -33538,11 +33538,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.0.0",
+      "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.0.0"
+        "@infineon/infineon-design-system-stencil": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33415,7 +33415,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+      "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -33476,7 +33476,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+      "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -33487,7 +33487,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+        "@infineon/infineon-design-system-angular": "^24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -33507,7 +33507,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+      "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33516,16 +33516,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
+        "@infineon/infineon-design-system-stencil": "^24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+      "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
+        "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -33538,11 +33538,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+      "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
+        "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33415,7 +33415,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.0.1",
+      "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -33476,7 +33476,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.0.1",
+      "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -33487,7 +33487,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.0.1",
+        "@infineon/infineon-design-system-angular": "^24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -33507,7 +33507,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.0.1",
+      "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33516,16 +33516,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.0.1"
+        "@infineon/infineon-design-system-stencil": "^24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.0.1",
+      "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.0.1"
+        "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -33538,11 +33538,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.0.1",
+      "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.0.1"
+        "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.0.0",
+  "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.0.0",
+    "@infineon/infineon-design-system-angular": "^24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+  "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+    "@infineon/infineon-design-system-angular": "^24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.0.1",
+  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.0.1",
+    "@infineon/infineon-design-system-angular": "^24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.0.1",
+  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.0.1"
+    "@infineon/infineon-design-system-stencil": "^24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+  "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
+    "@infineon/infineon-design-system-stencil": "^24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.0.0",
+  "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.0.0"
+    "@infineon/infineon-design-system-stencil": "^24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.0.0",
+  "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.0.0"
+    "@infineon/infineon-design-system-stencil": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+  "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
+    "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.0.1",
+  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.0.1"
+    "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.0.1",
+  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.0.1"
+    "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+  "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0"
+    "@infineon/infineon-design-system-stencil": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.0.0",
+  "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.0.0"
+    "@infineon/infineon-design-system-stencil": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.0.1",
+  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.0.2--canary.1386.51834e196d3143d8f68fae3c1ce3c3cf42788983.0",
+  "version": "24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.0.0",
+  "version": "24.0.1--canary.1386.7a98d62c10f4334c38b08a0740a52ee92bbbfcba.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/progress-bar/progress-bar.e2e.ts
+++ b/packages/components/src/components/progress-bar/progress-bar.e2e.ts
@@ -9,16 +9,14 @@ describe('ifx-progress-bar', () => {
     expect(element).toHaveClass('hydrated');
   });
 
-  it('should reflect value and label props', async () => {
+  it('should reflect value prop', async () => {
     const page = await newE2EPage();
-    await page.setContent('<ifx-progress-bar value="70" label="Progress"></ifx-progress-bar>');
+    await page.setContent('<ifx-progress-bar value="70"></ifx-progress-bar>');
 
     const progressBar = await page.find('ifx-progress-bar');
     const value = await progressBar.getProperty('value');
-    const label = await progressBar.getProperty('label');
 
     expect(value).toBe(70);
-    expect(label).toBe('Progress');
   });
 
   it('should show label when showLabel is true', async () => {

--- a/packages/components/src/components/progress-bar/progress-bar.scss
+++ b/packages/components/src/components/progress-bar/progress-bar.scss
@@ -13,7 +13,7 @@
   top: 0;
   left: 0;
   display: flex;
-  height: tokens.$ifxSize200;
+  height: tokens.$ifxSize250;
   border-radius: tokens.$ifxBorderRadius12;
   width: 100%; // Ensure the bar itself can grow up to 100% width
   overflow: hidden; // Ensures that the inner progress bar doesn't exceed the width of the outer progress bar
@@ -23,7 +23,7 @@
 
 
   .label {
-    height: 17px;
+    height: 20px;
     border-radius: 1px 0px 0px 1px;
   }
 

--- a/packages/components/src/components/progress-bar/progress-bar.scss
+++ b/packages/components/src/components/progress-bar/progress-bar.scss
@@ -19,46 +19,26 @@
   overflow: hidden; // Ensures that the inner progress bar doesn't exceed the width of the outer progress bar
   background-color: tokens.$ifxColorEngineering200;
   font-family: var(--ifx-font-family, sans-serif);
-
-
-
-  .label {
-    height: 20px;
-    border-radius: 1px 0px 0px 1px;
-  }
-
+  
   &.s {
     height: 4px;
   }
 
-  .progress {
-    height: 100%;
-    background-color: #0A8276;
-    position: relative;
-    transition: width 0.2s ease;
-
-    &:after {
-      content: '';
-      background-color: #EEEDED;
-      height: 100%;
-      position: absolute;
-    }
-
-  }
-
   .label {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: absolute;
     font-style: normal;
     font-size: tokens.$ifxFontSizeS;
     font-weight: 400;
     line-height: tokens.$ifxLineHeightS;
     color: tokens.$ifxColorBaseWhite;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
+  }
+  
+  .progress {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: fit-content;
+    height: 100%;
+    background-color: #0A8276;
+    transition: width 0.2s ease;
   }
 }

--- a/packages/components/src/components/progress-bar/progress-bar.tsx
+++ b/packages/components/src/components/progress-bar/progress-bar.tsx
@@ -7,7 +7,6 @@ import { Component, Prop, h, State, Watch } from '@stencil/core';
 })
 export class ProgressBar {
   @Prop() value: number = 0;
-  @Prop() label: string = '';
   @Prop() size: string;
   @Prop() showLabel: boolean = false;
 
@@ -27,7 +26,7 @@ export class ProgressBar {
   render() {
     return (
       <div aria-label='a progress bar' aria-value={this.value}  class={`progress-bar ${this.size}`}>
-        <div class="progress" style={{ width: `${this.internalValue === 0 ? 0 : Math.max(2, this.internalValue)}%` }}>
+        <div class="progress" style={{ width: `${this.internalValue}%` }}>
           {this.showLabel && this.size !== "s" && this.internalValue !== 0 && <span class="label">{`${this.internalValue}%`}</span>}
         </div>
       </div>

--- a/packages/components/src/components/progress-bar/readme.md
+++ b/packages/components/src/components/progress-bar/readme.md
@@ -9,7 +9,6 @@
 
 | Property    | Attribute    | Description | Type      | Default     |
 | ----------- | ------------ | ----------- | --------- | ----------- |
-| `label`     | `label`      |             | `string`  | `''`        |
 | `showLabel` | `show-label` |             | `boolean` | `false`     |
 | `size`      | `size`       |             | `string`  | `undefined` |
 | `value`     | `value`      |             | `number`  | `0`         |


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
Changed the height of progress bar from 16px to 20px to comply with figma design.

Related Issue
#1384 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@24.0.2--canary.1386.daea9b3c0cba8d3478d544fde473e67c3e7beb00.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
