### PR TITLE
Multiselect: selected state of the passed array of items is now reflected on the rendered component

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.3.0",
+  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+  "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -31982,7 +31982,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.3.0",
+      "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32043,7 +32043,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.3.0",
+      "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32054,7 +32054,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.3.0",
+        "@infineon/infineon-design-system-angular": "^24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32074,7 +32074,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.3.0",
+      "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32083,16 +32083,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.3.0"
+        "@infineon/infineon-design-system-stencil": "^24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.3.0",
+      "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.3.0"
+        "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32105,11 +32105,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.3.0",
+      "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.3.0"
+        "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31982,7 +31982,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.2.3",
+      "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32043,7 +32043,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.2.3",
+      "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32054,7 +32054,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.2.3",
+        "@infineon/infineon-design-system-angular": "^24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32074,7 +32074,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.2.3",
+      "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32083,16 +32083,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.2.3"
+        "@infineon/infineon-design-system-stencil": "^24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.2.3",
+      "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.3"
+        "@infineon/infineon-design-system-stencil": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32105,11 +32105,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.2.3",
+      "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.2.3"
+        "@infineon/infineon-design-system-stencil": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31982,7 +31982,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+      "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -32043,7 +32043,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+      "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^17.3.3",
@@ -32054,7 +32054,7 @@
         "@angular/platform-browser": "^17.3.3",
         "@angular/platform-browser-dynamic": "^17.3.3",
         "@angular/router": "^17.3.3",
-        "@infineon/infineon-design-system-angular": "^24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+        "@infineon/infineon-design-system-angular": "^24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -32074,7 +32074,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+      "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32083,16 +32083,16 @@
         "@angular/common": "^17.3.3",
         "@angular/core": "^17.3.3",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
+        "@infineon/infineon-design-system-stencil": "^24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+      "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
+        "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -32105,11 +32105,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+      "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
+        "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.3.0",
+  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.3.0",
+    "@infineon/infineon-design-system-angular": "^24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.2.3",
+    "@infineon/infineon-design-system-angular": "^24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+  "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^17.3.3",
     "@angular/platform-browser-dynamic": "^17.3.3",
     "@angular/router": "^17.3.3",
-    "@infineon/infineon-design-system-angular": "^24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+    "@infineon/infineon-design-system-angular": "^24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.2.3"
+    "@infineon/infineon-design-system-stencil": "^24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+  "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
+    "@infineon/infineon-design-system-stencil": "^24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.3.0",
+  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^17.3.3",
     "@angular/core": "^17.3.3",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.3.0"
+    "@infineon/infineon-design-system-stencil": "^24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+  "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
+    "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.3"
+    "@infineon/infineon-design-system-stencil": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.3.0",
+  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.3.0"
+    "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.2.3"
+    "@infineon/infineon-design-system-stencil": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.3.0",
+  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.3.0"
+    "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+  "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0"
+    "@infineon/infineon-design-system-stencil": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.3.0",
+  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.3.1--canary.1405.064afb1e12f0f8a52195082f087ff2ea923c1dfb.0",
+  "version": "24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.2.3",
+  "version": "24.2.4--canary.1405.0b0b2729712fe1c11cd561a82af7a8ef213f7f5e.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/select/multi-select/multiselect.stories.ts
+++ b/packages/components/src/components/select/multi-select/multiselect.stories.ts
@@ -30,6 +30,29 @@ const options = [
   },
 ];
 
+const longOptions = [];
+for (let i=1; i<=50; i++) {
+  let children = undefined;
+  if (i % 3 == 0) {
+    children = [{
+      "value":  `${i}.1`,
+      "label": `Option ${i}.1`,
+      "selected": i % 2 == 0 ? true : false
+    },{
+      "value": `${i}.2`,
+      "label": `Option ${i}.2`,
+      "selected": i % 4 == 0 ? true : false
+    }];
+  }
+  longOptions.push({
+    "value": i,
+    "label": `Option ${i}`,
+    "selected": i % 2 == 0 ? true : false,
+    "children": children
+  })
+}
+
+
 export default {
   title: 'Components/Select/Multi Select',
   // tags: ['autodocs'],
@@ -120,7 +143,7 @@ export default {
   },
 };
 
-const DefaultTemplate = args => {
+const Template = args => {
   const template = `<ifx-multiselect 
   options='${JSON.stringify(args.options)}' 
   batch-size='${args.batchSize}'
@@ -142,7 +165,14 @@ const DefaultTemplate = args => {
   return template;
 };
 
-export const Default = DefaultTemplate.bind({});
+export const Default = Template.bind({});
 Default.args = {
   options: options,
+};
+
+export const WithLazyLoading = Template.bind({});
+WithLazyLoading.args = {
+  options: longOptions,
+  batchSize: 5,
+  maxItemCount: undefined
 };


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Fixed that the multiselect will parse the options and mark the options with `selected: true` accordingly.
Also added a story with lazy loading.

Related Issue
[Multiselect: when select is set to true on an option, its checkbox remains unchecked on the menu #991](https://github.com/Infineon/infineon-design-system-stencil/issues/991)

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@24.3.1--canary.1405.fc5d5fdb6f84b4aa808b4927beba383ce6e7f5e7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
