### PR TITLE
Implemented a maxlength prop for input elements

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.1.0",
+  "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -32022,7 +32022,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.1.0",
+      "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32083,7 +32083,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.1.0",
+      "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32094,7 +32094,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.1.0",
+        "@infineon/infineon-design-system-angular": "^24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32114,7 +32114,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.1.0",
+      "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32123,16 +32123,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.1.0"
+        "@infineon/infineon-design-system-stencil": "^24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.1.0",
+      "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.1.0"
+        "@infineon/infineon-design-system-stencil": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32145,11 +32145,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.1.0",
+      "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.1.0"
+        "@infineon/infineon-design-system-stencil": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.1.0",
+  "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.1.0",
+    "@infineon/infineon-design-system-angular": "^24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.1.0",
+  "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.1.0"
+    "@infineon/infineon-design-system-stencil": "^24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.1.0",
+  "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.1.0"
+    "@infineon/infineon-design-system-stencil": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.1.0",
+  "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.1.0"
+    "@infineon/infineon-design-system-stencil": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.1.0",
+  "version": "24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/search-bar/readme.md
+++ b/packages/components/src/components/search-bar/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property   | Attribute  | Description | Type      | Default     |
-| ---------- | ---------- | ----------- | --------- | ----------- |
-| `disabled` | `disabled` |             | `boolean` | `false`     |
-| `isOpen`   | `is-open`  |             | `boolean` | `true`      |
-| `value`    | `value`    |             | `string`  | `undefined` |
+| Property    | Attribute   | Description | Type      | Default     |
+| ----------- | ----------- | ----------- | --------- | ----------- |
+| `disabled`  | `disabled`  |             | `boolean` | `false`     |
+| `isOpen`    | `is-open`   |             | `boolean` | `true`      |
+| `maxlength` | `maxlength` |             | `number`  | `undefined` |
+| `value`     | `value`     |             | `string`  | `undefined` |
 
 
 ## Events

--- a/packages/components/src/components/search-bar/search-bar.stories.ts
+++ b/packages/components/src/components/search-bar/search-bar.stories.ts
@@ -13,6 +13,10 @@ export default {
       action: 'ifxInput',
       description: 'Custom event emitted on input\n\n(see below for Two Way Data Binding in different JS frameworks)',
     },
+    maxlength: {
+      description: 'Maximum input length',
+      control: {type: 'number'}
+    },
     ifxSearchBarIsOpen: {
       action: 'ifxInput',
       description: 'Custom event',
@@ -27,11 +31,12 @@ export default {
   },
 };
 
