### PR TITLE
Tabs: prevent active tab from becoming negative index which causes error in React

### DIFF
--- a/examples/wrapper-components/react-vite-js/src/components/Tabs/Tabs.jsx
+++ b/examples/wrapper-components/react-vite-js/src/components/Tabs/Tabs.jsx
@@ -1,9 +1,9 @@
-import { useRef, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { IfxTabs, IfxTab } from '@infineon/infineon-design-system-react';
 
 function Tabs() {
   
-  const tabIndex = useRef(0);
+  const [tabIndex, setTabIndex]= useState(0);
   const INTERVAL = 20000;
 
   useEffect(() => {
@@ -22,7 +22,7 @@ function Tabs() {
   const setTab = () => {
     const next = Math.floor(Math.random() * (3));
     console.log("set next active tab: ", next)
-    tabIndex.current = next;
+    setTabIndex(next);
   }
 
   return (

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "25.7.0",
+  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+  "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "25.7.1",
+  "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -34580,7 +34580,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "25.7.0",
+      "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -34641,7 +34641,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "25.7.0",
+      "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -34652,7 +34652,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^25.7.0",
+        "@infineon/infineon-design-system-angular": "^25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -34672,7 +34672,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "25.7.0",
+      "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -34681,16 +34681,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.7.0"
+        "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "25.7.0",
+      "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.7.0"
+        "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -34703,11 +34703,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "25.7.0",
+      "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.7.0"
+        "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34580,7 +34580,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "25.7.1",
+      "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -34641,7 +34641,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "25.7.1",
+      "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -34652,7 +34652,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^25.7.1",
+        "@infineon/infineon-design-system-angular": "^25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -34672,7 +34672,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "25.7.1",
+      "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -34681,16 +34681,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.7.1"
+        "@infineon/infineon-design-system-stencil": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "25.7.1",
+      "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.7.1"
+        "@infineon/infineon-design-system-stencil": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -34703,11 +34703,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "25.7.1",
+      "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.7.1"
+        "@infineon/infineon-design-system-stencil": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34580,7 +34580,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+      "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -34641,7 +34641,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+      "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -34652,7 +34652,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+        "@infineon/infineon-design-system-angular": "^25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -34672,7 +34672,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+      "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -34681,16 +34681,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
+        "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+      "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
+        "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0"
       },
       "devDependencies": {
         "@types/node": "^20.1.4",
@@ -34703,11 +34703,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+      "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
+        "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "25.7.1",
+  "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^25.7.1",
+    "@infineon/infineon-design-system-angular": "^25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "25.7.0",
+  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^25.7.0",
+    "@infineon/infineon-design-system-angular": "^25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+  "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+    "@infineon/infineon-design-system-angular": "^25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "25.7.0",
+  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.7.0"
+    "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+  "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
+    "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "25.7.1",
+  "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.7.1"
+    "@infineon/infineon-design-system-stencil": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "25.7.1",
+  "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.7.1"
+    "@infineon/infineon-design-system-stencil": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "25.7.0",
+  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.7.0"
+    "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+  "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
+    "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "25.7.1",
+  "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.7.1"
+    "@infineon/infineon-design-system-stencil": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "25.7.0",
+  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.7.0"
+    "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+  "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0"
+    "@infineon/infineon-design-system-stencil": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "25.7.0",
+  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "25.7.1",
+  "version": "25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "25.7.1--canary.1532.3f4e3786638a39b41c287f63ff1eb15166a80887.0",
+  "version": "25.7.1--canary.1532.973c0cf5060dd8d68b01c0ee1c7c1cae3363135c.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/tabs/tabs.tsx
+++ b/packages/components/src/components/tabs/tabs.tsx
@@ -29,6 +29,9 @@ export class IfxTabs {
     if (index >= this.tabObjects.length) {
       index = this.tabObjects.length - 1;
     }
+    if (index < 0) {
+      index = 0;
+    }
     if (!this.tabObjects[index]?.disabled) {
       this.internalActiveTabIndex = index;
       this.internalFocusedTabIndex = index;

--- a/packages/components/src/components/tabs/tabs.tsx
+++ b/packages/components/src/components/tabs/tabs.tsx
@@ -29,7 +29,7 @@ export class IfxTabs {
     if (index >= this.tabObjects.length) {
       index = this.tabObjects.length - 1;
     }
-    if (!this.tabObjects[index].disabled) {
+    if (!this.tabObjects[index]?.disabled) {
       this.internalActiveTabIndex = index;
       this.internalFocusedTabIndex = index;
     }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
A console error would appear in react app in tab component because of useRef, fixed it by using useState hook.
Additionally, implemented array-index-out-of-bound check in tabs code component.

Related Issue
#1468 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@25.7.2--canary.1532.ad21b50ecfebca94216b0eb139834e81320e97d5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
