### PR TITLE
Bugfix: Use canary release of Tokens package to consume fonts from CDN

### DIFF
--- a/examples/stencil-components/vanilla-cdn/index.html
+++ b/examples/stencil-components/vanilla-cdn/index.html
@@ -6,6 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <script type="module" src="./dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>
+  <link rel="stylesheet" href="./dist/infineon-design-system-stencil/infineon-design-system-stencil.css">
+  
   <!-- <link rel="stylesheet" href="./node_modules/@infineon/design-system-tokens/dist/fonts/ifx-fonts.css"> -->
 
 

--- a/examples/stencil-components/vanilla-cdn/package.json
+++ b/examples/stencil-components/vanilla-cdn/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.2--canary.35.37fb280e88ed6cac90c421f89ba851375e93e62d.0",
-    "@infineon/infineon-design-system-stencil": "^20.44.1--canary.952.e2740b8e640aa78a0a199512580d52d96004104f.0",
+    "@infineon/infineon-design-system-stencil": "25.15.1--canary.1561.1c1eb8e300b13c71569ad58d2397e7bc06c66329.0",
     "typescript": "^4.5.4"
   }
 }

--- a/examples/stencil-components/vanilla-cdn/readme.md
+++ b/examples/stencil-components/vanilla-cdn/readme.md
@@ -4,7 +4,7 @@ This example application demonstrates the usage of some of our Stencil web compo
 
 The `index.html` at the root of this example application includes the CDN link to the latest npm package. 
 For testing purposes, however, we want to use the locally built Stencil components. 
-When not working on the Master branch, per default, the CDN link will point to the locally built components in the ```dist``` folder.
+When not working on the Master branch, per default, the CDN links will point to the locally built components in the ```dist``` folder as well as the stylesheet.
 To test the compiled components locally, follow the steps below.
 
 ## Run locally

--- a/examples/stencil-components/vanilla-cdn/update-link.js
+++ b/examples/stencil-components/vanilla-cdn/update-link.js
@@ -1,43 +1,57 @@
 const fs = require('fs');
 const path = require('path');
 
+// Path to the index.html file
 const indexHtmlPath = path.join(__dirname, '/index.html');
+
+// Determine if the current branch is master
 const isMaster = process.env.GITHUB_REF === 'refs/heads/master';
 
-console.log("is local", process.env.GITHUB_REF === undefined)
-
+// Read the content of index.html
 const htmlContent = fs.readFileSync(indexHtmlPath, 'utf-8');
 
