### PR TITLE
Single Select: removed unnecessary code

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.6.0",
+  "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -28816,7 +28816,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.6.0",
+      "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -28877,7 +28877,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.6.0",
+      "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -28888,7 +28888,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^24.6.0",
+        "@infineon/infineon-design-system-angular": "^24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -30732,7 +30732,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.6.0",
+      "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -30741,16 +30741,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.6.0"
+        "@infineon/infineon-design-system-stencil": "^24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.6.0",
+      "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.6.0"
+        "@infineon/infineon-design-system-stencil": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -30763,11 +30763,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.6.0",
+      "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.6.0"
+        "@infineon/infineon-design-system-stencil": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.6.0",
+  "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^24.6.0",
+    "@infineon/infineon-design-system-angular": "^24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.6.0",
+  "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.6.0"
+    "@infineon/infineon-design-system-stencil": "^24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.6.0",
+  "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.6.0"
+    "@infineon/infineon-design-system-stencil": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.6.0",
+  "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.6.0"
+    "@infineon/infineon-design-system-stencil": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.6.0",
+  "version": "24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/select/single-select/interfaces.tsx
+++ b/packages/components/src/components/select/single-select/interfaces.tsx
@@ -183,6 +183,4 @@ export interface IChoicesMethods {
   setChoiceByValue(value: string | Array<string>);
   clearStore();
   clearInput();
-  disable();
-  enable();
 }

--- a/packages/components/src/components/select/single-select/readme.md
+++ b/packages/components/src/components/select/single-select/readme.md
@@ -116,26 +116,6 @@ Type: `Promise<this>`
 
 
 
-### `disable() => Promise<this>`
-
-
-
-#### Returns
-
-Type: `Promise<this>`
-
-
-
-### `enable() => Promise<this>`
-
-
-
-#### Returns
-
-Type: `Promise<this>`
-
-
-
 ### `getValue(valueOnly?: boolean) => Promise<string | Array<string>>`
 
 

--- a/packages/components/src/components/select/single-select/select.tsx
+++ b/packages/components/src/components/select/single-select/select.tsx
@@ -89,9 +89,9 @@ export class Choices implements IChoicesProps, IChoicesMethods {
   @Watch('disabled')
   watchDisabled(newValue: boolean) {
     if (newValue) {
-      this.disable();
+      this.choice.disable();
     } else {
-      this.enable();
+      this.choice.enable();
     }
   }
 
@@ -226,22 +226,6 @@ export class Choices implements IChoicesProps, IChoicesMethods {
   @Method()
   public async clearInput() {
     this.choice.clearInput();
-
-    return this;
-  }
-
-  @Method()
-  public async enable() {
-    this.choice.enable();
-    this.disabled = false;
-
-    return this;
-  }
-
-  @Method()
-  public async disable() {
-    this.choice.disable();
-    this.disabled = true;
 
     return this;
   }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
Removed the enable() and disable() methods as a part of clean up and redundancy issues.

Related Issue
#1427 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@24.6.1--canary.1428.dd1241a5597012b5b0d40b9aa7a534165dae1e16.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
