### PR TITLE
Tooltip: implemented min and max width

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+  "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -31982,7 +31982,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.2.3",
+      "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32043,7 +32043,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.2.3",
+      "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32054,7 +32054,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.2.3",
+        "@infineon/infineon-design-system-angular": "^24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32074,7 +32074,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.2.3",
+      "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32083,16 +32083,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.2.3"
+        "@infineon/infineon-design-system-stencil": "^24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.2.3",
+      "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.3"
+        "@infineon/infineon-design-system-stencil": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32105,11 +32105,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.2.3",
+      "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.3"
+        "@infineon/infineon-design-system-stencil": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13000,7 +13000,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -31982,7 +31981,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+      "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32043,7 +32042,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+      "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32054,7 +32053,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+        "@infineon/infineon-design-system-angular": "^24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32072,9 +32071,34 @@
         "typescript": "~5.4.4"
       }
     },
+    "packages/components-angular/node_modules/@infineon/infineon-design-system-stencil": {
+      "version": "24.3.0--canary.1404.e95202a0a4c6a1e596224a9d62bcf5077427b847.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-24.3.0--canary.1404.e95202a0a4c6a1e596224a9d62bcf5077427b847.0.tgz",
+      "integrity": "sha512-3g6mXyJQs51ZiKGDiMvaUMGCznm2DxV/6LqbYgklp1bGgq4S+xgfqBfqpsVihcSC/JM0WLEKD60CtrnrJeCjBA==",
+      "peer": true,
+      "dependencies": {
+        "@infineon/design-system-tokens": "3.3.2",
+        "@infineon/infineon-icons": "^2.1.2",
+        "@popperjs/core": "^2.11.8",
+        "@stencil/core": "4.12.6",
+        "@storybook/cli": "^8.0.9",
+        "@storybook/test": "^8.0.9",
+        "babel-prettier-parser": "^0.10.8",
+        "classnames": "^2.3.2",
+        "i": "^0.3.7",
+        "npm": "^10.2.1",
+        "npm-run-all": "^4.1.5",
+        "prettier-standalone": "^1.3.1-0"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.4.5",
+        "ag-grid-community": "^30.0.6",
+        "choices.js": "^10.2.0"
+      }
+    },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+      "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32083,16 +32107,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
+        "@infineon/infineon-design-system-stencil": "^24.3.0--canary.1404.e95202a0a4c6a1e596224a9d62bcf5077427b847.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+      "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
+        "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32105,11 +32129,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+      "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
+        "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31982,7 +31982,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+      "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32043,7 +32043,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+      "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32054,7 +32054,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+        "@infineon/infineon-design-system-angular": "^24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32074,7 +32074,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+      "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32083,16 +32083,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
+        "@infineon/infineon-design-system-stencil": "^24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+      "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
+        "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32105,11 +32105,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+      "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
+        "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+  "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+    "@infineon/infineon-design-system-angular": "^24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+    "@infineon/infineon-design-system-angular": "^24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.2.3",
+    "@infineon/infineon-design-system-angular": "^24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+  "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
+    "@infineon/infineon-design-system-stencil": "^24.3.0--canary.1404.e95202a0a4c6a1e596224a9d62bcf5077427b847.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.2.3"
+    "@infineon/infineon-design-system-stencil": "^24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
+    "@infineon/infineon-design-system-stencil": "^24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
+    "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+  "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
+    "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.3"
+    "@infineon/infineon-design-system-stencil": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
+    "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.3"
+    "@infineon/infineon-design-system-stencil": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+  "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0"
+    "@infineon/infineon-design-system-stencil": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
+  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.3.0--canary.1404.8ae50864e758eae307f8af0ed297ee88924c5fa7.0",
+  "version": "24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1404.c0717cdcd345df88b4225e647ea5a05f51d8255b.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -19,12 +19,17 @@
   z-index: 1080;
   display: none;
   transition: opacity 0.3s;
-  position: relative;
+  position: absolute;
   font-size: 14px;
   font-style: normal;
   font-weight: 400;
   line-height: 20px;
   color: tokens.$ifxColorBaseWhite;