-const scriptRegex = /<\s*script[^>]+src\s*=\s*['"]\s?(https:\/\/www\.googletagservices\.com\/tag\/js\/gpt\.js)*([^'" ]+)\s*["'][^>]*><\/script>/gis
-// const stylesheetRegex = /<\s*link[^>]+href\s*=\s*['"]\s?(https:\/\/www\.googletagservices\.com\/tag\/js\/gpt\.js)*([^'" ]+)\s*["'][^>]*>/gis
+// Define regex patterns to match both local dist and CDN script tags for JS and link tags for CSS files
+const scriptRegex = /<\s*script[^>]+src\s*=\s*['"]\s?(https:\/\/cdn\.jsdelivr\.net\/npm\/@infineon\/infineon-design-system-stencil[^'" ]*\.esm\.js|\.\/dist\/infineon-design-system-stencil\/infineon-design-system-stencil\.esm\.js)\s*["'][^>]*><\/script>/gis;
+const stylesheetRegex = /<\s*link[^>]+href\s*=\s*['"]\s?(https:\/\/cdn\.jsdelivr\.net\/npm\/@infineon\/infineon-design-system-stencil[^'" ]*\.css|\.\/dist\/infineon-design-system-stencil\/infineon-design-system-stencil\.css)\s*["'][^>]*>/gis;
 
+// Load the current version from the package.json file
 const version = require('../../../packages/components/package.json').version;
 
-const cdnLinkLatest = '<script type="module" src="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil/dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>';
-const cdnLinkCanary = `<script type="module" src="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil@${version}/dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>`;
+// Define the CDN links
+const cdnLinkLatestJS = '<script type="module" src="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil/dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>';
+const cdnLinkCanaryJS = `<script type="module" src="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil@${version}/dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>`;
 
-// const cdnStylesheetLatest = `<script type="module" src="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil/dist/infineon-design-system-stencil/infineon-design-system-stencil.css"></script>`;
-// const cdnStylesheetCanary = `<script type="module" src="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil@${version}/dist/infineon-design-system-stencil/infineon-design-system-stencil.css"></script>`;
+const cdnLinkLatestCSS = '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil/dist/infineon-design-system-stencil/infineon-design-system-stencil.css">';
+const cdnLinkCanaryCSS = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil@${version}/dist/infineon-design-system-stencil/infineon-design-system-stencil.css">`;
 
-const localLink = '<script type="module" src="./dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>';
-// const localStylesheet = '<link rel="stylesheet" href="dist/infineon-design-system-stencil/infineon-design-system-stencil.css">';
+// Define the local links
+const localLinkJS = '<script type="module" src="./dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>';
+const localLinkCSS = '<link rel="stylesheet" href="./dist/infineon-design-system-stencil/infineon-design-system-stencil.css">';
 
+// Determine the new source links based on the environment
 let newScriptSrc;
-// let newStylesheet
+let newStylesheetSrc;
 
-console.log("current branch: ", process.env.GITHUB_REF, " - package version: ", require('../../../packages/components/package.json').version);
+console.log("current branch: ", process.env.GITHUB_REF, " - package version: ", version);
 
 if (process.env.GITHUB_REF === undefined) {
-  newScriptSrc = localLink;
-  // newStylesheet = localStylesheet;
+  newScriptSrc = localLinkJS;
+  newStylesheetSrc = localLinkCSS;
 } else {
-  newScriptSrc = isMaster ? cdnLinkLatest : cdnLinkCanary;
-  // newStylesheet = isMaster ? cdnStylesheetLatest : cdnStylesheetCanary;
-
+  newScriptSrc = isMaster ? cdnLinkLatestJS : cdnLinkCanaryJS;
+  newStylesheetSrc = isMaster ? cdnLinkLatestCSS : cdnLinkCanaryCSS;
 }
-const updatedScriptSrc = htmlContent.replace(scriptRegex, newScriptSrc);
-// const updatedScriptSrcAndStylesheet = updatedScriptSrc.replace(stylesheetRegex, newStylesheet);
 
-fs.writeFileSync(indexHtmlPath, updatedScriptSrc, 'utf-8');
+console.log("newScriptSrc: ", newScriptSrc);
+console.log("newStylesheetSrc: ", newStylesheetSrc);
 
-console.log("updated: ", newScriptSrc);
+// Replace local dist or CDN links with the appropriate new CDN links in the HTML content
+const updatedHtmlContent = htmlContent
+  .replace(scriptRegex, newScriptSrc)
+  .replace(stylesheetRegex, newStylesheetSrc);
+
+// Write the updated content back to index.html
+fs.writeFileSync(indexHtmlPath, updatedHtmlContent, 'utf-8');
+
+console.log("updated JS link: ", newScriptSrc);
+console.log("updated CSS link: ", newStylesheetSrc);

--- a/examples/stencil-components/vanilla-cdn/vite.config.js
+++ b/examples/stencil-components/vanilla-cdn/vite.config.js
@@ -1,9 +1,8 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-
+  base: "./",
   server: {
-
     watch: {
       // Watch the 'dist' folder for changes
       include: 'dist/**',

--- a/examples/wrapper-components/react-vite-js/package-lock.json
+++ b/examples/wrapper-components/react-vite-js/package-lock.json
@@ -8,7 +8,7 @@
       "name": "react-vite",
       "version": "0.0.0",
       "dependencies": {
-        "@infineon/infineon-design-system-react": "27.6.1--canary.1606.c941b7a8e662121a96c584103cceb26e361f035b.0",
+        "@infineon/infineon-design-system-react": "27.10.2--canary.1561.a4d4de4a99a2d695989b5647678078289a0219eb.0",
         "path": "^0.12.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -2188,21 +2188,21 @@
       }
     },
     "node_modules/@infineon/infineon-design-system-react": {
-      "version": "27.6.1--canary.1606.c941b7a8e662121a96c584103cceb26e361f035b.0",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-react/-/infineon-design-system-react-27.6.1--canary.1606.c941b7a8e662121a96c584103cceb26e361f035b.0.tgz",
-      "integrity": "sha512-5e8p8xHSl0dFR0wFXdvWPcoJcRPibi5n2LeMpX7BzSxFNcqohDtVMHidphFUjtVH7NbawlMAAZCts/vCUQw5bg==",
+      "version": "27.10.2--canary.1561.a4d4de4a99a2d695989b5647678078289a0219eb.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-react/-/infineon-design-system-react-27.10.2--canary.1561.a4d4de4a99a2d695989b5647678078289a0219eb.0.tgz",
+      "integrity": "sha512-MbaJGC19ylNNXCkHtjc0iYdAi3BYqNesg2q9gcAez8DqNGCHS0xDGTvfy5xfCKBJO0BY0haE+vooZWs5M+NLDA==",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.6.1--canary.1606.c941b7a8e662121a96c584103cceb26e361f035b.0",
+        "@infineon/infineon-design-system-stencil": "^27.10.2--canary.1561.a4d4de4a99a2d695989b5647678078289a0219eb.0",
         "@stencil/react-output-target": "^0.7.1"
       }
     },
     "node_modules/@infineon/infineon-design-system-stencil": {
-      "version": "27.6.1--canary.1606.c941b7a8e662121a96c584103cceb26e361f035b.0",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-27.6.1--canary.1606.c941b7a8e662121a96c584103cceb26e361f035b.0.tgz",
-      "integrity": "sha512-brPWIDn7S58RHp90BvMCJYsUGacXxm7w+1QtbwZx+ThGhfQzb8XJTNTy5rIDcByrdcAUaKMg1reSAjJsxoHTrg==",
+      "version": "27.10.2--canary.1561.a4d4de4a99a2d695989b5647678078289a0219eb.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-27.10.2--canary.1561.a4d4de4a99a2d695989b5647678078289a0219eb.0.tgz",
+      "integrity": "sha512-bYEe7N6ZaAB9uAbmtt5SdDA+YpPqyCrYfxMiR4Xv/C760nnH47or1YU6mAz99TZSh+YNyBCrpXC4ZQxwPd/m9g==",
       "dependencies": {
-        "@infineon/design-system-tokens": "3.3.3",
+        "@infineon/design-system-tokens": "3.3.4",
         "@infineon/infineon-icons": "^2.1.2",
         "@popperjs/core": "^2.11.8",
         "@stencil/angular-output-target": "^0.9.0",
@@ -2222,6 +2222,15 @@
         "@floating-ui/dom": "^1.4.5",
         "ag-grid-community": "^31.0.3",
         "choices.js": "^10.2.0"
+      }
+    },
+    "node_modules/@infineon/infineon-design-system-stencil/node_modules/@infineon/design-system-tokens": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@infineon/design-system-tokens/-/design-system-tokens-3.3.4.tgz",
+      "integrity": "sha512-mtvrP1nF961V4bxZHhIgNT7FOJf+y6jWyhacgVny6IoP/W3I2ZkBF3erwwxQLHOec9hP2LHhtdMtXQRuDRVHSg==",
+      "dependencies": {
+        "@tokens-studio/sd-transforms": "^0.10.5",
+        "sass": "^1.78.0"
       }
     },
     "node_modules/@infineon/infineon-icons": {
@@ -3058,9 +3067,9 @@
       }
     },
     "node_modules/@storybook/codemod/node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
+      "integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -3449,9 +3458,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.5.tgz",
-      "integrity": "sha512-4ZOwtk2bqG5Y6xRGHcveZVr+6txkH7M2e+nPFd6guSoN638v/1XQ0K06eOpi0ptVU/2tW/pIU4IoPotY/GZ9fw==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.6.tgz",
+      "integrity": "sha512-exZyLcEnHgDMKc54TtHca4McV4sKT+NKAe9ix/yhd/qkYb/TP8HTyXRFDijV19qKqTZM0hPL4753zU/U8L/gAA==",
       "dependencies": {
         "tinyrainbow": "^1.2.0"
       },
@@ -3471,11 +3480,11 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.5.tgz",
-      "integrity": "sha512-yfj6Yrp0Vesw2cwJbP+cl04OC+IHFsuQsrsJBL9pyGeQXE56v1UAOQco+SR55Vf1nQzfV0QJg1Qum7AaWUwwYg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.6.tgz",
+      "integrity": "sha512-ixNkFy3k4vokOUTU2blIUvOgKq/N2PW8vKIjZZYsGJCMX69MRa9J2sKqX5hY/k5O5Gty3YJChepkqZ3KM9LyIQ==",
       "dependencies": {
-        "@vitest/pretty-format": "2.1.5",
+        "@vitest/pretty-format": "2.1.6",
         "loupe": "^3.1.2",
         "tinyrainbow": "^1.2.0"
       },
@@ -4358,9 +4367,9 @@
       }
     },
     "node_modules/create-storybook/node_modules/prettier": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
