### PR TITLE
Single-select: clears select field when options updated

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+    "@infineon/infineon-design-system-react": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+    "@infineon/infineon-design-system-vue": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -32831,7 +32831,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+      "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -32893,7 +32893,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+      "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -32904,7 +32904,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+        "@infineon/infineon-design-system-angular": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33010,7 +33010,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+      "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33019,16 +33019,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0"
+        "@infineon/infineon-design-system-stencil": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+      "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+        "@infineon/infineon-design-system-stencil": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33128,11 +33128,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+      "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0"
+        "@infineon/infineon-design-system-stencil": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+    "@infineon/infineon-design-system-angular": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0"
+    "@infineon/infineon-design-system-stencil": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+    "@infineon/infineon-design-system-stencil": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0"
+    "@infineon/infineon-design-system-stencil": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "30.5.0--canary.1653.e0dbd3314b37fb8bdea4791ccaa98bb5bd212c8f.0",
+  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/select/single-select/select.tsx
+++ b/packages/components/src/components/select/single-select/select.tsx
@@ -100,11 +100,15 @@ export class Choices implements IChoicesProps, IChoicesMethods {
 
   handleDeleteSelection() {
     this.clearInput()
-    this.selectedOption = null;
+    this.clearSelectField()
     this.setPreSelected(null);
     this.closeDropdown();
-    this.ifxSelect.emit(null);
     this.optionIsSelected = false;
+  }
+
+  clearSelectField() { 
+    this.selectedOption = null;
+    this.ifxSelect.emit(null);
   }
 
   @Method()
@@ -288,8 +292,10 @@ export class Choices implements IChoicesProps, IChoicesMethods {
 
   protected componentWillUpdate() { 
     this.handleCloseButton()
-    
+    this.clearSelectField()
   }
+
+
 
   addResizeObserver() { 
     this.resizeObserver = new ResizeObserver(() => {


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Clears the select field when the options array has been dynamically updated
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
