### PR TITLE
Icon-button: event not emitted anymore when disabled

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+  "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "25.6.2",
+  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -34580,7 +34580,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+      "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -34641,7 +34641,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+      "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -34652,7 +34652,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+        "@infineon/infineon-design-system-angular": "^25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -34670,9 +34670,37 @@
         "ng-packagr": "^18.2.0"
       }
     },
+    "packages/components-angular/node_modules/@infineon/infineon-design-system-stencil": {
+      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0.tgz",
+      "integrity": "sha512-bm9nZopjPg+pEGxqC6nbn2WaaqHY4fZBWZ+sUOX+XsvikZTB0/fTzdbKoeiFw+QDMLyMlhfyH+FRQMzd5EDh6Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@infineon/design-system-tokens": "3.3.3",
+        "@infineon/infineon-icons": "^2.1.2",
+        "@popperjs/core": "^2.11.8",
+        "@stencil/angular-output-target": "^0.9.0",
+        "@stencil/core": "^4.21.0",
+        "@stencil/vue-output-target": "^0.8.9",
+        "@storybook/cli": "^8.3.0",
+        "@storybook/test": "^8.3.0",
+        "babel-prettier-parser": "^0.10.8",
+        "classnames": "^2.3.2",
+        "i": "^0.3.7",
+        "npm": "^10.2.1",
+        "npm-run-all": "^4.1.5",
+        "prettier-standalone": "^1.3.1-0"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.4.5",
+        "ag-grid-community": "^30.0.6",
+        "choices.js": "^10.2.0"
+      }
+    },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+      "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -34681,16 +34709,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
+        "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+      "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
+        "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -34703,11 +34731,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+      "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
+        "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34580,7 +34580,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "25.6.2",
+      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -34641,7 +34641,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "25.6.2",
+      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -34652,7 +34652,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^25.6.2",
+        "@infineon/infineon-design-system-angular": "^25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -34672,7 +34672,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "25.6.2",
+      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -34681,16 +34681,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.6.2"
+        "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "25.6.2",
+      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.6.2"
+        "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -34703,11 +34703,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "25.6.2",
+      "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.6.2"
+        "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+  "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+    "@infineon/infineon-design-system-angular": "^25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "25.6.2",
+  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^25.6.2",
+    "@infineon/infineon-design-system-angular": "^25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+  "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
+    "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "25.6.2",
+  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.6.2"
+    "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "25.6.2",
+  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.6.2"
+    "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+  "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
+    "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "25.6.2",
+  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.6.2"
+    "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+  "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0"
+    "@infineon/infineon-design-system-stencil": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "25.6.2",
+  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "25.6.3--canary.1519.ca4f361c6f4fbef88e00a80c257645f4f8ef7d36.0",
+  "version": "25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/icon-button/icon-button.e2e.ts
+++ b/packages/components/src/components/icon-button/icon-button.e2e.ts
@@ -1,0 +1,35 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ifx-icon-button', () => {
+    it('should render', async () => {
+        const page = await newE2EPage();
+        await page.setContent('<ifx-icon-button></ifx-icon-button>');
+
+        const element = await page.find('ifx-icon-button');
+        expect(element).not.toBeNull();
+    });
+
+    it('should not propagate click event if disabled', async () => {
+        const page = await newE2EPage();
+        await page.setContent('<ifx-icon-button disabled="true"></ifx-icon-button>');
+        const spy = await page.spyOnEvent('click');
+        const element = await page.find('ifx-icon-button');
+    
+        await element.click();
+        await page.waitForChanges();
+
+        expect(spy).not.toHaveReceivedEvent();
+    });
+
+    it('should propagate click event if enabled', async () => {
+        const page = await newE2EPage();
+        await page.setContent('<ifx-icon-button disabled="false"></ifx-icon-button>');
+        const spy = await page.spyOnEvent('click');
+        const element = await page.find('ifx-icon-button');
+    
+        await element.click();
+        await page.waitForChanges();
+
+        expect(spy).toHaveReceivedEvent();
+    });
+});

--- a/packages/components/src/components/icon-button/icon-button.tsx
+++ b/packages/components/src/components/icon-button/icon-button.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, Host, Method, Element } from '@stencil/core';
+import { Component, Prop, h, Host, Method, Element, Listen } from '@stencil/core';
 import classNames from 'classnames';
  
 
@@ -20,6 +20,13 @@ export class IconButton {
 
   private focusableElement: HTMLElement;
 
+  @Listen('click', { capture: true })
+  handleClick(event: Event) {
+    if (this.disabled) {
+      event.stopImmediatePropagation();
+    }
+  }
+
   @Method()
   async setFocus() {
     this.focusableElement.focus();
@@ -30,8 +37,6 @@ export class IconButton {
       this.shape = 'round';
     }
   }
-
-
 
   render() {
     return (
@@ -59,8 +64,6 @@ export class IconButton {
       </Host>
     );
   }
-
-
 
   getVariantClass() {
     return `${this.variant}` === "secondary"

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -14,14 +14,13 @@
   </style>
 
   <script defer>
-    
+
   </script>
 
 </head>
 
 <body>
 
-  
 </body>
 
 </html>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

When disable is true, the onClick event is not emitted anymore on click.
Relevant issue: https://github.com/Infineon/infineon-design-system-stencil/issues/1488

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@25.6.3--canary.1519.3d42092a7be308839d7d98a7fc1396d2c67edc8b.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