-      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
+      "integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4842,7 +4851,11 @@
     "node_modules/es-toolkit": {
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.27.0.tgz",
-      "integrity": "sha512-ETSFA+ZJArcuSCpzD2TjAy6UHpx4E4uqFsoDg9F/nTLogrLmVVZQ+zNxco5h7cWnA1nNak07IXsLcaSMih+ZPQ=="
+      "integrity": "sha512-ETSFA+ZJArcuSCpzD2TjAy6UHpx4E4uqFsoDg9F/nTLogrLmVVZQ+zNxco5h7cWnA1nNak07IXsLcaSMih+ZPQ==",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.24.0",
@@ -5321,9 +5334,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.254.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.254.1.tgz",
-      "integrity": "sha512-dyUrQD6ZyI4PVQppj8PP5kj6BVThK8FprAcPCnJNLIZM7zcAL6/xGS1EE1haWv2HcO/dHy7GSwOAO59uaffjYw==",
+      "version": "0.255.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.255.0.tgz",
+      "integrity": "sha512-7QHV2m2mIMh6yIMaAPOVbyNEW77IARwO69d4DgvfDCjuORiykdMLf7XBjF7Zeov7Cpe1OXJ8sB6/aaCE3xuRBw==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7086,6 +7099,13 @@
         "validate-npm-package-name",
         "which",
         "write-file-atomic"
+      ],
+      "workspaces": [
+        "docs",
+        "smoke-tests",
+        "mock-globals",
+        "mock-registry",
+        "workspaces/*"
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+    "@infineon/infineon-design-system-react": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+    "@infineon/infineon-design-system-react": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+    "@infineon/infineon-design-system-vue": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^3.0.1",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+    "@infineon/infineon-design-system-vue": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^3.0.1",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+  "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+  "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33598,7 +33598,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+      "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
@@ -33660,7 +33660,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+      "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33671,7 +33671,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+        "@infineon/infineon-design-system-angular": "^27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33689,61 +33689,14 @@
         "ng-packagr": "^18.2.0"
       }
     },
