### PR TITLE
Basic-table: Reverts back noRowsOverlayComponentParams prop

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+    "@infineon/infineon-design-system-react": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+    "@infineon/infineon-design-system-vue": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+  "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33022,7 +33022,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+      "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33084,7 +33084,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+      "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33095,7 +33095,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+        "@infineon/infineon-design-system-angular": "^30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33207,7 +33207,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+      "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33216,16 +33216,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0"
+        "@infineon/infineon-design-system-stencil": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+      "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+        "@infineon/infineon-design-system-stencil": "^30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33325,11 +33325,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+      "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0"
+        "@infineon/infineon-design-system-stencil": "^30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+  "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+    "@infineon/infineon-design-system-angular": "^30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+  "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0"
+    "@infineon/infineon-design-system-stencil": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+  "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+    "@infineon/infineon-design-system-stencil": "^30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+  "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0"
+    "@infineon/infineon-design-system-stencil": "^30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "30.2.0--canary.1641.2fa3dc92b1652a9ad0c0488d80e396bc04aab9d2.0",
+  "version": "30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/table-basic-version/table.tsx
+++ b/packages/components/src/components/table-basic-version/table.tsx
@@ -45,6 +45,10 @@ export class Table {
       rowData: this.rowData,
       loadingOverlayComponent: CustomLoadingOverlay,
       noRowsOverlayComponent: CustomNoRowsOverlay,
+      noRowsOverlayComponentParams: {
+        noRowsMessageFunc: () =>
+          'No rows found at: ' + new Date().toLocaleTimeString(),
+      },
       icons: {
         sortAscending: '<ifx-icon icon="arrowtriangleup16"></ifx-icon>',
         sortDescending: '<ifx-icon icon="arrowtriangledown16"></ifx-icon>',


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Reverts back previously removed noRowsOverlayComponentParams param. 
Useful for when dynamically populating cols and rows on initial load.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@30.3.0--canary.1642.f54a68597876cb1b2caf62d3f28c120024d5938a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
