### PR TITLE
Bugfix: Backgroundcolor of multiselect

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "24.7.0",
+  "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33093,7 +33093,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "24.7.0",
+      "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
@@ -33154,7 +33154,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "24.7.0",
+      "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33165,7 +33165,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^24.7.0",
+        "@infineon/infineon-design-system-angular": "^24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.14.4"
@@ -33198,7 +33198,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "24.7.0",
+      "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33207,16 +33207,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "^24.7.0"
+        "@infineon/infineon-design-system-stencil": "^24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "24.7.0",
+      "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.7.0"
+        "@infineon/infineon-design-system-stencil": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -33229,11 +33229,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "24.7.0",
+      "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.2",
-        "@infineon/infineon-design-system-stencil": "24.7.0"
+        "@infineon/infineon-design-system-stencil": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "24.7.0",
+  "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^24.7.0",
+    "@infineon/infineon-design-system-angular": "^24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.4"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "24.7.0",
+  "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "^24.7.0"
+    "@infineon/infineon-design-system-stencil": "^24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "24.7.0",
+  "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.7.0"
+    "@infineon/infineon-design-system-stencil": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "24.7.0",
+  "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2",
-    "@infineon/infineon-design-system-stencil": "24.7.0"
+    "@infineon/infineon-design-system-stencil": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "24.7.0",
+  "version": "24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/select/multi-select/multiselect.scss
+++ b/packages/components/src/components/select/multi-select/multiselect.scss
@@ -3,7 +3,6 @@
 @use "../../../global/font.scss";
 
 .ifx-multiselect-container {
-  background-color: tokens.$ifxColorBaseWhite;
   position: relative;
   box-sizing: border-box;
   font-family: var(--ifx-font-family);
@@ -41,6 +40,7 @@
   }
 
   .ifx-multiselect-wrapper {
+    background-color: tokens.$ifxColorBaseWhite;
     box-sizing: border-box;
     position: relative;
     display: flex;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Fixed to multiselect to not override the background color anymore.

Related Issue
Closing #1446 

Context
![image](https://github.com/user-attachments/assets/75757402-2b9a-45ce-90c3-b8fd19042842)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@24.7.1--canary.1453.4f7c483069b1dd599dd54520ccb2947bba8f1bfb.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