-    "packages/components-angular/projects/component-library": {
-      "name": "@infineon/infineon-design-system-angular",
+    "packages/components-angular/node_modules/@infineon/infineon-design-system-stencil": {
       "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0.tgz",
+      "integrity": "sha512-cC1RDzSg3GQ9Qn2GRTtoDraKCOApmvzBcwkECaP9Cc2IfiPQ5xLzfal1AGLrCDciuzS6ZmqhHGrmX0w/n7N7nQ==",
       "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^18.0.0",
-        "@angular/core": "^18.0.0",
-        "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0"
-      }
-    },
-    "packages/components-react": {
-      "name": "@infineon/infineon-design-system-react",
-      "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
-      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
-        "@stencil/react-output-target": "^0.7.1"
-      },
-      "devDependencies": {
-        "@types/node": "^20.1.4",
-        "@types/react": "^18.2.6",
-        "@types/react-dom": "^18.2.4",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
-        "typescript": "^5.0.4"
-      }
-    },
-    "packages/components-vue": {
-      "name": "@infineon/infineon-design-system-vue",
-      "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
-      "license": "MIT",
-      "dependencies": {
-        "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0"
-      },
-      "devDependencies": {
-        "@babel/types": "^7.22.5",
-        "@types/node": "^20.2.5",
-        "rollup": "^4.1.4",
-        "rollup-plugin-node-resolve": "^5.2.0",
-        "typescript": "^5.0.4",
-        "vue": "^3.2.47"
-      }
-    },
-    "packages/components-vue/node_modules/@infineon/infineon-design-system-stencil": {
-      "version": "27.10.1",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-27.10.1.tgz",
-      "integrity": "sha512-y7Fhpgm+eFi975CsMFt7AqWEj1ClMujfRP7A7qToNFWD59hXdKeIg6YaJze92aIF6mefretPuXDqoDydEADdQg==",
-      "dependencies": {
-        "@infineon/design-system-tokens": "3.3.3",
         "@infineon/infineon-icons": "^2.1.2",
         "@popperjs/core": "^2.11.8",
         "@stencil/angular-output-target": "^0.9.0",
@@ -33765,74 +33718,22 @@
         "choices.js": "^10.2.0"
       }
     },