+  width: max-content;
+
+  white-space: pre-wrap;   /* wraps text at spaces and within words */
+  word-wrap: break-word;   /* breaks text within a word if necessary */
+  overflow-wrap: anywhere; /* breaks text at arbitrary points when needed */
 
   &.visible {
     display: flex !important;
@@ -201,20 +206,20 @@
 }
 
 
-.tooltip-compact {
+.tooltip-compact.visible {
   @extend %tooltip-arrow-positions;
-  min-width: 28px;
-  max-width: 145px;
+  min-width: 28px !important;
+  max-width: 145px !important;
 }
 
 .tooltip-dismissible {
   @extend %tooltip-arrow-positions;
-  min-width: 145px;
-  max-width: 310px;
+  min-width: 145px !important;
+  max-width: 310px !important;
 }
 
 .tooltip-extended {
   @extend %tooltip-arrow-positions;
-  min-width: 145px;
-  max-width: 310px;
+  min-width: 145px !important;
+  max-width: 310px !important;
 }

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -38,7 +38,6 @@
 
 .tooltip-dismissible {
   @extend %tooltip-common;
-  min-width: 110px;
   width: auto;
 
     .close-button {
@@ -92,7 +91,6 @@
 
 .tooltip-extended {
   @extend %tooltip-common;
-  min-width: 100px;
   width: auto;
   //padding-left: 36px; // Added this line, adjust as per your icon width
   //padding-left: tokens.$ifxSpace150; // Added this line, adjust as per your icon width
@@ -205,12 +203,18 @@
 
 .tooltip-compact {
   @extend %tooltip-arrow-positions;
+  min-width: 28px;
+  max-width: 145px;
 }
 
 .tooltip-dismissible {
   @extend %tooltip-arrow-positions;
+  min-width: 145px;
+  max-width: 310px;
 }
 
 .tooltip-extended {
   @extend %tooltip-arrow-positions;
+  min-width: 145px;
+  max-width: 310px;
 }

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -206,7 +206,7 @@
 }
 
 
-.tooltip-compact.visible {
+.tooltip-compact {
   @extend %tooltip-arrow-positions;
   min-width: 28px !important;
   max-width: 145px !important;

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -43,7 +43,6 @@
 
 .tooltip-dismissible {
   @extend %tooltip-common;
-  width: auto;
 
     .close-button {
       all: unset;
@@ -96,7 +95,6 @@
 
 .tooltip-extended {
   @extend %tooltip-common;
-  width: auto;
   //padding-left: 36px; // Added this line, adjust as per your icon width
   //padding-left: tokens.$ifxSpace150; // Added this line, adjust as per your icon width
   align-items: center;

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -26,6 +26,7 @@
   line-height: 20px;
   color: tokens.$ifxColorBaseWhite;
   width: max-content;
+  box-sizing: border-box;
 
   white-space: pre-wrap;   /* wraps text at spaces and within words */
   word-wrap: break-word;   /* breaks text within a word if necessary */

--- a/packages/components/src/components/tooltip/tooltip.stories.ts
+++ b/packages/components/src/components/tooltip/tooltip.stories.ts
@@ -37,7 +37,7 @@ const DefaultTemplate = ({ header, text, variant, position, icon }) => {
   element.setAttribute('position', position);
   element.setAttribute('icon', icon);
 
-  element.textContent = "I'm the tooltip reference element - Please hover me"; // Set content for the reference element
+  element.textContent = `I'm the tooltip reference element - Please ${variant==='dismissible' ? 'click' : 'hover'} me`; // Set content for the reference element
 
   return element;
 };


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Implement min/max-width for tooltip versions.
Also fixed the reference label in the story to say 'click me' instead of 'hover me' for the dismissible variant.

Related Issue
[Tooltip: implement min and max width #1385](https://github.com/Infineon/infineon-design-system-stencil/issues/1385)

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@24.3.0--canary.1404.1bdc97d0f737d29870aeaaf6cd091143bc6bcb6e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
