### PR TITLE
Accessibility enhancement added to Chip

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+    "@infineon/infineon-design-system-react": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+    "@infineon/infineon-design-system-react": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+    "@infineon/infineon-design-system-vue": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^3.0.1",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+    "@infineon/infineon-design-system-vue": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^3.0.1",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+  "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+  "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -32828,7 +32828,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+      "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -32890,7 +32890,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+      "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -32901,7 +32901,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+        "@infineon/infineon-design-system-angular": "^27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -32921,7 +32921,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+      "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32930,16 +32930,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0"
+        "@infineon/infineon-design-system-stencil": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+      "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+        "@infineon/infineon-design-system-stencil": "^27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -32953,11 +32953,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+      "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0"
+        "@infineon/infineon-design-system-stencil": "^27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33552,7 +33552,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+      "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
@@ -33614,7 +33614,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+      "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33625,7 +33625,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+        "@infineon/infineon-design-system-angular": "^27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33645,7 +33645,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+      "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33654,16 +33654,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0"
+        "@infineon/infineon-design-system-stencil": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+      "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+        "@infineon/infineon-design-system-stencil": "^27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33677,11 +33677,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+      "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.3",
-        "@infineon/infineon-design-system-stencil": "^27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0"
+        "@infineon/infineon-design-system-stencil": "^27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+  "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+    "@infineon/infineon-design-system-angular": "^27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+  "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+    "@infineon/infineon-design-system-angular": "^27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+  "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0"
+    "@infineon/infineon-design-system-stencil": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+  "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0"
+    "@infineon/infineon-design-system-stencil": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+  "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+    "@infineon/infineon-design-system-stencil": "^27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+  "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+    "@infineon/infineon-design-system-stencil": "^27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+  "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0"
+    "@infineon/infineon-design-system-stencil": "^27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+  "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.3",
-    "@infineon/infineon-design-system-stencil": "^27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0"
+    "@infineon/infineon-design-system-stencil": "^27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "27.6.0--canary.1592.b2cdfef3d8997e95872e807946cdcac6b87a3624.0",
+  "version": "27.7.0--canary.1605.7ba22fd39f5274d51878f29368bea7b1126f59d2.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "27.8.0--canary.1609.b2cfda25e6222becf92d02be7d4ef6fb386afdab.0",
+  "version": "27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/chip/chip-item/chip-item.scss
+++ b/packages/components/src/components/chip/chip-item/chip-item.scss
@@ -22,6 +22,10 @@
     &:active {
         background-color: tokens.$ifxColorEngineering300;
     }