-    "packages/components-vue/node_modules/@infineon/infineon-design-system-stencil/node_modules/@infineon/design-system-tokens": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@infineon/design-system-tokens/-/design-system-tokens-3.3.3.tgz",
-      "integrity": "sha512-AfDvgUz2wkOtPpK6m0/ETh+8irjMPM/QyJhU3DOj4KFrBstCOrXXeKOCy3d1cFdSFEVDwVveyba6360tlTxhvw==",
-      "dependencies": {
-        "@tokens-studio/sd-transforms": "^0.10.5",
-        "sass": "^1.78.0"
-      }
-    },
-    "packages/components-vue/node_modules/@parcel/watcher": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
-      "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.5",
-        "node-addon-api": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.5.0",
-        "@parcel/watcher-darwin-arm64": "2.5.0",
-        "@parcel/watcher-darwin-x64": "2.5.0",
-        "@parcel/watcher-freebsd-x64": "2.5.0",
-        "@parcel/watcher-linux-arm-glibc": "2.5.0",
-        "@parcel/watcher-linux-arm-musl": "2.5.0",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.0",
-        "@parcel/watcher-linux-arm64-musl": "2.5.0",
-        "@parcel/watcher-linux-x64-glibc": "2.5.0",
-        "@parcel/watcher-linux-x64-musl": "2.5.0",
-        "@parcel/watcher-win32-arm64": "2.5.0",
-        "@parcel/watcher-win32-ia32": "2.5.0",
-        "@parcel/watcher-win32-x64": "2.5.0"
-      }
-    },
-    "packages/components-vue/node_modules/brace-expansion": {
+    "packages/components-angular/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
-    "packages/components-vue/node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "optional": true,
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "packages/components-vue/node_modules/glob": {
+    "packages/components-angular/node_modules/glob": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
       "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "license": "ISC",
+      "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^4.0.1",
@@ -33851,15 +33752,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/components-vue/node_modules/immutable": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
-      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw=="
-    },
-    "packages/components-vue/node_modules/jackspeak": {
+    "packages/components-angular/node_modules/jackspeak": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
       "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -33870,18 +33768,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/components-vue/node_modules/lru-cache": {
+    "packages/components-angular/node_modules/lru-cache": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
       "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "20 || >=22"
       }
     },
-    "packages/components-vue/node_modules/minimatch": {
+    "packages/components-angular/node_modules/minimatch": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
       "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -33892,16 +33794,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/components-vue/node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "optional": true
-    },
-    "packages/components-vue/node_modules/path-scurry": {
+    "packages/components-angular/node_modules/path-scurry": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
       "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
         "minipass": "^7.1.2"
@@ -33913,23 +33811,53 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "packages/components-vue/node_modules/sass": {
-      "version": "1.81.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.81.0.tgz",
-      "integrity": "sha512-Q4fOxRfhmv3sqCLoGfvrC9pRV8btc0UtqL9mN6Yrv6Qi9ScL55CVH1vlPP863ISLEEMNLLuu9P+enCeGHlnzhA==",
+    "packages/components-angular/projects/component-library": {
+      "name": "@infineon/infineon-design-system-angular",
+      "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
+      "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
-        "source-map-js": ">=0.6.2 <2.0.0"
+        "tslib": "^2.3.0"
       },
-      "bin": {
-        "sass": "sass.js"
+      "peerDependencies": {
+        "@angular/common": "^18.0.0",
+        "@angular/core": "^18.0.0",
+        "@infineon/design-system-tokens": "3.3.4",
+        "@infineon/infineon-design-system-stencil": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0"
+      }
+    },
+    "packages/components-react": {
+      "name": "@infineon/infineon-design-system-react",
+      "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
+      "license": "MIT",
+      "dependencies": {
+        "@infineon/design-system-tokens": "3.3.4",
+        "@infineon/infineon-design-system-stencil": "^27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
+        "@stencil/react-output-target": "^0.7.1"
       },
-      "engines": {
-        "node": ">=14.0.0"
+      "devDependencies": {
+        "@types/node": "^20.1.4",
+        "@types/react": "^18.2.6",
+        "@types/react-dom": "^18.2.4",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "typescript": "^5.0.4"
+      }
+    },
+    "packages/components-vue": {
+      "name": "@infineon/infineon-design-system-vue",
+      "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
+      "license": "MIT",
+      "dependencies": {
+        "@infineon/design-system-tokens": "3.3.4",
+        "@infineon/infineon-design-system-stencil": "^27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0"
       },
-      "optionalDependencies": {
-        "@parcel/watcher": "^2.4.1"
+      "devDependencies": {
+        "@babel/types": "^7.22.5",
+        "@types/node": "^20.2.5",
+        "rollup": "^4.1.4",
+        "rollup-plugin-node-resolve": "^5.2.0",
+        "typescript": "^5.0.4",
+        "vue": "^3.2.47"
       }
     },
     "packages/components/node_modules/@parcel/watcher": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -339,6 +339,60 @@
         }
       }
     },
+    "node_modules/@angular/build/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.4.tgz",
+      "integrity": "sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@angular/build/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/@angular/build/node_modules/rollup": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
+      "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.22.4",
+        "@rollup/rollup-android-arm64": "4.22.4",
+        "@rollup/rollup-darwin-arm64": "4.22.4",
+        "@rollup/rollup-darwin-x64": "4.22.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.22.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.22.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.22.4",
+        "@rollup/rollup-linux-arm64-musl": "4.22.4",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.22.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.22.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.22.4",
+        "@rollup/rollup-linux-x64-gnu": "4.22.4",
+        "@rollup/rollup-linux-x64-musl": "4.22.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.22.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.22.4",
+        "@rollup/rollup-win32-x64-msvc": "4.22.4",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "18.2.12",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.12.tgz",
@@ -3090,10 +3144,9 @@
       }
     },
     "node_modules/@infineon/design-system-tokens": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@infineon/design-system-tokens/-/design-system-tokens-3.3.3.tgz",
