### PR TITLE
Revert back stencil version to 4.27.2

### DIFF
--- a/.github/workflows/github_pages_storybook_master.yml
+++ b/.github/workflows/github_pages_storybook_master.yml
@@ -1,6 +1,5 @@
 name: Deploy Master Storybook
 on:
-  workflow_dispatch:
   push:
     branches:
       - master
@@ -25,7 +24,7 @@ jobs:
 
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
-          npm ci
+          npm install
           npm run build:storybook
 
       - name: Deploy 🚀

--- a/.github/workflows/github_pages_storybook_master.yml
+++ b/.github/workflows/github_pages_storybook_master.yml
@@ -1,5 +1,6 @@
 name: Deploy Master Storybook
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/github_pages_storybook_preview.yml
+++ b/.github/workflows/github_pages_storybook_preview.yml
@@ -35,7 +35,7 @@ jobs:
               ~/.npm
               **/node_modules
   
-            key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/lerna.json') }}
+            key: ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}
             restore-keys: |
               ${{ runner.os }}-build-${{ hashFiles('**/package-lock.json') }}-
               ${{ runner.os }}-build-

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+    "@infineon/infineon-design-system-react": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+    "@infineon/infineon-design-system-vue": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -3792,6 +3792,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -9320,7 +9348,6 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9341,7 +9368,6 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -10040,6 +10066,13 @@
       "engines": {
         "node": ">=8.9.0"
       }
+    },
+    "node_modules/ag-grid-community": {
+      "version": "31.3.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
+      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -11549,6 +11582,18 @@
         "node": ">= 16"
       }
     },
+    "node_modules/choices.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-10.2.0.tgz",
+      "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "fuse.js": "^6.6.2",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -12618,7 +12663,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -14771,6 +14815,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -27621,7 +27675,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -27943,6 +27996,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3792,34 +3792,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -9348,6 +9320,7 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9368,6 +9341,7 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -10066,13 +10040,6 @@
       "engines": {
         "node": ">=8.9.0"
       }
