### PR TITLE
Accordion: Removed redundant code

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "25.5.1",
+  "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -34580,7 +34580,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "25.5.1",
+      "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -34641,7 +34641,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "25.5.1",
+      "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -34652,7 +34652,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^25.5.1",
+        "@infineon/infineon-design-system-angular": "^25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -34672,7 +34672,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "25.5.1",
+      "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -34681,16 +34681,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.5.1"
+        "@infineon/infineon-design-system-stencil": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "25.5.1",
+      "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.5.1"
+        "@infineon/infineon-design-system-stencil": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -34703,11 +34703,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "25.5.1",
+      "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.5.1"
+        "@infineon/infineon-design-system-stencil": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "25.5.1",
+  "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^25.5.1",
+    "@infineon/infineon-design-system-angular": "^25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "25.5.1",
+  "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.5.1"
+    "@infineon/infineon-design-system-stencil": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "25.5.1",
+  "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.5.1"
+    "@infineon/infineon-design-system-stencil": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "25.5.1",
+  "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.5.1"
+    "@infineon/infineon-design-system-stencil": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "25.5.1",
+  "version": "25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/accordion/accordion.stories.tsx
+++ b/packages/components/src/components/accordion/accordion.stories.tsx
@@ -7,21 +7,16 @@ export default {
 
   args: {
     autoCollapse: false,
-    initialCollapse: true,
   },
 
   argTypes: {
     amountOfItems: { control: 'number' },
-    initialCollapse: {
-      description: 'If set on more than one accordion-item, auto-collapse must be false',
-    },
   },
 };
 
 const Template = args => {
   const accordionElement = document.createElement('ifx-accordion');
   const initialItem = document.createElement('ifx-accordion-item');
-  initialItem.setAttribute('initialCollapse', args.initialCollapse);
   initialItem.setAttribute('caption', `Label`);
   initialItem.setAttribute('open', `true`);
 

--- a/packages/components/src/components/accordion/accordionItem.tsx
+++ b/packages/components/src/components/accordion/accordionItem.tsx
@@ -11,7 +11,6 @@ export class IfxAccordionItem {
   @Prop({
     mutable: true,
   }) open: boolean = false;
-  @Prop() initialCollapse: boolean = true;
   @State() internalOpen: boolean = false;
   @Event() ifxItemOpen: EventEmitter;
   @Event() ifxItemClose: EventEmitter;
@@ -20,9 +19,6 @@ export class IfxAccordionItem {
 
   componentWillLoad() {
     this.internalOpen = this.open;
-    if (!this.initialCollapse) {
-      this.internalOpen = true;
-    }
   }
 
   componentDidLoad() {

--- a/packages/components/src/components/accordion/readme.md
+++ b/packages/components/src/components/accordion/readme.md
@@ -7,11 +7,10 @@
 
 ## Properties
 
-| Property          | Attribute          | Description | Type      | Default     |
-| ----------------- | ------------------ | ----------- | --------- | ----------- |
-| `caption`         | `caption`          |             | `string`  | `undefined` |
-| `initialCollapse` | `initial-collapse` |             | `boolean` | `true`      |
-| `open`            | `open`             |             | `boolean` | `false`     |
+| Property  | Attribute | Description | Type      | Default     |
+| --------- | --------- | ----------- | --------- | ----------- |
+| `caption` | `caption` |             | `string`  | `undefined` |
+| `open`    | `open`    |             | `boolean` | `false`     |
 
 
 ## Events


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Removed `initialCollapse` prop from `accordionItem` as it was redundant. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@25.6.0--canary.1517.a14961e3135f4f26e2068de0965d7636ecc8f737.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
