### PR TITLE
Bugfix: tooltip: x-close button on dismissible variant does not work

### DIFF
--- a/examples/wrapper-components/react-javascript/src/components/Tooltip/Tooltip.js
+++ b/examples/wrapper-components/react-javascript/src/components/Tooltip/Tooltip.js
@@ -15,9 +15,9 @@ function Tooltip() {
         position="auto">I'm the dismissible tooltip reference
         element - Please click me</IfxTooltip>
       <br />
-      <IfxTooltip header="Dismissible tooltip header" text="Hi, I'm a dismissible tooltip" variant="extended"
-        position="auto">I'm the dismissible tooltip reference
-        element - Please click me</IfxTooltip>
+      <IfxTooltip header="Extended tooltip header" text="Hi, I'm a extended tooltip" variant="extended"
+        position="auto">I'm the extended tooltip reference
+        element - Please hover me</IfxTooltip>
     </div>
   );
 }

--- a/examples/wrapper-components/react-typescript/src/components/Tooltip/Tooltip.tsx
+++ b/examples/wrapper-components/react-typescript/src/components/Tooltip/Tooltip.tsx
@@ -14,9 +14,9 @@ function Tooltip() {
         position="auto">I'm the dismissible tooltip reference
         element - Please click me</IfxTooltip>
       <br />
-      <IfxTooltip header="Dismissible tooltip header" text="Hi, I'm a dismissible tooltip" variant="extended"
-        position="auto">I'm the dismissible tooltip reference
-        element - Please click me</IfxTooltip>
+      <IfxTooltip header="Extended tooltip header" text="Hi, I'm a extended tooltip" variant="extended"
+        position="auto">I'm the extended tooltip reference
+        element - Please hover me</IfxTooltip>
     </div>
   );
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.2.0",
+  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+  "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -31982,7 +31982,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+      "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32043,7 +32043,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+      "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32054,7 +32054,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+        "@infineon/infineon-design-system-angular": "^24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32074,7 +32074,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+      "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32083,16 +32083,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
+        "@infineon/infineon-design-system-stencil": "^24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+      "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
+        "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32105,11 +32105,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+      "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
+        "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31982,7 +31982,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.2.0",
+      "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32043,7 +32043,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.2.0",
+      "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32054,7 +32054,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.2.0",
+        "@infineon/infineon-design-system-angular": "^24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32074,7 +32074,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.2.0",
+      "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32083,16 +32083,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.2.0"
+        "@infineon/infineon-design-system-stencil": "^24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.2.0",
+      "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.0"
+        "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32105,11 +32105,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.2.0",
+      "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.0"
+        "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+  "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+    "@infineon/infineon-design-system-angular": "^24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.2.0",
+  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.2.0",
+    "@infineon/infineon-design-system-angular": "^24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.2.0",
+  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.2.0"
+    "@infineon/infineon-design-system-stencil": "^24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+  "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
+    "@infineon/infineon-design-system-stencil": "^24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+  "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
+    "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.2.0",
+  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.0"
+    "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+  "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
+    "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.2.0",
+  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.0"
+    "@infineon/infineon-design-system-stencil": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.2.0",
+  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.2.1--canary.1401.11824299bc04fd19854cf88cbae05af583a41ffa.0",
+  "version": "24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/tooltip/tooltip.e2e.ts
+++ b/packages/components/src/components/tooltip/tooltip.e2e.ts
@@ -24,6 +24,25 @@ describe('ifx-tooltip', () => {
     expect(tooltipEl).not.toBeNull();
   });
 
+  it('dismissable tooltip gets invisible after dismiss button is clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ifx-tooltip variant="dismissible" text="Tooltip"><ifx-button>Open</ifx-button></ifx-tooltip>');  
+  
+    const button = await page.find('ifx-button');
+    await button.click();
+
+    const tooltip = await page.find('ifx-tooltip >>> .tooltip-dismissible');
+
+    // should be visible
+    expect(tooltip).not.toBeNull();
+    expect(tooltip.className).toContain('visible')
+
+    const dismissButton = await page.find('ifx-tooltip >>> .close-button');
+    await dismissButton.click();
+
+    // should not be visible after click
+    expect(tooltip.className).not.toContain('visible')
+  });  
 
 });
 

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -49,8 +49,9 @@
       cursor: pointer;
       position: relative;
       order: 2;
-      padding-top: 12px;
-      padding-right: 12px;
+      margin-top: 12px;
+      margin-right: 12px;
+      line-height: 0px;
     }
 
   .tooltip-dismissible-content {

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -28,7 +28,7 @@
 
   &.visible {
     display: flex !important;
-    align-items: center;
+    align-items: start;
     //min-width: 100px;
     //width: auto;
   }
@@ -41,17 +41,17 @@
   min-width: 110px;
   width: auto;
 
-  .close-button {
-    //position: absolute;
-    //top: tokens.$ifxSpace150;
-    //right: tokens.$ifxSpace150;
-    cursor: pointer;
-    position: relative;
-    top: 0px;
-    //right: 0px;
-    order: 2;
-    padding-right: 12px;
-  }
+    .close-button {
+      all: unset;
+      //position: absolute;
+      //top: tokens.$ifxSpace150;
+      //right: tokens.$ifxSpace150;
+      cursor: pointer;
+      position: relative;
+      order: 2;
+      padding-top: 12px;
+      padding-right: 12px;
+    }
 
   .tooltip-dismissible-content {
     display: flex;

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -193,7 +193,7 @@ export class Tooltip {
         <slot></slot>
 
         {this.variant.toLowerCase() === 'dismissible' && <div class={tooltipDismissible}>
-          <button class="close-button" onClick={this.onDismissClick}>
+          <button aria-label="Close Tooltip" class="close-button" onClick={this.onDismissClick}>
             <ifx-icon icon="cross16"></ifx-icon>
           </button>
           <div class="tooltip-dismissible-content">

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -167,6 +167,11 @@ export class Tooltip {
     }
   }
 
+  onDismissClick = () => {
+    this.tooltipVisible = false;
+    this.tooltipEl.style.display = 'none';
+  }
+
   render() {
     const tooltipDismissible = {
       'tooltip-dismissible': true,
@@ -188,7 +193,9 @@ export class Tooltip {
         <slot></slot>
 
         {this.variant.toLowerCase() === 'dismissible' && <div class={tooltipDismissible}>
-          <ifx-icon icon="cross16" class="close-button"></ifx-icon>
+          <button class="close-button" onClick={this.onDismissClick}>
+            <ifx-icon icon="cross16"></ifx-icon>
+          </button>
           <div class="tooltip-dismissible-content">
             {this.header && <div class="tooltip-dismissible-header">{this.header}</div>}
             <div class="tooltip-dismissible-body">{this.text}</div>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Fix that a click on the X-Close Button of the dismissable tooltip will close the button.
Also fixed the layout of the Close Button to comply with figma.

Related Issue
[Tooltip: x-close button on dismissible variant does not work #1390](https://github.com/Infineon/infineon-design-system-stencil/issues/1390)

Context
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@24.2.1--canary.1401.d8ee9f6ad74ffb76d548de6517a29ea99487e4f7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
