### PR TITLE
Multi-select: label is now clickable + Design adjustment

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+  "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.2.2",
+  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -13000,7 +13000,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -31982,7 +31981,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+      "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32043,7 +32042,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+      "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32054,7 +32053,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+        "@infineon/infineon-design-system-angular": "^24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32072,9 +32071,34 @@
         "typescript": "~5.4.4"
       }
     },
+    "packages/components-angular/node_modules/@infineon/infineon-design-system-stencil": {
+      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0.tgz",
+      "integrity": "sha512-OeDNCLmDFpthGT1qW82v9X+Hx5ayz8K9FhMGrigU/L1VzUU5lWJQB5da7Ent0SwZyNh8vBnlpYrDsMaGY3+Bhw==",
+      "peer": true,
+      "dependencies": {
+        "@infineon/design-system-tokens": "3.3.2",
+        "@infineon/infineon-icons": "^2.1.2",
+        "@popperjs/core": "^2.11.8",
+        "@stencil/core": "4.12.6",
+        "@storybook/cli": "^8.0.9",
+        "@storybook/test": "^8.0.9",
+        "babel-prettier-parser": "^0.10.8",
+        "classnames": "^2.3.2",
+        "i": "^0.3.7",
+        "npm": "^10.2.1",
+        "npm-run-all": "^4.1.5",
+        "prettier-standalone": "^1.3.1-0"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.4.5",
+        "ag-grid-community": "^30.0.6",
+        "choices.js": "^10.2.0"
+      }
+    },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+      "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32088,11 +32112,11 @@
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+      "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0"
+        "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32105,11 +32129,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+      "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0"
+        "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31982,7 +31982,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.2.2",
+      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32043,7 +32043,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.2.2",
+      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32054,7 +32054,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.2.2",
+        "@infineon/infineon-design-system-angular": "^24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32074,7 +32074,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.2.2",
+      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32083,16 +32083,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.2.2"
+        "@infineon/infineon-design-system-stencil": "^24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.2.2",
+      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.2"
+        "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32105,11 +32105,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.2.2",
+      "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.2"
+        "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.2.2",
+  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.2.2",
+    "@infineon/infineon-design-system-angular": "^24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+  "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+    "@infineon/infineon-design-system-angular": "^24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+  "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.2.2",
+  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.2.2"
+    "@infineon/infineon-design-system-stencil": "^24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.2.2",
+  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.2"
+    "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+  "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0"
+    "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.2.2",
+  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.2"
+    "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+  "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0"
+    "@infineon/infineon-design-system-stencil": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
+  "version": "24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.2.2",
+  "version": "24.2.3--canary.1402.e358912e3d1850232034b696f182b87fb837c6bf.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/select/multi-select/multiselect.scss
+++ b/packages/components/src/components/select/multi-select/multiselect.scss
@@ -228,7 +228,7 @@
       background-color: tokens.$ifxColorEngineering200;
     }
 
-    &:focus {
+    &:focus:not(.disabled) {
       background-color: tokens.$ifxColorEngineering300;
       outline: none;
     }

--- a/packages/components/src/components/select/multi-select/multiselect.scss
+++ b/packages/components/src/components/select/multi-select/multiselect.scss
@@ -246,6 +246,10 @@
       padding-left: 30px;
       /* or however much indentation you want */
     }
+
+    label {
+      cursor: pointer;
+    }
   }
 
 

--- a/packages/components/src/components/select/multi-select/multiselect.scss
+++ b/packages/components/src/components/select/multi-select/multiselect.scss
@@ -247,8 +247,14 @@
       /* or however much indentation you want */
     }
 
+    &.disabled {
+      &:hover {
+        cursor: default;
+      }
+    }
+
     label {
-      cursor: pointer;
+      cursor: inherit;
     }
   }
 

--- a/packages/components/src/components/select/multi-select/multiselect.tsx
+++ b/packages/components/src/components/select/multi-select/multiselect.tsx
@@ -457,7 +457,7 @@ export class Multiselect {
           tabindex="0"
           role={`${option.children?.length > 0 ? "treeitem" : "option"}`}>
           <ifx-checkbox ref={(el) => option.checkboxRef = el} id={uniqueId} size="s" value={isIndeterminate ? false : isSelected} indeterminate={isIndeterminate} disabled={disableCheckbox}></ifx-checkbox>
-          <label htmlFor={uniqueId}>{option.label}</label>
+          <label htmlFor={uniqueId} onClick={(e) => e.stopPropagation()}>{option.label}</label>
         </div>
         {option.children && option.children.map((child, childIndex) => this.renderSubOption(child, `${index}-${childIndex}`))}
       </div>
@@ -512,7 +512,7 @@ export class Multiselect {
         onClick={() => !disableCheckbox && this.handleOptionClick(option)}
         tabindex="0">
         <ifx-checkbox ref={(el) => option.checkboxRef = el} id={uniqueId} size="s" value={isSelected} disabled={disableCheckbox}></ifx-checkbox>
-        <label htmlFor={uniqueId}>{option.label}</label>
+        <label htmlFor={uniqueId} onClick={(e) => e.stopPropagation()}>{option.label}</label>
       </div>
     );
   }

--- a/packages/components/src/components/select/multi-select/multiselect.tsx
+++ b/packages/components/src/components/select/multi-select/multiselect.tsx
@@ -450,7 +450,7 @@ export class Multiselect {
 
     return (
       <div class="option-wrapper">
-        <div class={`option ${isSelected ? 'selected' : ''} 
+        <div class={`option ${isSelected ? 'selected' : ''} ${disableCheckbox ? 'disabled' : ''} 
         ${this.getSizeClass()}`}
           data-value={option.value}
           onClick={() => !disableCheckbox && this.handleOptionClick(option)}
@@ -506,7 +506,7 @@ export class Multiselect {
     const uniqueId = `checkbox-${option.value}-${index}`;
 
     return (
-      <div class={`option sub-option ${isSelected ? 'selected' : ''} ${this.getSizeClass()}`}
+      <div class={`option sub-option ${isSelected ? 'selected' : ''} ${this.getSizeClass()} ${disableCheckbox ? 'disabled' : ''}`}
         data-value={option.value}
         role={`${option.children?.length > 0 ? "option" : "treeitem"}`}
         onClick={() => !disableCheckbox && this.handleOptionClick(option)}


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
The options could not be toggled by clicking on the label. This behaviour is now fixed.

Related Issue
[Multi-select: label is not clickable #1383](https://github.com/Infineon/infineon-design-system-stencil/issues/1383)
[Multi-select: adjust design to Figma design #1294](https://github.com/Infineon/infineon-design-system-stencil/issues/1294)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@24.2.3--canary.1402.870d9c311b3d7139c859c8c9a059744c706bdc1d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
