### PR TITLE
Stepper: implemented `emittedByClick` key in event object emitted by ifxChange

### DIFF
--- a/examples/wrapper-components/react-vite-js/package-lock.json
+++ b/examples/wrapper-components/react-vite-js/package-lock.json
@@ -8,7 +8,7 @@
       "name": "react-vite",
       "version": "0.0.0",
       "dependencies": {
-        "@infineon/infineon-design-system-react": "27.4.0--canary.1546.b5fce8c8dbb50fe969e40ce89859c2aa305d7275.0",
+        "@infineon/infineon-design-system-react": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
         "path": "^0.12.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -2225,12 +2225,13 @@
       }
     },
     "node_modules/@infineon/infineon-design-system-react": {
-      "version": "27.4.0--canary.1546.b5fce8c8dbb50fe969e40ce89859c2aa305d7275.0",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-react/-/infineon-design-system-react-27.4.0--canary.1546.b5fce8c8dbb50fe969e40ce89859c2aa305d7275.0.tgz",
-      "integrity": "sha512-5IFuHoKQOca86lEuyLJ9pq/b5U9hxFWhm0PV6Cx83/PwcppD7GdlaCIqypaUfQksjFjqQgD7mLHoVEuX2jhsiw==",
+      "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-react/-/infineon-design-system-react-27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0.tgz",
+      "integrity": "sha512-8m1JsYtsk68RjqPM4rMVngDxFX43zuzWpTMo1yD8Dt53YdLZtQw97Rby3pXW8Ktqs/Y1ortLS0ms8eeBjO1fAw==",
+      "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.4.0--canary.1546.b5fce8c8dbb50fe969e40ce89859c2aa305d7275.0",
+        "@infineon/infineon-design-system-stencil": "^27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
         "@stencil/react-output-target": "^0.7.1"
       }
     },
@@ -12390,6 +12391,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tiny-invariant": {

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+    "@infineon/infineon-design-system-react": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+    "@infineon/infineon-design-system-react": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+    "@infineon/infineon-design-system-vue": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^3.0.1",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+    "@infineon/infineon-design-system-vue": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^3.0.1",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+  "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33114,7 +33114,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+      "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -33176,7 +33176,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+      "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33187,7 +33187,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+        "@infineon/infineon-design-system-angular": "^27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33207,7 +33207,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+      "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33216,16 +33216,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0"
+        "@infineon/infineon-design-system-stencil": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+      "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+        "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33239,11 +33239,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+      "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0"
+        "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33114,7 +33114,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+      "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -33176,7 +33176,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+      "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33187,7 +33187,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+        "@infineon/infineon-design-system-angular": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33205,38 +33205,9 @@
         "ng-packagr": "^18.2.0"
       }
     },
-    "packages/components-angular/node_modules/@infineon/infineon-design-system-stencil": {
-      "version": "27.4.0--canary.1546.b5fce8c8dbb50fe969e40ce89859c2aa305d7275.0",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-27.4.0--canary.1546.b5fce8c8dbb50fe969e40ce89859c2aa305d7275.0.tgz",
-      "integrity": "sha512-ugLTSEMjpY+1LJd6QuIaiUQv0m0RXrlpaGIP6m3yVZIJZ1gTpVx445zbnU7Pa/mNh1485erOfFuV9cD8H6lwEA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-icons": "^2.1.2",
-        "@popperjs/core": "^2.11.8",
-        "@stencil/angular-output-target": "^0.9.0",
-        "@stencil/core": "^4.21.0",
-        "@stencil/vue-output-target": "^0.8.9",
-        "@storybook/cli": "^8.3.0",
-        "@storybook/test": "^8.3.0",
-        "babel-prettier-parser": "^0.10.8",
-        "classnames": "^2.3.2",
-        "glob": "^11.0.0",
-        "i": "^0.3.7",
-        "npm": "^10.2.1",
-        "npm-run-all": "^4.1.5",
-        "prettier-standalone": "^1.3.1-0"
-      },
-      "peerDependencies": {
-        "@floating-ui/dom": "^1.4.5",
-        "ag-grid-community": "^31.0.3",
-        "choices.js": "^10.2.0"
-      }
-    },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+      "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33245,16 +33216,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0"
+        "@infineon/infineon-design-system-stencil": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+      "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+        "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33268,11 +33239,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+      "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0"
+        "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+  "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+    "@infineon/infineon-design-system-angular": "^27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+    "@infineon/infineon-design-system-angular": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+  "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0"
+    "@infineon/infineon-design-system-stencil": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0"
+    "@infineon/infineon-design-system-stencil": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+    "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+  "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+    "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0"
+    "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+  "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0"
+    "@infineon/infineon-design-system-stencil": "^27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
+  "version": "27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "27.4.0--canary.1546.5f1f339a711276b02a5fc6abf4698fd5124335c0.0",
+  "version": "27.5.0--canary.1594.282ed30fa151dee36223c4b57398835230de6831.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/stepper/interfaces.tsx
+++ b/packages/components/src/components/stepper/interfaces.tsx
@@ -4,6 +4,6 @@ export interface StepperState {
     showStepNumber: boolean;
     variant: 'default' | 'compact';
 
-    setActiveStep?(stepId: number): null;
+    setActiveStep?(stepId: number, setByClick: boolean): null;
 }
   