-    },
-    "node_modules/ag-grid-community": {
-      "version": "31.3.4",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
-      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -11582,18 +11549,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/choices.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-10.2.0.tgz",
-      "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "fuse.js": "^6.6.2",
-        "redux": "^4.2.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -12663,6 +12618,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -14815,16 +14771,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -27675,6 +27621,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -27996,16 +27943,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {
@@ -33691,7 +33628,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33753,7 +33690,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33764,7 +33701,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33784,7 +33721,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33793,16 +33730,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0"
+        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33816,11 +33753,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0"
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33628,7 +33628,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+      "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33690,7 +33690,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+      "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33701,7 +33701,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33721,7 +33721,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+      "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33730,16 +33730,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1"
+        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+      "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33753,11 +33753,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+      "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1"
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/components-angular/projects/*"
       ],
       "devDependencies": {
-        "@rollup/plugin-replace": "^6.0.1",
         "@types/node": "^20.12.7",
         "lerna": "^8.1.9",
         "nx": "^16.10.0",
@@ -1202,21 +1201,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
+        "@babel/generator": "^7.26.10",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -1232,13 +1231,13 @@
       }
     },
     "node_modules/@babel/core/node_modules/@babel/generator": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/parser": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -1602,25 +1601,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -3289,16 +3288,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
-      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
+      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/generator": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/types": "^7.26.10",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -3307,13 +3306,13 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/generator": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/parser": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -3335,9 +3334,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
@@ -3792,6 +3791,34 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -5818,6 +5845,14 @@
         "@inquirer/prompts": ">= 3 < 6"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/@lit/react": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.7.tgz",
@@ -5825,6 +5860,17 @@
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
@@ -7325,28 +7371,6 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-replace": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.2.tgz",
-      "integrity": "sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "magic-string": "^0.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -9343,7 +9367,6 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9364,7 +9387,6 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -9450,6 +9472,14 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -10064,6 +10094,13 @@
         "node": ">=8.9.0"
       }
     },
+    "node_modules/ag-grid-community": {
+      "version": "31.3.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
+      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/agent-base": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
@@ -10420,9 +10457,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
+      "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -11572,6 +11609,18 @@
         "node": ">= 16"
       }
     },
+    "node_modules/choices.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-10.2.0.tgz",
+      "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "fuse.js": "^6.6.2",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -12641,7 +12690,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -13290,9 +13338,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.114",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.114.tgz",
-      "integrity": "sha512-DFptFef3iktoKlFQK/afbo274/XNWD00Am0xa7M8FZUepHlHT8PEuiNBoRfFHbH1okqN58AlhbJ4QTkcnXorjA==",
+      "version": "1.5.115",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.115.tgz",
+      "integrity": "sha512-MN1nahVHAQMOz6dz6bNZ7apgqc9InZy7Ja4DBEVCTdeiUcegbyOYE9bi/f2Z/z6ZxLi0RxLpyJ3EGe+4h3w73A==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -14794,6 +14842,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -17043,6 +17101,14 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jasmine-core": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
+      "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jest": {
       "version": "29.7.0",
@@ -20193,6 +20259,43 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/lmdb": {
@@ -27197,6 +27300,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prettier-standalone": {
       "version": "1.3.1-0",
       "resolved": "https://registry.npmjs.org/prettier-standalone/-/prettier-standalone-1.3.1-0.tgz",
@@ -27650,7 +27769,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -27972,6 +28090,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {
@@ -33376,7 +33504,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -33390,7 +33517,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-json-file": {
@@ -33664,7 +33790,7 @@
         "@infineon/infineon-icons": "^2.1.2",
         "@popperjs/core": "^2.11.8",
         "@stencil/angular-output-target": "^0.9.0",
-        "@stencil/core": "^4.26.0",
+        "@stencil/core": "4.27.2",
         "@stencil/vue-output-target": "^0.8.9",
         "@storybook/cli": "^8.3.0",
         "@storybook/test": "^8.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3792,6 +3792,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -9339,7 +9367,6 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9360,7 +9387,6 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -10067,6 +10093,13 @@
       "engines": {
         "node": ">=8.9.0"
       }
+    },
+    "node_modules/ag-grid-community": {
+      "version": "31.3.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
+      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -11576,6 +11609,18 @@
         "node": ">= 16"
       }
     },
+    "node_modules/choices.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-10.2.0.tgz",
+      "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "fuse.js": "^6.6.2",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -12645,7 +12690,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -14798,6 +14842,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -27709,7 +27763,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -28031,6 +28084,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5817,14 +5817,6 @@
         "@inquirer/prompts": ">= 3 < 6"
       }
     },
-    "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
-      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
     "node_modules/@lit/react": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.7.tgz",
@@ -5832,17 +5824,6 @@
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"
-      }
-    },
-    "node_modules/@lit/reactive-element": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
-      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
@@ -9446,14 +9427,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -17048,14 +17021,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/jasmine-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
-      "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
@@ -20205,43 +20170,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/lit": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
-      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit-element": "^4.1.0",
-        "lit-html": "^3.2.0"
-      }
-    },
-    "node_modules/lit-element": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
-      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.0.4",
-        "lit-html": "^3.2.0"
-      }
-    },
-    "node_modules/lit-html": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
-      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/lmdb": {
@@ -27246,22 +27174,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
@@ -33435,6 +33347,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -33448,6 +33361,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-json-file": {
@@ -33714,7 +33628,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+      "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33776,7 +33690,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+      "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33787,7 +33701,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33807,7 +33721,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+      "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33816,16 +33730,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0"
+        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+      "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33839,11 +33753,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+      "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0"
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3792,6 +3792,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -9320,7 +9348,6 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9341,7 +9368,6 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -10040,6 +10066,13 @@
       "engines": {
         "node": ">=8.9.0"
       }
+    },
+    "node_modules/ag-grid-community": {
+      "version": "31.3.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
+      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -11549,6 +11582,18 @@
         "node": ">= 16"
       }
     },
+    "node_modules/choices.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-10.2.0.tgz",
+      "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "fuse.js": "^6.6.2",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -12618,7 +12663,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -14771,6 +14815,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -27627,7 +27681,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -27949,6 +28002,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3792,34 +3792,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -9348,6 +9320,7 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9368,6 +9341,7 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -10066,13 +10040,6 @@
       "engines": {
         "node": ">=8.9.0"
       }
-    },
-    "node_modules/ag-grid-community": {
-      "version": "31.3.4",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
-      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -11582,18 +11549,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/choices.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-10.2.0.tgz",
-      "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "fuse.js": "^6.6.2",
-        "redux": "^4.2.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -12663,6 +12618,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -14815,16 +14771,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -27675,6 +27621,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -27996,16 +27943,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {
@@ -33691,7 +33628,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33753,7 +33690,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33764,7 +33701,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33784,7 +33721,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33793,16 +33730,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0"
+        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33816,11 +33753,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0"
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5845,6 +5845,14 @@
         "@inquirer/prompts": ">= 3 < 6"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/@lit/react": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.7.tgz",
@@ -5852,6 +5860,17 @@
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
@@ -9453,6 +9472,14 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -17075,6 +17102,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/jasmine-core": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
+      "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
@@ -20224,6 +20259,43 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/lmdb": {
@@ -27228,11 +27300,21 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prettier-standalone": {
-      "version": "1.3.1-0",
-      "resolved": "https://registry.npmjs.org/prettier-standalone/-/prettier-standalone-1.3.1-0.tgz",
-      "integrity": "sha512-wxJiwE5XS45BQD8QTXcTeqnWzsYrCliIYOYrURM8MiJaw8NA5q+BSd9UBhM5QPDFShn+pFWa8X2XH3y5A47q+Q==",
-      "license": "MIT"
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
     },
     "node_modules/pretty-error": {
       "version": "4.0.0",
@@ -33416,7 +33498,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -33430,7 +33511,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-json-file": {
@@ -33714,8 +33794,7 @@
         "i": "^0.3.7",
         "lerna": "8.1.9",
         "npm": "^10.2.1",
-        "npm-run-all": "^4.1.5",
-        "prettier-standalone": "^1.3.1-0"
+        "npm-run-all": "^4.1.5"
       },
       "devDependencies": {
         "@babel/core": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33634,7 +33634,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33697,7 +33697,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33708,7 +33708,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33728,7 +33728,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33737,16 +33737,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0"
+        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33760,11 +33760,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0"
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33628,7 +33628,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33690,7 +33690,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33701,7 +33701,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33721,7 +33721,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33730,16 +33730,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0"
+        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33753,11 +33753,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+      "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0"
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33628,7 +33628,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+      "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33690,7 +33690,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+      "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33701,7 +33701,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33721,7 +33721,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+      "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33730,16 +33730,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0"
+        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+      "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33753,11 +33753,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+      "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0"
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3792,34 +3792,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -9348,6 +9320,7 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9368,6 +9341,7 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -10066,13 +10040,6 @@
       "engines": {
         "node": ">=8.9.0"
       }
-    },
-    "node_modules/ag-grid-community": {
-      "version": "31.3.4",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
-      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -11582,18 +11549,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/choices.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-10.2.0.tgz",
-      "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "fuse.js": "^6.6.2",
-        "redux": "^4.2.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -12663,6 +12618,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -14815,16 +14771,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -27681,6 +27627,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -28002,16 +27949,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {
@@ -33697,7 +33634,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+      "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33760,7 +33697,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+      "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33771,7 +33708,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33791,7 +33728,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+      "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33800,16 +33737,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1"
+        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+      "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33823,11 +33760,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+      "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1"
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3792,34 +3792,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -5845,14 +5817,6 @@
         "@inquirer/prompts": ">= 3 < 6"
       }
     },
-    "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
-      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
     "node_modules/@lit/react": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.7.tgz",
@@ -5860,17 +5824,6 @@
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"
-      }
-    },
-    "node_modules/@lit/reactive-element": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
-      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
@@ -9367,6 +9320,7 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9387,6 +9341,7 @@
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -9472,14 +9427,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -10093,13 +10040,6 @@
       "engines": {
         "node": ">=8.9.0"
       }
-    },
-    "node_modules/ag-grid-community": {
-      "version": "31.3.4",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
-      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -11609,18 +11549,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/choices.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-10.2.0.tgz",
-      "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "fuse.js": "^6.6.2",
-        "redux": "^4.2.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -12690,6 +12618,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -14842,16 +14771,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -17101,14 +17020,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/jasmine-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
-      "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/jest": {
       "version": "29.7.0",
@@ -20259,43 +20170,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/lit": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
-      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit-element": "^4.1.0",
-        "lit-html": "^3.2.0"
-      }
-    },
-    "node_modules/lit-element": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
-      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.0.4",
-        "lit-html": "^3.2.0"
-      }
-    },
-    "node_modules/lit-html": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
-      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/lmdb": {
@@ -27300,22 +27174,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/prettier-standalone": {
       "version": "1.3.1-0",
       "resolved": "https://registry.npmjs.org/prettier-standalone/-/prettier-standalone-1.3.1-0.tgz",
@@ -27769,6 +27627,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -28090,16 +27949,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {
@@ -33504,6 +33353,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -33517,6 +33367,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-json-file": {
@@ -33783,7 +33634,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33846,7 +33697,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33857,7 +33708,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33877,7 +33728,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33886,16 +33737,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1"
+        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33909,11 +33760,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+      "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1"
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33628,7 +33628,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33690,7 +33690,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33701,7 +33701,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+        "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33721,7 +33721,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33730,16 +33730,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0"
+        "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33753,11 +33753,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+      "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0"
+        "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "packages/components-angular/projects/*"
   ],
   "devDependencies": {
-    "@rollup/plugin-replace": "^6.0.1",
     "@types/node": "^20.12.7",
     "lerna": "^8.1.9",
     "nx": "^16.10.0",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+    "@infineon/infineon-design-system-angular": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1"
+    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0"
+    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1"
+    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0"
+    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0"
+    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0"
+    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0"
+    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0"
+    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0"
+    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1"
+    "@infineon/infineon-design-system-stencil": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1"
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1"
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0"
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0"
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0"
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1"
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0"
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0"
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0"
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0"
+    "@infineon/infineon-design-system-stencil": "^32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/.storybook/preview.js
+++ b/packages/components/.storybook/preview.js
@@ -1,7 +1,5 @@
 
 import { defineCustomElements } from '../loader';
-import prettier from 'prettier/standalone';
-import prettierBabel from 'prettier/parser-babel';
 import ifxTheme from './ifxTheme';
 import tokens from './exported-sass-array.json';
 import "../public-storybook/fonts/ifx-fonts.css";
@@ -37,11 +35,6 @@ export const parameters = {
     canvas: {
       sourceState: "shown"
     },
-    transformSource: input =>
-      prettier.format(input, {
-        parser: 'babel',
-        plugins: [prettierBabel],
-      }),
   },
   options: {
     storySort: {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.4.0--canary.1775.756259da12a1dfb17cce9ed5191975e09537b47f.1",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,8 +52,7 @@
     "i": "^0.3.7",
     "lerna": "8.1.9",
     "npm": "^10.2.1",
-    "npm-run-all": "^4.1.5",
-    "prettier-standalone": "^1.3.1-0"
+    "npm-run-all": "^4.1.5"
   },
   "peerDependencies": {
     "@floating-ui/dom": "^1.4.5",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
+  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -42,7 +42,7 @@
     "@infineon/infineon-icons": "^2.1.2",
     "@popperjs/core": "^2.11.8",
     "@stencil/angular-output-target": "^0.9.0",
-    "@stencil/core": "^4.26.0",
+    "@stencil/core": "4.27.2",
     "@stencil/vue-output-target": "^0.8.9",
     "@storybook/cli": "^8.3.0",
     "@storybook/test": "^8.3.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
+  "version": "32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
+  "version": "32.4.1--canary.1779.39a855fa9cbd4e5618cfb6d016010ca5bddf0c1b.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.0",
+  "version": "32.4.1--canary.1779.f19edf9f97c875b19bd7704753b9d3f923b0ef12.1",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.4.1--canary.1779.186a1b0912cb5986bda32c3182ea211abd8ac3a8.0",
+  "version": "32.4.1--canary.1779.f5467759a134931df2d9f8fefa2e354170688204.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
+  "version": "32.4.1--canary.1779.f2627b6e36532eaca8556ae1c959985aca5f56f8.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.0",
+  "version": "32.4.1--canary.1779.748fd1c29a43ab8c1bd3c2130df2d5246a0bb051.1",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -1,21 +1,12 @@
 import { Config } from '@stencil/core';
 import { sass } from '@stencil/sass';
 import { frameworkTargets } from './framework-output-targets';
-import dotenv from 'dotenv';
-import replace from '@rollup/plugin-replace';
-
-dotenv.config();
 
 export const config: Config = {
   namespace: 'infineon-design-system-stencil',
   globalStyle: 'src/global/global.scss',
   plugins: [
-    sass(),
-    replace({
-      'process.env.CLIENT_ID': JSON.stringify(process.env.CLIENT_ID),
-      'process.env.SCOPE': JSON.stringify(process.env.SCOPE),
-      'process.env.STATE': JSON.stringify(process.env.STATE),
-    }),
+    sass()
   ],
   extras: {
     cloneNodeFix: true,


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1
  # or 
  yarn add @infineon/infineon-design-system-stencil@32.4.1--canary.1779.eea3b81aebf761894ca7fdfc14eb88f1de640ffa.1
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
