### PR TITLE
Tabs: removes focus state on mouse click

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+    "@infineon/infineon-design-system-react": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+    "@infineon/infineon-design-system-react": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+    "@infineon/infineon-design-system-vue": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+    "@infineon/infineon-design-system-vue": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+  "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -32794,7 +32794,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+      "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -32856,7 +32856,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+      "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -32867,7 +32867,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+        "@infineon/infineon-design-system-angular": "^30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -32887,6 +32887,46 @@
     },
     "packages/components-angular/node_modules/@infineon/design-system-tokens": {
       "version": "3.3.4",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tokens-studio/sd-transforms": "^0.10.5",
+        "sass": "^1.78.0"
+      }
+    },
+    "packages/components-angular/node_modules/@infineon/infineon-design-system-stencil": {
+      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+      "resolved": "https://registry.npmjs.org/@infineon/infineon-design-system-stencil/-/infineon-design-system-stencil-30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0.tgz",
+      "integrity": "sha512-rkwQRIT3CcxFpdbrYHk+Bm3jJ5CPj1BYderl4BnHXujDHW1K0P/neje5kXOeMa5Vm+NRnGMw5G619ZN4luf+Sg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@infineon/design-system-tokens": "4.0.0",
+        "@infineon/infineon-icons": "^2.1.2",
+        "@popperjs/core": "^2.11.8",
+        "@stencil/angular-output-target": "^0.9.0",
+        "@stencil/core": "^4.22.3",
+        "@stencil/vue-output-target": "^0.8.9",
+        "@storybook/cli": "^8.3.0",
+        "@storybook/test": "^8.3.0",
+        "babel-prettier-parser": "^0.10.8",
+        "classnames": "^2.3.2",
+        "glob": "^11.0.0",
+        "i": "^0.3.7",
+        "npm": "^10.2.1",
+        "npm-run-all": "^4.1.5",
+        "prettier-standalone": "^1.3.1-0"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.4.5",
+        "ag-grid-community": "^31.0.3",
+        "choices.js": "^10.2.0"
+      }
+    },
+    "packages/components-angular/node_modules/@infineon/infineon-design-system-stencil/node_modules/@infineon/design-system-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@infineon/design-system-tokens/-/design-system-tokens-4.0.0.tgz",
+      "integrity": "sha512-UlIcFwZzZhoj9mUiORDIsJJjSm/Gew8EgYtX5AMgItBaa9Zk7TLnPMGlswAbGhmVg/7E2XvysuLZjdQ2znH5Nw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -32973,7 +33013,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+      "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32982,16 +33022,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0"
+        "@infineon/infineon-design-system-stencil": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+      "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+        "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33091,11 +33131,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+      "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0"
+        "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32794,7 +32794,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -32856,7 +32856,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -32867,7 +32867,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+        "@infineon/infineon-design-system-angular": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -32973,7 +32973,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32982,16 +32982,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0"
+        "@infineon/infineon-design-system-stencil": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+        "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33091,11 +33091,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+      "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0"
+        "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+  "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+    "@infineon/infineon-design-system-angular": "^30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+    "@infineon/infineon-design-system-angular": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0"
+    "@infineon/infineon-design-system-stencil": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+  "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0"
+    "@infineon/infineon-design-system-stencil": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+    "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+  "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+    "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0"
+    "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+  "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0"
+    "@infineon/infineon-design-system-stencil": "^30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -36,7 +36,7 @@ module.exports = {
         display: block;
         content: 'Latest Version ${await getLatestLibraryVersion()}';
         margin: 10px 0 0 0;
-        color: #005DA9;
+        color: #0A8276;
         font-size: 18px;
         font-weight: bold;
     }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "30.8.1--canary.1587.ff537897bd122fea275421fcf2bf3c45f289dbbf.0",
+  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "30.9.1--canary.1663.b0c0128f4fe868e8faedc420ffb95f1e622c3a82.0",
+  "version": "30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/tabs/tabs.tsx
+++ b/packages/components/src/components/tabs/tabs.tsx
@@ -242,7 +242,7 @@ export class IfxTabs {
             <li
               class={this.getTabItemClass(index)}
               ref={(el) => (this.tabHeaderRefs[index] = el)}
-              tabindex="0"
+              onMouseDown={(event) => event.preventDefault()}
               onClick={() => this.handleClick(tab, index)}
               aria-selected={index === this.internalActiveTabIndex ? 'true' : 'false'}
               aria-disabled={tab.disabled ? 'true' : 'false'}


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Removes the focus state on mouse click over a tab
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@30.9.1--canary.1663.04cb986ccd7894a97ab77b9bea18e02ca81adbee.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
