### PR TITLE
Navbar: added condition that checks if right-items exist before querying them to prevent edge case errors

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+    "@infineon/infineon-design-system-react": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+    "@infineon/infineon-design-system-vue": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+  "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33598,7 +33598,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+      "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
@@ -33660,7 +33660,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+      "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33671,7 +33671,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+        "@infineon/infineon-design-system-angular": "^29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33689,131 +33689,9 @@
         "ng-packagr": "^18.2.0"
       }
     },
-    "packages/components-angular/node_modules/@infineon/infineon-design-system-stencil": {
-      "version": "29.2.0--canary.1633.e59bc7aded7cbd7a27b2dc639beeb9422cc5896f.0",
-      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-29.2.0--canary.1633.e59bc7aded7cbd7a27b2dc639beeb9422cc5896f.0.tgz",
-      "integrity": "sha512-Mj69U6ZBlFUzMsGLU21HBcf4n+Xkn9Y57m8/GM6XIGBqLlicp584nN7luPH5rA0bURqTFNq9cKourWgZW17AXw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-icons": "^2.1.2",
-        "@popperjs/core": "^2.11.8",
-        "@stencil/angular-output-target": "^0.9.0",
-        "@stencil/core": "^4.22.3",
-        "@stencil/vue-output-target": "^0.8.9",
-        "@storybook/cli": "^8.3.0",
-        "@storybook/test": "^8.3.0",
-        "babel-prettier-parser": "^0.10.8",
-        "classnames": "^2.3.2",
-        "glob": "^11.0.0",
-        "i": "^0.3.7",
-        "npm": "^10.2.1",
-        "npm-run-all": "^4.1.5",
-        "prettier-standalone": "^1.3.1-0"
-      },
-      "peerDependencies": {
-        "@floating-ui/dom": "^1.4.5",
-        "ag-grid-community": "^31.0.3",
-        "choices.js": "^10.2.0"
-      }
-    },
-    "packages/components-angular/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "packages/components-angular/node_modules/glob": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
-      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^4.0.1",
-        "minimatch": "^10.0.0",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/components-angular/node_modules/jackspeak": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
-      "integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/components-angular/node_modules/lru-cache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "packages/components-angular/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/components-angular/node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+      "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33822,16 +33700,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0"
+        "@infineon/infineon-design-system-stencil": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+      "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+        "@infineon/infineon-design-system-stencil": "^29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33845,11 +33723,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+      "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0"
+        "@infineon/infineon-design-system-stencil": "^29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+  "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+    "@infineon/infineon-design-system-angular": "^29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+  "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0"
+    "@infineon/infineon-design-system-stencil": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+  "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+    "@infineon/infineon-design-system-stencil": "^29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+  "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0"
+    "@infineon/infineon-design-system-stencil": "^29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "29.2.0--canary.1633.214aed990d3de1b50c30dd8bb0eef450e5c3bee8.0",
+  "version": "29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/navigation/navbar/navbar.tsx
+++ b/packages/components/src/components/navigation/navbar/navbar.tsx
@@ -426,7 +426,9 @@ export class Navbar {
         if(this.searchBarIsOpen) { 
           searchBarRight.onNavbarMobile()
         }
-        searchBarRight.setAttribute('slot', 'search-bar-left')
+        if(searchBarRight) { 
+          searchBarRight.setAttribute('slot', 'search-bar-left')
+        }
       }
 
       //left-side


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

This is an edge case. Under some circumstances, when the page loads on a mobile, the right-items are not hidden inside the
navbar mobile menu, and thus, when you expand the screen, an error occurs because the items inside the menu are being queried but they don't exist.
This PR adds a condition that checks if searchBarRight exists before attempting to query it.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@29.2.1--canary.1638.b8df42a289a6ff6eb917dbf3f987e4b3899cfdce.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