-      "integrity": "sha512-AfDvgUz2wkOtPpK6m0/ETh+8irjMPM/QyJhU3DOj4KFrBstCOrXXeKOCy3d1cFdSFEVDwVveyba6360tlTxhvw==",
-      "license": "MIT",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@infineon/design-system-tokens/-/design-system-tokens-3.3.4.tgz",
+      "integrity": "sha512-mtvrP1nF961V4bxZHhIgNT7FOJf+y6jWyhacgVny6IoP/W3I2ZkBF3erwwxQLHOec9hP2LHhtdMtXQRuDRVHSg==",
       "dependencies": {
         "@tokens-studio/sd-transforms": "^0.10.5",
         "sass": "^1.78.0"
@@ -6665,9 +6718,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.4.tgz",
-      "integrity": "sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
+      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
       "cpu": [
         "x64"
       ],
@@ -28717,13 +28770,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
-      "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
+      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -28733,22 +28786,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.22.4",
-        "@rollup/rollup-android-arm64": "4.22.4",
-        "@rollup/rollup-darwin-arm64": "4.22.4",
-        "@rollup/rollup-darwin-x64": "4.22.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.22.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.22.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.22.4",
-        "@rollup/rollup-linux-arm64-musl": "4.22.4",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.22.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.22.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.22.4",
-        "@rollup/rollup-linux-x64-gnu": "4.22.4",
-        "@rollup/rollup-linux-x64-musl": "4.22.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.22.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.22.4",
-        "@rollup/rollup-win32-x64-msvc": "4.22.4",
+        "@rollup/rollup-android-arm-eabi": "4.24.0",
+        "@rollup/rollup-android-arm64": "4.24.0",
+        "@rollup/rollup-darwin-arm64": "4.24.0",
+        "@rollup/rollup-darwin-x64": "4.24.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
+        "@rollup/rollup-linux-arm64-musl": "4.24.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-gnu": "4.24.0",
+        "@rollup/rollup-linux-x64-musl": "4.24.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
+        "@rollup/rollup-win32-x64-msvc": "4.24.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -28794,13 +28847,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/rollup/node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -33552,10 +33598,10 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+      "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
       "license": "MIT",
       "dependencies": {
-        "@infineon/design-system-tokens": "3.3.3",
+        "@infineon/design-system-tokens": "3.3.4",
         "@infineon/infineon-icons": "^2.1.2",
         "@popperjs/core": "^2.11.8",
         "@stencil/angular-output-target": "^0.9.0",
@@ -33614,7 +33660,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+      "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33625,7 +33671,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+        "@infineon/infineon-design-system-angular": "^27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33645,7 +33691,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+      "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33653,17 +33699,17 @@
       "peerDependencies": {
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
-        "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0"
+        "@infineon/design-system-tokens": "3.3.4",
+        "@infineon/infineon-design-system-stencil": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+      "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
       "license": "MIT",
       "dependencies": {
-        "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+        "@infineon/design-system-tokens": "3.3.4",
+        "@infineon/infineon-design-system-stencil": "^27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33680,7 +33726,7 @@
       "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
       "license": "MIT",
       "dependencies": {
-        "@infineon/design-system-tokens": "3.3.3",
+        "@infineon/design-system-tokens": "3.3.4",
         "@infineon/infineon-design-system-stencil": "^27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0"
       },
       "devDependencies": {
@@ -33690,6 +33736,200 @@
         "rollup-plugin-node-resolve": "^5.2.0",
         "typescript": "^5.0.4",
         "vue": "^3.2.47"
+      }
+    },
+    "packages/components-vue/node_modules/@infineon/infineon-design-system-stencil": {
+      "version": "27.10.1",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-27.10.1.tgz",
+      "integrity": "sha512-y7Fhpgm+eFi975CsMFt7AqWEj1ClMujfRP7A7qToNFWD59hXdKeIg6YaJze92aIF6mefretPuXDqoDydEADdQg==",
+      "dependencies": {
+        "@infineon/design-system-tokens": "3.3.3",
+        "@infineon/infineon-icons": "^2.1.2",
+        "@popperjs/core": "^2.11.8",
+        "@stencil/angular-output-target": "^0.9.0",
+        "@stencil/core": "^4.22.3",
+        "@stencil/vue-output-target": "^0.8.9",
+        "@storybook/cli": "^8.3.0",
+        "@storybook/test": "^8.3.0",
+        "babel-prettier-parser": "^0.10.8",
+        "classnames": "^2.3.2",
+        "glob": "^11.0.0",
+        "i": "^0.3.7",
+        "npm": "^10.2.1",
+        "npm-run-all": "^4.1.5",
+        "prettier-standalone": "^1.3.1-0"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.4.5",
+        "ag-grid-community": "^31.0.3",
+        "choices.js": "^10.2.0"
+      }
+    },
+    "packages/components-vue/node_modules/@infineon/infineon-design-system-stencil/node_modules/@infineon/design-system-tokens": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@infineon/design-system-tokens/-/design-system-tokens-3.3.3.tgz",
+      "integrity": "sha512-AfDvgUz2wkOtPpK6m0/ETh+8irjMPM/QyJhU3DOj4KFrBstCOrXXeKOCy3d1cFdSFEVDwVveyba6360tlTxhvw==",
+      "dependencies": {
+        "@tokens-studio/sd-transforms": "^0.10.5",
+        "sass": "^1.78.0"
+      }
+    },
+    "packages/components-vue/node_modules/@parcel/watcher": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
+      "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.5",
+        "node-addon-api": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.0",
+        "@parcel/watcher-darwin-arm64": "2.5.0",
+        "@parcel/watcher-darwin-x64": "2.5.0",
+        "@parcel/watcher-freebsd-x64": "2.5.0",
+        "@parcel/watcher-linux-arm-glibc": "2.5.0",
+        "@parcel/watcher-linux-arm-musl": "2.5.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.0",
+        "@parcel/watcher-linux-arm64-musl": "2.5.0",
+        "@parcel/watcher-linux-x64-glibc": "2.5.0",
+        "@parcel/watcher-linux-x64-musl": "2.5.0",
+        "@parcel/watcher-win32-arm64": "2.5.0",
+        "@parcel/watcher-win32-ia32": "2.5.0",
+        "@parcel/watcher-win32-x64": "2.5.0"
+      }
+    },
+    "packages/components-vue/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/components-vue/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "optional": true,
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "packages/components-vue/node_modules/glob": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/components-vue/node_modules/immutable": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
+      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw=="
+    },
+    "packages/components-vue/node_modules/jackspeak": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
+      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/components-vue/node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/components-vue/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/components-vue/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "optional": true
+    },
+    "packages/components-vue/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/components-vue/node_modules/sass": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.81.0.tgz",
+      "integrity": "sha512-Q4fOxRfhmv3sqCLoGfvrC9pRV8btc0UtqL9mN6Yrv6Qi9ScL55CVH1vlPP863ISLEEMNLLuu9P+enCeGHlnzhA==",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.0.2",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "packages/components/node_modules/@parcel/watcher": {

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+  "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+    "@infineon/infineon-design-system-angular": "^27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+  "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+    "@infineon/infineon-design-system-angular": "^27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+  "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -10,8 +10,8 @@
   "peerDependencies": {
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
-    "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0"
+    "@infineon/design-system-tokens": "3.3.4",
+    "@infineon/infineon-design-system-stencil": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+  "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0"
+    "@infineon/infineon-design-system-stencil": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+  "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+    "@infineon/infineon-design-system-stencil": "^27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+  "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -27,8 +27,8 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+    "@infineon/design-system-tokens": "3.3.4",
+    "@infineon/infineon-design-system-stencil": "^27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+  "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0"
+    "@infineon/infineon-design-system-stencil": "^27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -29,7 +29,7 @@
     "vue": "^3.2.47"
   },
   "dependencies": {
-    "@infineon/design-system-tokens": "3.3.3",
+    "@infineon/design-system-tokens": "3.3.4",
     "@infineon/infineon-design-system-stencil": "^27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0"
   },
   "auto": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
+  "version": "27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "27.10.1--canary.1614.4c1f8184f6750e71bf0d0b3e4fe35f74dd4d91c9.0",
+  "version": "27.10.2--canary.1561.afb921d3a8890d36a78f57e7a161786a69162891.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",
@@ -38,7 +38,7 @@
     "storybook": "npm run process:design-tokens && npm run dev"
   },
   "dependencies": {
-    "@infineon/design-system-tokens": "3.3.3",
+    "@infineon/design-system-tokens": "3.3.4",
     "@infineon/infineon-icons": "^2.1.2",
     "@popperjs/core": "^2.11.8",
     "@stencil/angular-output-target": "^0.9.0",


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Use canary release of Tokens package to consume fonts from CDN
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@27.10.2--canary.1561.333cd73f994eeebe23606e192659070c1e9b6a73.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