-const DefaultTemplate = ({ isOpen, disabled }) => {
+const DefaultTemplate = ({ isOpen, disabled, maxlength }) => {
   const element = document.createElement('ifx-search-bar');
   element.setAttribute('is-open', isOpen);
   element.setAttribute('disabled', disabled);
   element.addEventListener('ifxInput', action('ifxInput'));
+  if(maxlength != undefined) element.setAttribute('maxlength', maxlength);
 
   return element;
 };

--- a/packages/components/src/components/search-bar/search-bar.tsx
+++ b/packages/components/src/components/search-bar/search-bar.tsx
@@ -10,6 +10,7 @@ export class SearchBar {
   @Prop() disabled: boolean = false;
   @State() internalState: boolean;
   @Prop({ mutable: true }) value: string;
+  @Prop() maxlength?: number;
   @Event() ifxInput: EventEmitter;
   @Event() ifxSearchBarIsOpen: EventEmitter;
   @Element() el;
@@ -53,7 +54,7 @@ export class SearchBar {
       <div aria-label='a search bar' aria-disabled={this.disabled} class={`search-bar ${this.internalState ? 'open' : 'closed'}`}>
         {this.internalState ? (
           <div class="search-bar-wrapper">
-            <ifx-search-field disabled={this.disabled} value={this.value} onIfxInput={this.handleInput.bind(this)}>
+            <ifx-search-field disabled={this.disabled} value={this.value} maxlength={this.maxlength} onIfxInput={this.handleInput.bind(this)}>
               <ifx-icon icon="search-16" slot="search-icon"></ifx-icon>
             </ifx-search-field>
 

--- a/packages/components/src/components/search-field/readme.md
+++ b/packages/components/src/components/search-field/readme.md
@@ -10,6 +10,7 @@
 | Property         | Attribute          | Description | Type      | Default       |
 | ---------------- | ------------------ | ----------- | --------- | ------------- |
 | `disabled`       | `disabled`         |             | `boolean` | `false`       |
+| `maxlength`      | `maxlength`        |             | `number`  | `null`        |
 | `placeholder`    | `placeholder`      |             | `string`  | `"Search..."` |
 | `showDeleteIcon` | `show-delete-icon` |             | `boolean` | `false`       |
 | `size`           | `size`             |             | `string`  | `'l'`         |

--- a/packages/components/src/components/search-field/search-field.e2e.ts
+++ b/packages/components/src/components/search-field/search-field.e2e.ts
@@ -78,4 +78,16 @@ describe('SearchField', () => {
     expect(await input.getProperty('placeholder')).toBe('Search...');
     expect(await wrapper.getProperty('className')).toContain('focused');
   });
+
+  it('should not update value when maxlength is set', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ifx-search-field maxlength="2"></ifx-search-field>');
+
+    const input = await page.find('ifx-search-field >>> input');
+    await input.press('KeyA');
+    await input.press('KeyB');
+    await input.press('KeyC');
+
+    expect(await input.getProperty('value')).toBe('ab');
+  })
 });

--- a/packages/components/src/components/search-field/search-field.stories.ts
+++ b/packages/components/src/components/search-field/search-field.stories.ts
@@ -19,6 +19,10 @@ export default {
       description: 'Place holder text - default value: "Search..."',
       control: { type: 'text'}
     },
+    maxlength: {
+      description: 'Maximum input length',
+      control: {type: 'number'}
+    },
     ifxInput: {
       action: 'ifxInput',
       description: 'Custom event',
@@ -33,12 +37,13 @@ export default {
   },
 };
 
-const DefaultTemplate = ({ disabled, size, showDeleteIcon, placeholder }) => {
+const DefaultTemplate = ({ disabled, size, showDeleteIcon, placeholder, maxlength }) => {
   const element = document.createElement('ifx-search-field');
   element.setAttribute('size', size);
   element.setAttribute('disabled', disabled);
   element.setAttribute('show-delete-icon', showDeleteIcon);
   if(placeholder != undefined) element.setAttribute('placeholder', placeholder);
+  if(maxlength != undefined) element.setAttribute('maxlength', maxlength);
   element.addEventListener('ifxInput', action('ifxInput'));
 
   return element;

--- a/packages/components/src/components/search-field/search-field.tsx
+++ b/packages/components/src/components/search-field/search-field.tsx
@@ -22,6 +22,7 @@ export class SearchField {
   @Prop() size: string = 'l';
   @State() isFocused: boolean = false;
   @Prop() placeholder: string = "Search...";
+  @Prop() maxlength?: number = null;  
 
   @Listen('mousedown', { target: 'document' })
   handleOutsideClick(event: MouseEvent) {
@@ -78,6 +79,7 @@ export class SearchField {
             onInput={() => this.handleInput()}
             placeholder={this.placeholder}
             disabled={this.disabled}
+            maxlength={this.maxlength}
             value={this.value} // bind the value property to input element
           />
           {this.showDeleteIcon && this.showDeleteIconInternalState ? (

--- a/packages/components/src/components/text-field/readme.md
+++ b/packages/components/src/components/text-field/readme.md
@@ -14,6 +14,7 @@
 | `error`       | `error`       |             | `boolean` | `false`         |
 | `icon`        | `icon`        |             | `string`  | `""`            |
 | `label`       | `label`       |             | `string`  | `""`            |
+| `maxlength`   | `maxlength`   |             | `number`  | `undefined`     |
 | `optional`    | `optional`    |             | `boolean` | `false`         |
 | `placeholder` | `placeholder` |             | `string`  | `"Placeholder"` |
 | `required`    | `required`    |             | `boolean` | `false`         |

--- a/packages/components/src/components/text-field/text-field.e2e.ts
+++ b/packages/components/src/components/text-field/text-field.e2e.ts
@@ -100,6 +100,18 @@ describe('ifx-text-field', () => {
 
     expect(formData['textField']).toBe("");
   });
+
+  it('handles value change', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ifx-text-field maxlength="2"></ifx-text-field>');
+
+    const input = await page.find('ifx-text-field >>> input');
+    await input.press('KeyA');
+    await input.press('KeyB');
+    await input.press('KeyC');
+
+    expect(await input.getProperty('value')).toBe('ab');
+  });
 });
 
 async function newE2EPageWithRadioButtonWithinForm(): Promise<E2EPage> {

--- a/packages/components/src/components/text-field/text-field.stories.ts
+++ b/packages/components/src/components/text-field/text-field.stories.ts
@@ -32,6 +32,10 @@ export default {
     name: {
       description: 'Name of the element, that is used as reference when a form is submitted.'
     },
+    maxlength: {
+      description: 'Maximum input length',
+      control: {type: 'number'}
+    },
     ifxInput: {
       action: 'ifxInput',
       description: 'Custom event',
@@ -46,7 +50,7 @@ export default {
   },
 };
 
-const DefaultTemplate = ({ error, disabled, success, size, placeholder, label, caption, icon, required, optional, name }) => {
+const DefaultTemplate = ({ error, disabled, success, size, placeholder, label, caption, icon, required, optional, name, maxlength }) => {
   const element = document.createElement('ifx-text-field');
   element.setAttribute('error', error);
   element.setAttribute('disabled', disabled);
@@ -58,7 +62,10 @@ const DefaultTemplate = ({ error, disabled, success, size, placeholder, label, c
   element.setAttribute('required', required);
   element.setAttribute('optional', optional);
   element.setAttribute('name', name);
+  if (maxlength) element.setAttribute('maxlength', maxlength);
+
   element.addEventListener('ifxInput', action('ifxInput'));
+
 
   const slotContent = document.createTextNode(label);
   element.appendChild(slotContent);

--- a/packages/components/src/components/text-field/text-field.tsx
+++ b/packages/components/src/components/text-field/text-field.tsx
@@ -21,6 +21,7 @@ export class TextField {
   @Prop() optional: boolean = false;
   @Prop() success: boolean = false;
   @Prop() disabled: boolean = false;
+  @Prop() maxlength?: number;
   @Event() ifxInput: EventEmitter<String>;
   // @Prop({ reflect: true })
   // resetOnSubmit: boolean = false;
@@ -82,6 +83,7 @@ export class TextField {
               value={this.value}
               onInput={() => this.handleInput()}
               placeholder={this.placeholder}
+              maxlength={this.maxlength}
               class={
                 `${this.icon ? 'icon' : ""}
                 ${this.error ? 'error' : ""} 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Adds maxlength property to search-field, search-bar, text-field.

Related Issue
#1375 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@24.1.1--canary.1388.2fe3e8be060ccb6a0aa174aabbbcbcb9f6f1b788.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