+
+    &:focus {
+        outline: 2px solid tokens.$ifxColorOcean500;
+    }
     
     &.chip-item--large {
         font: tokens.$ifxBodyBody03;

--- a/packages/components/src/components/chip/chip-item/chip-item.tsx
+++ b/packages/components/src/components/chip/chip-item/chip-item.tsx
@@ -91,8 +91,9 @@ render() {
                     chip-item--${(this.selected && this.chipState.variant) === 'single' ? 'selected' : ''}`} 
            tabIndex={0}
            onClick={() => {this.handleItemClick()}}
-           onKeyDown={(e) => {this.handleItemKeyDown(e)}}>
-
+           onKeyDown={(e) => {this.handleItemKeyDown(e)}}
+           role="option"
+           aria-selected={this.selected.toString()}>    
            {/* Checkbox; renders only in 'multi' variant. */}
            { 
                this.chipState.variant === 'multi' &&

--- a/packages/components/src/components/chip/chip.scss
+++ b/packages/components/src/components/chip/chip.scss
@@ -31,6 +31,10 @@
         outline: none;
         border: 1px solid tokens.$ifxColorEngineering500;
     }
+
+    &:focus {
+        border: 1px solid tokens.$ifxColorOcean500;
+    }
     
     &.chip__wrapper--small {
         padding: tokens.$ifxSpace50 tokens.$ifxSpace150;

--- a/packages/components/src/components/chip/chip.tsx
+++ b/packages/components/src/components/chip/chip.tsx
@@ -42,6 +42,20 @@ export class Chip {
     }
   }
 
+  @Listen('keydown')
+  handleKeyDown(event: KeyboardEvent) {
+    // override behavior of all keys except Tab. Users should be able to tab out of the component.
+    if (event.code !== 'Tab') {
+      event.preventDefault(); 
+    }
+
+    if ((event.target as HTMLElement).tagName === 'IFX-CHIP') {
+      this.handleWrapperKeyDown(event);
+    } else if ((event.target as HTMLElement).tagName === 'IFX-CHIP-ITEM') {
+      this.handleDropdownKeyDown(event);
+    }
+  }
+
   @Listen('ifxChipItemSelect')
   updateSelectedOptions(event: CustomEvent<ChipItemSelectEvent>) {
     const eventDetail: ChipItemSelectEvent = event.detail;
@@ -102,6 +116,38 @@ export class Chip {
     this.opened = !this.opened;
   }
 
+  /**
+   * Focuses the chip item at the specified index.
+   * @param index the index of the chip item to focus. -1 will focus the last chip item.
+   */
+  focusChipItemAt(index: number = 0) {
+    this.opened = true;
+    const chipItems: NodeList = this.getChipItems();
+    let item: HTMLIfxChipItemElement;
+    
+    if (index === -1) {
+      item = chipItems.item(chipItems.length - 1) as HTMLIfxChipItemElement;
+    } else if (index >= 0 && index < chipItems.length) {
+      item = chipItems.item(index) as HTMLIfxChipItemElement;
+    } else {
+      console.error(`Invalid index: ${index}`);
+      return;
+    }
+
+    const shadowItem = item.shadowRoot.querySelector('.chip-item') as HTMLDivElement;
+    if (shadowItem) {
+      // Delay needed for the shadow item to be rendered.
+      setTimeout(() => {
+        shadowItem.focus();
+      }, 1);
+    }
+  }
+
+  focusChip() {
+    const chipWrapper: HTMLElement = this.chip.shadowRoot.querySelector('.chip__wrapper');
+    chipWrapper.focus();
+  }
+
   handleUnselectButtonClick(event: MouseEvent) {
     event.stopPropagation();
     this.opened = false;
@@ -139,10 +185,67 @@ export class Chip {
   }
 
   handleWrapperKeyDown(event: KeyboardEvent) {
-    if (!this.readOnly && (event.code === 'Space' || event.code === 'Enter')) {
-      this.toggleDropdownMenu();
+    // Keymap oriented at https://www.w3.org/WAI/ARIA/apg/patterns/combobox/#keyboard_interaction
+    if (this.readOnly) return;
+
+    if (!this.opened) {
+      switch (event.code) {
+        case 'Space':
+        case 'Enter':
+        case 'ArrowDown':
+          this.focusChipItemAt(0);
+          break;
+        case 'ArrowUp':
+          this.focusChipItemAt(-1);
+          break;
+      }
+    } else {
+      switch (event.code) {
+        case 'Escape':
+          this.opened = false;
+          this.focusChip();
+          break;
+      }
     }
   }
+
+  handleDropdownKeyDown(event: KeyboardEvent) {
+    let chipitems = this.getChipItems();
+
+    let targetIndex = Array.from(chipitems).indexOf(event.target as HTMLIfxChipItemElement);
+    if (targetIndex === -1) {
+      console.error('Target not found in chip items');
+      return;
+    }
+
+    switch (event.code) {
+      case 'ArrowDown':
+        if (targetIndex === chipitems.length - 1) break;
+        this.focusChipItemAt(targetIndex + 1);
+        break;
+      case 'ArrowUp':
+        if (targetIndex === 0) break;
+        this.focusChipItemAt( targetIndex - 1);
+        break;
+      case 'Escape':
+        this.opened = false;
+        this.focusChip();
+        break;
+      case 'Space':
+        // selection is handled by the chip-item component
+        if (this.variant === 'single') {
+          // only close dropdown if single select
+          this.opened = false;
+          this.focusChip();
+        }
+        break;
+      case 'Enter':
+        // selection is handled by the chip-item component
+        this.opened = false;
+        this.focusChip();
+        break;
+      }
+    }
 
   syncChipState() {
     const chipItems: NodeList = this.getChipItems();
@@ -200,7 +303,6 @@ export class Chip {
                   ${this.selectedOptions.length ? 'chip__wrapper--selected' : ''}`}
           tabIndex={0}
           onClick={!this.readOnly ? () => { this.handleWrapperClick() } : undefined}
-          onKeyDown={!this.readOnly ? (e) => { this.handleWrapperKeyDown(e) } : undefined}
           role='combobox'
           aria-label={this.AriaLabel}
           aria-value={this.getSelectedOptions()}

--- a/packages/components/src/components/chip/chip.tsx
+++ b/packages/components/src/components/chip/chip.tsx
@@ -15,6 +15,7 @@ export class Chip {
   @Prop({ mutable: true }) value: Array<string> | string = undefined;
   @Prop() variant: 'single' | 'multi' = 'single';
   @Prop() readOnly: boolean = false;
+  @Prop() AriaLabel: string;
 
   @State() opened: boolean = false;
   @State() selectedOptions: Array<ChipItemSelectEvent> = [];
@@ -192,14 +193,23 @@ export class Chip {
 
   render() {
     return (
-      <div aria-value={this.getSelectedOptions()} aria-label='chip with a dropdown menu' class='chip'>
+      <div class='chip'>
         <div class={`chip__wrapper chip__wrapper--${this.size === 'small' ? 'small' : 'large'}
                   chip__wrapper--${this.variant === 'multi' ? 'multi' : 'single'}
                   ${this.opened && !this.readOnly ? 'chip__wrapper--opened' : ''}
                   ${this.selectedOptions.length ? 'chip__wrapper--selected' : ''}`}
           tabIndex={0}
           onClick={!this.readOnly ? () => { this.handleWrapperClick() } : undefined}
-          onKeyDown={!this.readOnly ? (e) => { this.handleWrapperKeyDown(e) } : undefined}>
+          onKeyDown={!this.readOnly ? (e) => { this.handleWrapperKeyDown(e) } : undefined}
+          role='combobox'
+          aria-label={this.AriaLabel}
+          aria-value={this.getSelectedOptions()}
+          aria-haspopup={!this.readOnly ? 'listbox' : undefined}
+          aria-expanded={!this.readOnly ? this.opened.toString() : undefined}
+          aria-controls={!this.readOnly ? 'dropdown' : undefined}
+          aria-readonly={this.readOnly ? 'true' : undefined}
+          aria-multiselectable={this.variant === 'multi' ? 'true' : undefined}
+          >
 
           <div class='wrapper__label'>
             {
@@ -250,7 +260,7 @@ export class Chip {
 
         {
           this.opened && !this.readOnly &&
-          <div class='chip__dropdown'>
+          <div id='dropdown' role='listbox' class='chip__dropdown'>
             <slot />
           </div>
         }

--- a/packages/components/src/components/chip/readme.md
+++ b/packages/components/src/components/chip/readme.md
@@ -9,6 +9,7 @@
 
 | Property      | Attribute     | Description | Type                  | Default     |
 | ------------- | ------------- | ----------- | --------------------- | ----------- |
+| `AriaLabel`   | `aria-label`  |             | `string`              | `undefined` |
 | `placeholder` | `placeholder` |             | `string`              | `''`        |
 | `readOnly`    | `read-only`   |             | `boolean`             | `false`     |
 | `size`        | `size`        |             | `"large" \| "small"`  | `'large'`   |


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
- Added Aria attributes
- Added keyboard control
- Added focus styling

Related Issue
#1264 

Context
<details>
<summary>WCAG Guidelines Checklist</summary>

Guideline num | Guideline | Level | Summary | Status | Comments
-- | -- | -- | -- | -- | --
1.1.1 | Non-text   Content | A | Provide text   alternatives for non-text content | Not Applicable |  
1.2.1 | Audio-only and Video-only (Pre-recorded) | A | Provide an alternative to video-only and audio-only content | Not Applicable |  
1.2.2 | Captions   (Pre-recorded) | A | Provide   captions for videos with audio | Not Applicable |  
1.2.3 | Audio Description or Media Alternative (Pre-recorded) | A | Video with audio has a second alternative | Not Applicable |  
1.2.4 | Captions (Live) | AA | Live videos   have captions | Not Applicable |  
1.2.5 | Audio Description (Pre-recorded) | AA | Users have access to audio description for video content | Not Applicable |  
1.2.6 | Sign Language   (Pre-recorded) | AAA | Provide sign   language translations for videos | Not Applicable |  
1.2.7 | Extended Audio description (Pre-recorded) | AAA | Provide extended audio description for videos | Not Applicable |  
1.2.8 | Media   Alternative (Pre-recorded) | AAA | Provide a text   alternative to videos | Not Applicable |  
1.2.9 | Audio Only (Live) | AAA | Provide alternatives for live audio | Not Applicable |  
1.3.1 | Info and   Relationships | A | Logical   structure | Passing |  
1.3.2 | Meaningful Sequence | A | Present content in a meaningful order | Passing |  
1.3.3 | Sensory   Characteristics | A | Use more than   one sense for instructions | Passing |  
1.3.4 | Orientation (WCAG 2.1) | AA | Content can be display in portrait and landscape   orientation | Passing |  
1.3.5 | Identify Input   Purpose (WCAG 2.1) | AA | Each input   field must be able to be determined programmatically, a user should be able   for example to autofill inputs | Passing |  
1.3.6 | Identify Purpose (WCAG 2.1) | AAA | Interface components, icons and landmarks (sections,   article, main, etc.) must be able to be identified programmatically to help   navigation for assistive technologies | Passing |  
1.4.1 | Use of Colour | A | Don’t use   presentation that relies solely on colour | Passing |  
1.4.2 | Audio Control | A | Don’t play audio automatically | Not Applicable |  
1.4.3 | Contrast   (Minimum) | AA | Contrast ratio   between text and background is at least 4.5:1 | Passing |  
1.4.4 | Resize Text | AA | Text can be resized to 200% without loss of content or   function | Passing |  
1.4.5 | Images of Text | AA | Don’t use   images of text | Passing |  
1.4.6 | Contrast (Enhanced) | AAA | Contrast ratio between text and background is at least 7:1 | Failing | If selected: 4.7:1
1.4.7 | Low or No   Background Audio | AAA | Audio is clear   for listeners to hear | Not Applicable |  
1.4.8 | Visual Presentation | AAA | Offer users a range of presentation options | Failing |  
1.4.9 | Images of Text   (No Exception) | AAA | Don’t use   images of text | Passing |  
1.4.10 | Reflow (WCAG 2.1) | AA | User must be able to browse a website using a 320 pixel   wide screen without having to scroll horizontally (There are some exceptions) | Passing |  
1.4.11 | Non-Text   Contrast  (WCAG 2.1) | AA | Extend color   contrast of at least 3:1 to non-text content such as infographics, diagrams,   states, etc. | Passing |  
1.4.12 | Text Spacing  (WCAG   2.1) | AA | Changing text style properties shouldn't break the page   (line height, spacing after paragraph, letter spacing, word spacing) | Passing |  
1.4.13 | Content on   Hover or Focus  (WCAG 2.1) | AA | Elements that   are being shown on focus or hover (skip navigation, tooltip) should be   dismissible(Esc), hoverable, persistent | Passing |  
2.1.1 | Keyboard | A | Accessible by keyboard only | Passing |  
2.1.2 | No Keyboard   Trap | A | Don’t trap   keyboard users | Passing |  
2.1.3 | Keyboard (No Exception) | AAA | Accessible by keyboard only, without exception | Passing |  
2.1.4 | Character Key   Shortcuts (WCAG 2.1) | A | If using single   letter keyboard shortcut, the shortcut should be able to be turn off, or   remap, or active only on focus | Passing |  
2.2.1 | Timing Adjustable | A | Time limits have user controls | Not Applicable |  
2.2.2 | Pause, Stop,   Hide | A | Provide user   controls for moving content | Not Applicable |  
2.2.3 | No Timing | AAA | No time limits | Passing |  
2.2.4 | Interruptions | AAA | Don’t interrupt   users | Passing |  
2.2.5 | Re-authenticating | AAA | Save user data when re-authenticating | Not Applicable |  
2.2.6 | Timeouts  (WCAG 2.1) | AAA | Users should be   warned if user inactivity could cause data loss, unless data is preserved for   more than 20h | Not Applicable |  
2.3.1 | Three Flashes or Below | A | No content flashes more than three times per second | Passing |  
2.3.2 | Three Flashes | AAA | No content   flashes more than three times per second | Passing |  
2.3.3 | Animation from Interactions    (WCAG 2.1) | AAA | Motion animation triggered by interaction can be disabled | Not Applicable |  
2.4.1 | Bypass Blocks | A | Provide a ‘Skip   to Content’ link | Not Applicable |  
2.4.10 | Section Headings | AAA | Break up content with headings | Not Applicable |  
2.4.11 | Focus Not   Obscured (Minimum) (WCAG 2.2) | AA | When a user   interface component receives keyboard focus, the component is not entirely   hidden due to author-created content. | Passing |  
2.4.12 | Focus Not Obscured (Enhanced) (WCAG 2.2) | AAA | When a user interface component receives keyboard focus, no   part of the component is hidden by author-created content. | Passing |  
2.4.13 | Focus   Appearance (WCAG 2.2) | AAA | The keyboard   focus indicator is at least 2 pixel thick and has a contrast ratio of at   least 3:1 to the unfocused state | Failing | only   1px
2.4.2 | Page Titled | A | Use helpful and clear page titles | Not Applicable |  
2.4.3 | Focus Order | A | Logical order | Passing |  
2.4.4 | Link Purpose (In Context) | A | Every link’s purpose is clear from its context | Not Applicable |  
2.4.5 | Multiple Ways | AA | Offer several   ways to find pages | Not Applicable |  
2.4.6 | Headings and Labels | AA | Use clear headings and labels | Passing |  
2.4.7 | Focus Visible | AA | Ensure keyboard   focus is visible and clear | Passing |  
2.4.8 | Location | AAA | Let users know where they are within a set of web pages | Not Applicable |  
2.4.9 | Link Purpose   (Link Only) | AAA | Every link’s   purpose is clear from its text | Passing |  
2.5.1 | Pointer Gestures (WCAG 2.1) | A | Complex gesture (Pinch, zooming, swiping) should have a   simpler gesture alternative (Tap, double taps, long press) | Not Applicable |  
2.5.2 | Pointer   Cancellation  (WCAG 2.1) | A | When using   single pointer events, one of the following should be true, No Down-Event,   Abort or Undo, Up Reversal, Essential | Passing |  
2.5.3 | Label in Name (WCAG 2.1) | A | Text in buttons or label should be readable by assistant   technologies and can be used with Text-to-speech | Passing |  
2.5.4 | Motion   Actuation  (WCAG 2.1) | A | Functionalities   trigger by moving the device should have a fallback without (Eg some apps use   shake to undo) | Not Applicable |  
2.5.5 | Target Size (WCAG 2.1) | AAA | The size of the target for pointer inputs is at least 44 by   44 CSS pixels | Failing | Height: 37px
2.5.6 | Concurrent   Input Mechanisms (WCAG 2.1) | AAA | Inputs must to   available to use with a different mechanism (Mouse, keyboard, stylus, touch,   voice) | Passing |  
2.5.7 | Dragging Movements    (WCAG 2.2) | AA | All functionality that uses a dragging movement for   operation can be achieved by a single pointer without dragging unless   essential or functionality determined by user agent | Not Applicable |  
2.5.8 | Target Size   (Minimum)  (WCAG 2.2) | AA | The size of the   target for pointer inputs is at least 24 by 24 CSS pixels, except where:   spacing, equivalent, inline, user agent control, essential | Passing |  
3.1.1 | Language of Page | A | Page has a language assigned | Not Applicable |  
3.1.2 | Language of   Parts | AA | Tell users when   the language on a page changes | Not Applicable |  
3.1.3 | Unusual words | AAA | Explain any strange words | Not Applicable |  
3.1.4 | Abbreviations | AAA | Explain any   abbreviations | Not Applicable |  
3.1.5 | Reading Level | AAA | Users with nine years of school can read your content | Not Applicable |  
3.1.6 | Pronunciation | AAA | Explain any   words that are hard to pronounce | Not Applicable |  
3.2.1 | On Focus | A | Elements do not change when they receive focus | Passing |  
3.2.2 | On Input | A | Elements do not   change when they receive input | Passing |  
3.2.3 | Consistent Navigation | AA | Use menus consistently | Passing |  
3.2.4 | Consistent   Identification | AA | Use icons and   buttons consistently | Passing |  
3.2.5 | Change on Request | AAA | Don’t change elements on your website until users ask | Passing |  
3.2.6 | Consistent Help   (WCAG 2.2) | A | Help mechanisms   are available on every page in the same manner | Not Applicable |  
3.3.1 | Error Identification | A | Clearly identify input errors | Not Applicable |  
3.3.2 | Labels or   Instructions | A | Label elements   and give instructions | Not Applicable |  
3.3.3 | Error Suggestion | AA | Suggest fixes when users make errors | Not Applicable |  
3.3.4 | Error   Prevention (Legal, Financial, Data) | AA | Reduce the risk   of input errors for sensitive data | Not Applicable |  
3.3.5 | Help | AAA | Provide detailed help and instructions | Not Applicable |  
3.3.6 | Error   Prevention (All) | AAA | Reduce the risk   of all input errors | Not Applicable |  
3.3.7 | Redundant Entry (WCAG 2.2) | A | Information previously entered by or provided to the user   that is required to be entered again in the same process is either   auto-populated or available to select (Exceptions) | Not Applicable |  
3.3.8 | Accessible   Authentication (Minimum) (WCAG 2.2) | AA | A cognitive   function test is not required in authentication unless at least one of the   following is met: alternative, mechanism, object recognition, personal   content | Not Applicable |  
3.3.9 | Accessible Authentication (Enhanced) (WCAG 2.2) | AAA | A cognitive function test is not required in authentication   unless at least one of the following is met: alternative, mechanism | Not Applicable |  
4.1.1 | Parsing   (removed in WCAG 2.2) | A | No major code   errors | Passing |  
4.1.2 | Name, Role, Value | A | Build all components for accessibility | Passing |  
4.1.3 | Status Messages   (WCAG 2.1) | AA | Content that is   updated dynamically must be notified to users of assistive technologies   without getting visual focus | Passing |  

</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@27.9.0--canary.1605.19960d33529b5d614ba2c1c9bbb39603c08ce922.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
