### PR TITLE
Updates version 2 of date-picker in the overview table in Storybook

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+    "@infineon/infineon-design-system-react": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+    "@infineon/infineon-design-system-react": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+    "@infineon/infineon-design-system-vue": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+    "@infineon/infineon-design-system-vue": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+  "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -32794,7 +32794,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+      "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -32856,7 +32856,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+      "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -32867,7 +32867,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+        "@infineon/infineon-design-system-angular": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -32973,7 +32973,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+      "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32982,16 +32982,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0"
+        "@infineon/infineon-design-system-stencil": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+      "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+        "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33091,11 +33091,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+      "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0"
+        "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32794,7 +32794,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+      "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -32856,7 +32856,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+      "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -32867,7 +32867,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+        "@infineon/infineon-design-system-angular": "^30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -32973,7 +32973,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+      "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -32982,16 +32982,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0"
+        "@infineon/infineon-design-system-stencil": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+      "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+        "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33091,11 +33091,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+      "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "3.3.4",
-        "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0"
+        "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+    "@infineon/infineon-design-system-angular": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+  "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+    "@infineon/infineon-design-system-angular": "^30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0"
+    "@infineon/infineon-design-system-stencil": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+  "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0"
+    "@infineon/infineon-design-system-stencil": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+  "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+    "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+    "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+  "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0"
+    "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "3.3.4",
-    "@infineon/infineon-design-system-stencil": "^30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0"
+    "@infineon/infineon-design-system-stencil": "^30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/.storybook/exported-sass-array.json
+++ b/packages/components/.storybook/exported-sass-array.json
@@ -1030,13 +1030,8 @@
     "compiledValue": "1200px"
   },
   {
-    "name": "$ifxBreakpoint2xl",
+    "name": "$ifxBreakpointXxl",
     "value": "1400px",
     "compiledValue": "1400px"
-  },
-  {
-    "name": "$ifxBreakpoint3xl",
-    "value": "1920px",
-    "compiledValue": "1920px"
   }
 ]

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
+  "version": "30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "30.9.2--canary.1673.aae465494350113a03d5687dfe66c3823dc98f42.0",
+  "version": "30.9.3--canary.1679.8d0c83c3f0040ae0386585c5203298c7d94911f3.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/overview-table/overview-table.tsx
+++ b/packages/components/src/components/overview-table/overview-table.tsx
@@ -501,7 +501,18 @@ export class OverviewTable {
                   </td>
                   <td >
                     <ul>
-
+                      <li>
+                        <span>
+                          <ifx-icon class='check__icon' icon="check12"></ifx-icon>
+                        </span>
+                        <span>Range</span>
+                      </li>
+                      <li>
+                        <span>
+                          <ifx-icon class='check__icon' icon="check12"></ifx-icon>
+                        </span>
+                        <span>Default value</span>
+                      </li>
                     </ul>
                   </td>
                   <td></td>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Added `range` and `default value` features on the version 2 of the date-picker on the table overview.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@30.9.3--canary.1679.da8e517594310046a5539f2999ea3bac886d652e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
