### PR TITLE
Advanced-table: removes bug where default sort order icon appears

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+    "@infineon/infineon-design-system-react": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+    "@infineon/infineon-design-system-vue": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+  "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -32831,7 +32831,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+      "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -32893,7 +32893,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+      "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -32904,7 +32904,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+        "@infineon/infineon-design-system-angular": "^30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33010,7 +33010,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+      "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33019,16 +33019,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0"
+        "@infineon/infineon-design-system-stencil": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+      "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+        "@infineon/infineon-design-system-stencil": "^30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33128,11 +33128,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+      "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0"
+        "@infineon/infineon-design-system-stencil": "^30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+  "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+    "@infineon/infineon-design-system-angular": "^30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+  "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0"
+    "@infineon/infineon-design-system-stencil": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+  "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+    "@infineon/infineon-design-system-stencil": "^30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+  "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0"
+    "@infineon/infineon-design-system-stencil": "^30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "30.5.1--canary.1655.9885959d458e06593271685d632a6120c4904eb3.0",
+  "version": "30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/table-advanced-version/table.scss
+++ b/packages/components/src/components/table-advanced-version/table.scss
@@ -190,6 +190,10 @@
   line-height: 12px;
 }
 
+.ag-sort-indicator-container .ag-sort-order { 
+  display: none;
+}
+
 .unsort-icon-custom-color {
   color: tokens.$ifxColorEngineering400;
 }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Removes edge case bug where the ag-grid default sort order icon appears next to the custom inserted sort icon.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@30.6.1--canary.1656.b5da1c2957da9e94993bc4cab18fa31e2fd1e681.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