--- a/packages/components/src/components/stepper/step/step.tsx
+++ b/packages/components/src/components/stepper/step/step.tsx
@@ -49,13 +49,13 @@ export class Step {
 
     handleStepClick() {
         if (!this.disabled && this.stepperState.variant === 'default' && (this.clickable || this.complete)) {
-            this.stepperState.setActiveStep(this.stepId)
+            this.stepperState.setActiveStep(this.stepId, true)
         } 
     }
 
     handleStepKeyDown(event: KeyboardEvent) {
         if (!this.disabled && this.stepperState.variant === 'default' && (this.clickable || this.complete) && event.key === 'Enter') {
-            this.stepperState.setActiveStep(this.stepId)
+            this.stepperState.setActiveStep(this.stepId, true)
         } 
     }
     

--- a/packages/components/src/components/stepper/step/step.tsx
+++ b/packages/components/src/components/stepper/step/step.tsx
@@ -52,18 +52,24 @@ export class Step {
             this.stepperState.setActiveStep(this.stepId, true)
         } 
     }
-
+    
     handleStepKeyDown(event: KeyboardEvent) {
         if (!this.disabled && this.stepperState.variant === 'default' && (this.clickable || this.complete) && event.key === 'Enter') {
             this.stepperState.setActiveStep(this.stepId, true)
         } 
     }
     
+    stopOnClickPropogation(event: Event) {
+        if (this.disabled) {
+            event.stopPropagation();
+        }
+    }
 
     render() {
         return (
             <div aria-current = {this.active ? 'step': false}
                 aria-disabled = {this.active || this.complete ? false : true}
+                onClick={ (e) => this.stopOnClickPropogation(e) }
                 class = {`step-wrapper ${this.stepId === 1 ? 'first-step': ''} 
                         ${this.error ? 'error': ''}
                         ${this.stepperState.variant}

--- a/packages/components/src/components/stepper/stepper.tsx
+++ b/packages/components/src/components/stepper/stepper.tsx
@@ -29,6 +29,7 @@ export class Stepper {
 
     @State() stepsCount: number;
     @State() shouldEmitEvent: boolean = true;
+    @State() emittedByClick: boolean = false;
 
     @Listen('ifxChange') 
     onStepChange(event: CustomEvent) {
@@ -77,11 +78,14 @@ export class Stepper {
             }
         }
     }
-
+    
     emitIfxChange(activeStep: number, previousActiveStep: number) {
         this.ifxChange.emit({activeStep: activeStep, 
             previousActiveStep: previousActiveStep, 
-            totalSteps: this.stepsCount });
+            totalSteps: this.stepsCount,
+            emittedByClick: this.emittedByClick
+        });
+        this.emittedByClick = false;
     }
 
     getSteps() {
@@ -100,7 +104,8 @@ export class Stepper {
     }
 
 
-    setActiveStep(stepId: number) {
+    setActiveStep(stepId: number, setByClick: boolean = false) {
+        this.emittedByClick = setByClick;
         this.activeStep = stepId;
     }
 

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -16,9 +16,8 @@
 
 </head>
 
-<body>  
-  
+<body> 
+   
 </body>
-
 
 </html>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Description
Implement `emittedByClick` key in event object emitted by ifxChange. If the step is changed because of click or keydown, the `emittedByClick` is true and false otherwise.

Prevent onClick on ifx-step from being emitted when the step is disabled.

Related Issue
#1593 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@27.5.0--canary.1594.e63b3f19519a5b90a61f1de91e6da41e228efd96.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
