### PR TITLE
Icon component: removed unnecessary console error 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+  "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -28816,7 +28816,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+      "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -28877,7 +28877,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+      "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -28888,7 +28888,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+        "@infineon/infineon-design-system-angular": "^24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -30732,7 +30732,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+      "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -30741,16 +30741,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
+        "@infineon/infineon-design-system-stencil": "^24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+      "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
+        "@infineon/infineon-design-system-stencil": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -30763,11 +30763,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+      "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
+        "@infineon/infineon-design-system-stencil": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28816,7 +28816,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.6.2",
+      "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -28877,7 +28877,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.6.2",
+      "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -28888,7 +28888,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^24.6.2",
+        "@infineon/infineon-design-system-angular": "^24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -30732,7 +30732,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.6.2",
+      "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -30741,16 +30741,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.6.2"
+        "@infineon/infineon-design-system-stencil": "^24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.6.2",
+      "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.6.2"
+        "@infineon/infineon-design-system-stencil": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -30763,11 +30763,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.6.2",
+      "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.6.2"
+        "@infineon/infineon-design-system-stencil": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+  "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+    "@infineon/infineon-design-system-angular": "^24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^24.6.2",
+    "@infineon/infineon-design-system-angular": "^24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+  "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
+    "@infineon/infineon-design-system-stencil": "^24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.6.2"
+    "@infineon/infineon-design-system-stencil": "^24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.6.2"
+    "@infineon/infineon-design-system-stencil": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+  "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
+    "@infineon/infineon-design-system-stencil": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.6.2"
+    "@infineon/infineon-design-system-stencil": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+  "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0"
+    "@infineon/infineon-design-system-stencil": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.6.2",
+  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.6.3--canary.1444.f8ffa114a3f65cf20d55d7b2236a5bb815f40137.0",
+  "version": "24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/icon/infineonIconStencil.tsx
+++ b/packages/components/src/components/icon/infineonIconStencil.tsx
@@ -56,7 +56,6 @@ export class InfineonIconStencil {
       const htmlPath = this.convertStringToHtml(this.ifxIcon.svgContent)
       const svgPath = this.convertPathsToVnode(htmlPath)
       const SVG = this.getSVG(svgPath)
-      this.consoleError.emit(false)
       return SVG;
     } else if(this.icon !== "") {
       console.error('Icon not found!')


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

`The "consoleError" event was emitted, but the dispatcher node is no longer connected to the dom.` warning occurs when using the Single select, and likely other components too. To prevent this error, I removed the `console.error` in the Icon component, which was not necessary. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@24.6.4--canary.1444.13aa764ee6979c6d7c0889a811adbb9d6c7dc169.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
