### PR TITLE
Navbar: fixed error when profile-item not used

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -28816,7 +28816,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.6.2",
+      "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -28877,7 +28877,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.6.2",
+      "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -28888,7 +28888,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^24.6.2",
+        "@infineon/infineon-design-system-angular": "^24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -30732,7 +30732,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.6.2",
+      "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -30741,16 +30741,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.6.2"
+        "@infineon/infineon-design-system-stencil": "^24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.6.2",
+      "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.6.2"
+        "@infineon/infineon-design-system-stencil": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -30763,11 +30763,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.6.2",
+      "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.6.2"
+        "@infineon/infineon-design-system-stencil": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^24.6.2",
+    "@infineon/infineon-design-system-angular": "^24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.6.2"
+    "@infineon/infineon-design-system-stencil": "^24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.6.2"
+    "@infineon/infineon-design-system-stencil": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.6.2"
+    "@infineon/infineon-design-system-stencil": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/navigation/navbar/navbar.tsx
+++ b/packages/components/src/components/navigation/navbar/navbar.tsx
@@ -133,7 +133,10 @@ export class Navbar {
     } else if(leftAssignedNodes.length !== 0) {
       this.searchBarIsOpen = 'left'
     }
-    navbarProfile.hideComponent()
+
+    if(navbarProfile) { 
+      navbarProfile.hideComponent()
+    }
     
     for(let l = 0; l < leftMenuItems.length; l++) { 
       if(!topRowWrapper.classList.contains('expand')) {
@@ -156,7 +159,9 @@ export class Navbar {
     const { navbarProfile, leftMenuItems, rightMenuItems, topRowWrapper } = this.getWrappers();
     this.searchBarIsOpen = undefined;
     
-    navbarProfile.showComponent()
+    if(navbarProfile) {
+      navbarProfile.showComponent()
+    }
     
     for(let l = 0; l < leftMenuItems.length; l++) { 
       if(!topRowWrapper.classList.contains('expand')) {
@@ -434,8 +439,10 @@ export class Navbar {
       //right-side
       const rightMenuItems = this.getMobileMenuBottom()
       const navbarProfileItem = this.el.querySelector('ifx-navbar-profile')
-      const showProfileItemLabel = navbarProfileItem.getAttribute('show-label');
-      navbarProfileItem.setAttribute('show-label', showProfileItemLabel)
+      if(navbarProfileItem) { 
+        const showProfileItemLabel = navbarProfileItem.getAttribute('show-label');
+        navbarProfileItem.setAttribute('show-label', showProfileItemLabel)
+      }
 
       for(let i = 0; i < rightMenuItems.length; i++) { 
         rightMenuItems[i].setAttribute('slot', 'right-item')


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

- Added a condition that checks if the profile-item exists before doing something with it.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@24.6.3--canary.1443.a7adb3645f92665602153fe642953b467ae387f0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
