### PR TITLE
Navbar-item: removed max-height

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+    "@infineon/infineon-design-system-react": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+    "@infineon/infineon-design-system-vue": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^3.0.1",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+  "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -32830,7 +32830,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+      "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -32892,7 +32892,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+      "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -32903,7 +32903,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+        "@infineon/infineon-design-system-angular": "^25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -32923,7 +32923,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+      "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32932,16 +32932,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0"
+        "@infineon/infineon-design-system-stencil": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+      "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+        "@infineon/infineon-design-system-stencil": "^25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -32955,11 +32955,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+      "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0"
+        "@infineon/infineon-design-system-stencil": "^25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+  "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+    "@infineon/infineon-design-system-angular": "^25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+  "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0"
+    "@infineon/infineon-design-system-stencil": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+  "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+    "@infineon/infineon-design-system-stencil": "^25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+  "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0"
+    "@infineon/infineon-design-system-stencil": "^25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "25.17.0--canary.1559.42abb5e5aa04343a514dcb1cb092bb45972759a5.0",
+  "version": "25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/navigation/navbar/navbar-item.scss
+++ b/packages/components/src/components/navigation/navbar/navbar-item.scss
@@ -189,7 +189,6 @@
   visibility: visible;
   flex-direction: column;
   width: 224px;
-  max-height: 289px;
   min-width: 224px;
   background: tokens.$ifxColorBaseWhite;
   box-shadow: 0px 6px 9px 0px #1d1d1d1a;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Navbar menu now has no max height and will display all items at once.

Related Issue
#1548

Context
![Screenshot 2024-11-06 095710](https://github.com/user-attachments/assets/ae0aecfa-874b-4bc4-b524-70bddce2de34)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@25.17.1--canary.1564.3f949f032ad1ef5384e3224642054812c6d2794d.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
