### PR TITLE
Bugfix: Placeholder in Multiselect is now changeable 

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+    "@infineon/infineon-design-system-react": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+    "@infineon/infineon-design-system-vue": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^3.0.1",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+  "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -34832,7 +34832,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+      "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -34894,7 +34894,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+      "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -34905,7 +34905,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+        "@infineon/infineon-design-system-angular": "^25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -34923,38 +34923,9 @@
         "ng-packagr": "^18.2.0"
       }
     },
-    "packages/components-angular/node_modules/@infineon/infineon-design-system-stencil": {
-      "version": "25.15.0--canary.1425.e2a10b8fb27892ca226cec7fa2febc31e41c6222.0",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-25.15.0--canary.1425.e2a10b8fb27892ca226cec7fa2febc31e41c6222.0.tgz",
-      "integrity": "sha512-9xHMk8TNUT30S80Bu8IZdNglbgxK4Inj4resjaN7cArovUr6krK8Qa/4ouNcP59K4rGK38ECYOgydo6tc8BWNQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-icons": "^2.1.2",
-        "@popperjs/core": "^2.11.8",
-        "@stencil/angular-output-target": "^0.9.0",
-        "@stencil/core": "^4.21.0",
-        "@stencil/vue-output-target": "^0.8.9",
-        "@storybook/cli": "^8.3.0",
-        "@storybook/test": "^8.3.0",
-        "babel-prettier-parser": "^0.10.8",
-        "classnames": "^2.3.2",
-        "glob": "^11.0.0",
-        "i": "^0.3.7",
-        "npm": "^10.2.1",
-        "npm-run-all": "^4.1.5",
-        "prettier-standalone": "^1.3.1-0"
-      },
-      "peerDependencies": {
-        "@floating-ui/dom": "^1.4.5",
-        "ag-grid-community": "^31.0.3",
-        "choices.js": "^10.2.0"
-      }
-    },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+      "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -34963,16 +34934,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0"
+        "@infineon/infineon-design-system-stencil": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+      "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+        "@infineon/infineon-design-system-stencil": "^25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -34986,11 +34957,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+      "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0"
+        "@infineon/infineon-design-system-stencil": "^25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+  "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+    "@infineon/infineon-design-system-angular": "^25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+  "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0"
+    "@infineon/infineon-design-system-stencil": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+  "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+    "@infineon/infineon-design-system-stencil": "^25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+  "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0"
+    "@infineon/infineon-design-system-stencil": "^25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "25.15.0--canary.1425.8811eeae871d96da76497d905b7b9947d0a58c08.0",
+  "version": "25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/select/multi-select/multiselect.tsx
+++ b/packages/components/src/components/select/multi-select/multiselect.tsx
@@ -622,7 +622,7 @@ export class Multiselect {
           `}
             onClick={this.disabled ? undefined : () => this.toggleDropdown()}
           >
-            {this.persistentSelectedOptions.length > 0 ? selectedOptionsLabels : 'Placeholder'}
+            {this.persistentSelectedOptions.length > 0 ? selectedOptionsLabels : this.placeholder}
           </div>
           {this.dropdownOpen && (
             <div class="ifx-multiselect-dropdown-menu"


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
The placeholder property in the multiselect component was fixed. Now it uses the value from the property to display its content. Before, it was using a hardcoded string with the value "Placeholder".

Related Issue
#1424 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@25.15.1--canary.1558.b04c1697c98fe53f8d029696d6c1a4aafe099229.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
