### PR TITLE
text-field: makes internal input id customizable via a prop

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+    "@infineon/infineon-design-system-react": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+    "@infineon/infineon-design-system-react": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+    "@infineon/infineon-design-system-react": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+    "@infineon/infineon-design-system-vue": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+    "@infineon/infineon-design-system-vue": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+    "@infineon/infineon-design-system-vue": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -3617,9 +3617,9 @@
       }
     },
     "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "22.13.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.14.tgz",
-      "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+      "version": "22.13.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.15.tgz",
+      "integrity": "sha512-imAbQEEbVni6i6h6Bd5xkCRwLqFc8hihCsi2GbtDoAtUcAFQ6Zs4pFXTZUUbroTkXdImczWM9AI8eZUuybXE3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4582,9 +4582,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/devkit": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.6.4.tgz",
-      "integrity": "sha512-lyEidfyPhTuHt1X6EsskugBREazS5VOKSPIcreQ8Qt0MaULxn0bQ9o0N6C+BQaw5Zu6RTaMRMWKGW0I0Qni0UA==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.7.0.tgz",
+      "integrity": "sha512-BzgeF7sVM6eLVVZIkhqwkSu8hzKx+Wa/bLyMithiU+aLJVGALWFQriDS68MBMA+MHyodKwV3QHQH9/9/UO6uyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4628,9 +4628,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/nx-darwin-arm64": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.6.4.tgz",
-      "integrity": "sha512-urdLFCY0c2X11FBuokSgCktKTma7kjZKWJi8mVO8PbTJh0h2Qtp4l9/px8tv9EHeHuusA18p2Wq3ZM6c95qcBg==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.7.0.tgz",
+      "integrity": "sha512-SuPP4AlBGuQjfkgFaGAO66GEUll0Isir5HKa0w0LcehHmxncE9LT4YagEJONPDp6SVDIjpoFIRw71jf9toFvPQ==",
       "cpu": [
         "arm64"
       ],
@@ -4645,9 +4645,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/nx-darwin-x64": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.6.4.tgz",
-      "integrity": "sha512-nNOXc9ccdsdmylC/InRud/F977ldat2zQuSWfhoI5+9exHIjMo0TNU8gZdT53t3S1OTQKOEbNXZcoEaURb6STA==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.7.0.tgz",
+      "integrity": "sha512-eJnGtZmXzhRqitBBSIU7CjUjEGyo7QMZlvTQsqIpkZDay3v3JyQ9tikdGe3L6BwnTgeFQsBxNfK3ddmwTyK19g==",
       "cpu": [
         "x64"
       ],
@@ -4662,9 +4662,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/nx-freebsd-x64": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.6.4.tgz",
-      "integrity": "sha512-jPGzjdB9biMu8N4038qBe0VBfrQ+HDjXfxBhETqrVIJPBfgdxN1I8CXIhCqMPG2CHBAM6kDQCU6QCTMWADJcEw==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.7.0.tgz",
+      "integrity": "sha512-WhuK5XGy2c7WNMrVW2+mWMb0MCvgoOaSUxvxpl8OORdENYmgsUjYUDVnndjqRdSzcQTB/WfQX5G7bJQhySzaww==",
       "cpu": [
         "x64"
       ],
@@ -4679,9 +4679,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.6.4.tgz",
-      "integrity": "sha512-j4ekxzZPc5lj+VbaLBpKJl6w2VyFXycLrT65CWQYAj9yqV5dUuDtTR33r50ddLtqQt3PVV5hJAj8+g7sGPXUWQ==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.7.0.tgz",
+      "integrity": "sha512-TZKDjO/YyOT/Zq449kIpkw9OUD4EQlmMk+aM8WW29VirJnnIfGxhjfCBkSRmVIOvwSlIf7GKLQjDuWwcObIZRg==",
       "cpu": [
         "arm"
       ],
@@ -4696,9 +4696,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.6.4.tgz",
-      "integrity": "sha512-nYMB4Sh5yI7WbunizZ/mgR21MQgrs77frnAChs+6aPF5HA7N1VGEn3FMKX+ypd3DjTl14zuwB/R5ilwNgKzL+A==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.7.0.tgz",
+      "integrity": "sha512-wEkE/MRcPQHZK10SgocPGCEyqFksLDdsSeE2fyVZb+N+vUGSp5YBu7OE6mUKobIs3uUXgftqP4d7QXTlehb7gw==",
       "cpu": [
         "arm64"
       ],
@@ -4713,9 +4713,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.6.4.tgz",
-      "integrity": "sha512-ukjB1pmBvtinT0zeYJ1lWi7BAw6cDnPQnfXMbyV+afYnNRcgdDFzQaUpo3UUeai69Fo3TTr0SWx6DjMVifxJZw==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.7.0.tgz",
+      "integrity": "sha512-je7OmX7d41ihMzq4/q6AOsYGfiH5B3xIsAKBfXHSmlGcaijnxMCzSHzjR3znxhmOS0bMcfICXCCwm1AVcyUAUA==",
       "cpu": [
         "arm64"
       ],
@@ -4730,9 +4730,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.6.4.tgz",
-      "integrity": "sha512-+6DloqqB8ZzuZOY4A1PryuPD5hGoxbSafRN++sXUFvKx6mRYNyLGrn5APT3Kiq1qPBxkAxcsreexcu/wsTcrcw==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.7.0.tgz",
+      "integrity": "sha512-dF5/VJgtbydSgu9WjL1CrzNIXZR/9Z92b4f7lrvd/KO/LwBB3EVavgV0tSq0TAFuu4n5eSo66SA1j0miIBA1dg==",
       "cpu": [
         "x64"
       ],
@@ -4747,9 +4747,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.6.4.tgz",
-      "integrity": "sha512-+ZuF6dobfGo5EN55syuUEdbYs9qxbLmTkGPMq66X7dZ/jm7kKTsVzDYnf9v3ynQCOq4DMFtdACneL32Ks22+NQ==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.7.0.tgz",
+      "integrity": "sha512-Jy760sdTDgzplpWerrUpfugmHnjQoNbCdcrNiBm1HaL2+P/6Wl2eZ2zLW3Uw5/D/wf7z8qsokMrPO9XdvnZ3cA==",
       "cpu": [
         "x64"
       ],
@@ -4764,9 +4764,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.6.4.tgz",
-      "integrity": "sha512-z+Y8iwEPZ8L8SISh/tcyqEtAy9Ju6aB5kLe8E/E1Wwzy5DU/jNvqM9Wq4HRPMY0r1S4jzwC6x7W3/fkxeFjZ7A==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.7.0.tgz",
+      "integrity": "sha512-5UvJg1RfOeSwcMr/7ghQA5yH3kpU8wye81sCLtyKPfBeH312Ntm52+ckc1IiCFAIkVyo2rmWF9ogRzOTR1O9sw==",
       "cpu": [
         "arm64"
       ],
@@ -4781,9 +4781,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.6.4.tgz",
-      "integrity": "sha512-9LMVHZQqc1m2Fulvfz1nPZFHUKvFjmU7igxoWJXj/m+q+DyYWEbE710ARK9JtMibLg+xSRfERKOcIy11k6Ro1A==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.7.0.tgz",
+      "integrity": "sha512-Ddtk/owLLj1wRHB5MUuUjEfxn9h6sQntOpCC1qDYJLCLRGe3jCEx7MHxKWo5MlmtShXeHRrS27CrA5AGzSS+6w==",
       "cpu": [
         "x64"
       ],
@@ -5206,9 +5206,9 @@
       }
     },
     "node_modules/@lerna/create/node_modules/nx": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-20.6.4.tgz",
-      "integrity": "sha512-mkRgGvPSZpezn65upZ9psuyywr03XTirHDsqlnRYp90qqDQqMH/I1FsHqqUG5qdy4gbm5qFkZ5Vvc8Z3RkN/jg==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-20.7.0.tgz",
+      "integrity": "sha512-IcrQr6alrSJTl5pb80Y/ytwK5Bsx7zC0LbJj5Ck5K+dctFKO2sEAvB2hKz5GiZx92NJzcfCVc5Lu44UeZST1bw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5253,16 +5253,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "20.6.4",
-        "@nx/nx-darwin-x64": "20.6.4",
-        "@nx/nx-freebsd-x64": "20.6.4",
-        "@nx/nx-linux-arm-gnueabihf": "20.6.4",
-        "@nx/nx-linux-arm64-gnu": "20.6.4",
-        "@nx/nx-linux-arm64-musl": "20.6.4",
-        "@nx/nx-linux-x64-gnu": "20.6.4",
-        "@nx/nx-linux-x64-musl": "20.6.4",
-        "@nx/nx-win32-arm64-msvc": "20.6.4",
-        "@nx/nx-win32-x64-msvc": "20.6.4"
+        "@nx/nx-darwin-arm64": "20.7.0",
+        "@nx/nx-darwin-x64": "20.7.0",
+        "@nx/nx-freebsd-x64": "20.7.0",
+        "@nx/nx-linux-arm-gnueabihf": "20.7.0",
+        "@nx/nx-linux-arm64-gnu": "20.7.0",
+        "@nx/nx-linux-arm64-musl": "20.7.0",
+        "@nx/nx-linux-x64-gnu": "20.7.0",
+        "@nx/nx-linux-x64-musl": "20.7.0",
+        "@nx/nx-win32-arm64-msvc": "20.7.0",
+        "@nx/nx-win32-x64-msvc": "20.7.0"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",
@@ -5512,6 +5512,14 @@
         "@inquirer/prompts": ">= 3 < 6"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
     "node_modules/@lit/react": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.7.tgz",
@@ -5519,6 +5527,17 @@
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
@@ -8980,9 +8999,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.17.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
-      "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
+      "version": "20.17.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.29.tgz",
+      "integrity": "sha512-6rbekrnsa5WWCo5UnPYEKfNuoF2yqAmigUKXM8wBzfEbZc+E/CITqjCrHqiq+6QBifsw0ZDaA5VdTFONOtG7+A==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -9121,6 +9140,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -9143,9 +9170,9 @@
       "license": "MIT"
     },
     "node_modules/@types/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12985,9 +13012,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.128",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.128.tgz",
-      "integrity": "sha512-bo1A4HH/NS522Ws0QNFIzyPcyUUNV/yyy70Ho1xqfGYzPUme2F/xr4tlEOuM6/A538U1vDA7a4XfCd1CKRegKQ==",
+      "version": "1.5.129",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.129.tgz",
+      "integrity": "sha512-JlXUemX4s0+9f8mLqib/bHH8gOHf5elKS6KeWG3sk3xozb/JTq/RLXIv8OKUWiK4Ah00Wm88EFj5PYkFr4RUPA==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -16749,6 +16776,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/jasmine-core": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
+      "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
@@ -18573,9 +18608,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/devkit": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.6.4.tgz",
-      "integrity": "sha512-lyEidfyPhTuHt1X6EsskugBREazS5VOKSPIcreQ8Qt0MaULxn0bQ9o0N6C+BQaw5Zu6RTaMRMWKGW0I0Qni0UA==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.7.0.tgz",
+      "integrity": "sha512-BzgeF7sVM6eLVVZIkhqwkSu8hzKx+Wa/bLyMithiU+aLJVGALWFQriDS68MBMA+MHyodKwV3QHQH9/9/UO6uyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18619,9 +18654,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/nx-darwin-arm64": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.6.4.tgz",
-      "integrity": "sha512-urdLFCY0c2X11FBuokSgCktKTma7kjZKWJi8mVO8PbTJh0h2Qtp4l9/px8tv9EHeHuusA18p2Wq3ZM6c95qcBg==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.7.0.tgz",
+      "integrity": "sha512-SuPP4AlBGuQjfkgFaGAO66GEUll0Isir5HKa0w0LcehHmxncE9LT4YagEJONPDp6SVDIjpoFIRw71jf9toFvPQ==",
       "cpu": [
         "arm64"
       ],
@@ -18636,9 +18671,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/nx-darwin-x64": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.6.4.tgz",
-      "integrity": "sha512-nNOXc9ccdsdmylC/InRud/F977ldat2zQuSWfhoI5+9exHIjMo0TNU8gZdT53t3S1OTQKOEbNXZcoEaURb6STA==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.7.0.tgz",
+      "integrity": "sha512-eJnGtZmXzhRqitBBSIU7CjUjEGyo7QMZlvTQsqIpkZDay3v3JyQ9tikdGe3L6BwnTgeFQsBxNfK3ddmwTyK19g==",
       "cpu": [
         "x64"
       ],
@@ -18653,9 +18688,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/nx-freebsd-x64": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.6.4.tgz",
-      "integrity": "sha512-jPGzjdB9biMu8N4038qBe0VBfrQ+HDjXfxBhETqrVIJPBfgdxN1I8CXIhCqMPG2CHBAM6kDQCU6QCTMWADJcEw==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.7.0.tgz",
+      "integrity": "sha512-WhuK5XGy2c7WNMrVW2+mWMb0MCvgoOaSUxvxpl8OORdENYmgsUjYUDVnndjqRdSzcQTB/WfQX5G7bJQhySzaww==",
       "cpu": [
         "x64"
       ],
@@ -18670,9 +18705,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.6.4.tgz",
-      "integrity": "sha512-j4ekxzZPc5lj+VbaLBpKJl6w2VyFXycLrT65CWQYAj9yqV5dUuDtTR33r50ddLtqQt3PVV5hJAj8+g7sGPXUWQ==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.7.0.tgz",
+      "integrity": "sha512-TZKDjO/YyOT/Zq449kIpkw9OUD4EQlmMk+aM8WW29VirJnnIfGxhjfCBkSRmVIOvwSlIf7GKLQjDuWwcObIZRg==",
       "cpu": [
         "arm"
       ],
@@ -18687,9 +18722,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.6.4.tgz",
-      "integrity": "sha512-nYMB4Sh5yI7WbunizZ/mgR21MQgrs77frnAChs+6aPF5HA7N1VGEn3FMKX+ypd3DjTl14zuwB/R5ilwNgKzL+A==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.7.0.tgz",
+      "integrity": "sha512-wEkE/MRcPQHZK10SgocPGCEyqFksLDdsSeE2fyVZb+N+vUGSp5YBu7OE6mUKobIs3uUXgftqP4d7QXTlehb7gw==",
       "cpu": [
         "arm64"
       ],
@@ -18704,9 +18739,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.6.4.tgz",
-      "integrity": "sha512-ukjB1pmBvtinT0zeYJ1lWi7BAw6cDnPQnfXMbyV+afYnNRcgdDFzQaUpo3UUeai69Fo3TTr0SWx6DjMVifxJZw==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.7.0.tgz",
+      "integrity": "sha512-je7OmX7d41ihMzq4/q6AOsYGfiH5B3xIsAKBfXHSmlGcaijnxMCzSHzjR3znxhmOS0bMcfICXCCwm1AVcyUAUA==",
       "cpu": [
         "arm64"
       ],
@@ -18721,9 +18756,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.6.4.tgz",
-      "integrity": "sha512-+6DloqqB8ZzuZOY4A1PryuPD5hGoxbSafRN++sXUFvKx6mRYNyLGrn5APT3Kiq1qPBxkAxcsreexcu/wsTcrcw==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.7.0.tgz",
+      "integrity": "sha512-dF5/VJgtbydSgu9WjL1CrzNIXZR/9Z92b4f7lrvd/KO/LwBB3EVavgV0tSq0TAFuu4n5eSo66SA1j0miIBA1dg==",
       "cpu": [
         "x64"
       ],
@@ -18738,9 +18773,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.6.4.tgz",
-      "integrity": "sha512-+ZuF6dobfGo5EN55syuUEdbYs9qxbLmTkGPMq66X7dZ/jm7kKTsVzDYnf9v3ynQCOq4DMFtdACneL32Ks22+NQ==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.7.0.tgz",
+      "integrity": "sha512-Jy760sdTDgzplpWerrUpfugmHnjQoNbCdcrNiBm1HaL2+P/6Wl2eZ2zLW3Uw5/D/wf7z8qsokMrPO9XdvnZ3cA==",
       "cpu": [
         "x64"
       ],
@@ -18755,9 +18790,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.6.4.tgz",
-      "integrity": "sha512-z+Y8iwEPZ8L8SISh/tcyqEtAy9Ju6aB5kLe8E/E1Wwzy5DU/jNvqM9Wq4HRPMY0r1S4jzwC6x7W3/fkxeFjZ7A==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.7.0.tgz",
+      "integrity": "sha512-5UvJg1RfOeSwcMr/7ghQA5yH3kpU8wye81sCLtyKPfBeH312Ntm52+ckc1IiCFAIkVyo2rmWF9ogRzOTR1O9sw==",
       "cpu": [
         "arm64"
       ],
@@ -18772,9 +18807,9 @@
       }
     },
     "node_modules/lerna/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.6.4.tgz",
-      "integrity": "sha512-9LMVHZQqc1m2Fulvfz1nPZFHUKvFjmU7igxoWJXj/m+q+DyYWEbE710ARK9JtMibLg+xSRfERKOcIy11k6Ro1A==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.7.0.tgz",
+      "integrity": "sha512-Ddtk/owLLj1wRHB5MUuUjEfxn9h6sQntOpCC1qDYJLCLRGe3jCEx7MHxKWo5MlmtShXeHRrS27CrA5AGzSS+6w==",
       "cpu": [
         "x64"
       ],
@@ -19257,9 +19292,9 @@
       }
     },
     "node_modules/lerna/node_modules/nx": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-20.6.4.tgz",
-      "integrity": "sha512-mkRgGvPSZpezn65upZ9psuyywr03XTirHDsqlnRYp90qqDQqMH/I1FsHqqUG5qdy4gbm5qFkZ5Vvc8Z3RkN/jg==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-20.7.0.tgz",
+      "integrity": "sha512-IcrQr6alrSJTl5pb80Y/ytwK5Bsx7zC0LbJj5Ck5K+dctFKO2sEAvB2hKz5GiZx92NJzcfCVc5Lu44UeZST1bw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -19304,16 +19339,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "20.6.4",
-        "@nx/nx-darwin-x64": "20.6.4",
-        "@nx/nx-freebsd-x64": "20.6.4",
-        "@nx/nx-linux-arm-gnueabihf": "20.6.4",
-        "@nx/nx-linux-arm64-gnu": "20.6.4",
-        "@nx/nx-linux-arm64-musl": "20.6.4",
-        "@nx/nx-linux-x64-gnu": "20.6.4",
-        "@nx/nx-linux-x64-musl": "20.6.4",
-        "@nx/nx-win32-arm64-msvc": "20.6.4",
-        "@nx/nx-win32-x64-msvc": "20.6.4"
+        "@nx/nx-darwin-arm64": "20.7.0",
+        "@nx/nx-darwin-x64": "20.7.0",
+        "@nx/nx-freebsd-x64": "20.7.0",
+        "@nx/nx-linux-arm-gnueabihf": "20.7.0",
+        "@nx/nx-linux-arm64-gnu": "20.7.0",
+        "@nx/nx-linux-arm64-musl": "20.7.0",
+        "@nx/nx-linux-x64-gnu": "20.7.0",
+        "@nx/nx-linux-x64-musl": "20.7.0",
+        "@nx/nx-win32-arm64-msvc": "20.7.0",
+        "@nx/nx-win32-x64-msvc": "20.7.0"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",
@@ -19897,6 +19932,43 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/lmdb": {
@@ -26901,6 +26973,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
@@ -28415,9 +28503,9 @@
       "license": "MIT"
     },
     "node_modules/sass": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.86.0.tgz",
-      "integrity": "sha512-zV8vGUld/+mP4KbMLJMX7TyGCuUp7hnkOScgCMsWuHtns8CWBoz+vmEhoGMXsaJrbUP8gj+F1dLvVe79sK8UdA==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.86.1.tgz",
+      "integrity": "sha512-Yaok4XELL1L9Im/ZUClKu//D2OP1rOljKj0Gf34a+GzLbMveOzL7CfqYo+JUa5Xt1nhTCW+OcKp/FtR7/iqj1w==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -28435,9 +28523,9 @@
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.86.0.tgz",
-      "integrity": "sha512-Ibq5DzxjSf9f/IJmKeHVeXlVqiZWdRJF+RXy6v6UupvMYVMU5Ei+teSFBvvpPD5bB2QhhnU/OJlSM0EBCtfr9g==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.86.1.tgz",
+      "integrity": "sha512-LMJvytHh7lIUtmjGCqpM4cRdIDvPllLJKznNIK4L7EZJ77BLeUFoOSRXEOHq4G4gqy5CVhHUKlHslzCANkDOhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -28457,32 +28545,32 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.86.0",
-        "sass-embedded-android-arm64": "1.86.0",
-        "sass-embedded-android-ia32": "1.86.0",
-        "sass-embedded-android-riscv64": "1.86.0",
-        "sass-embedded-android-x64": "1.86.0",
-        "sass-embedded-darwin-arm64": "1.86.0",
-        "sass-embedded-darwin-x64": "1.86.0",
-        "sass-embedded-linux-arm": "1.86.0",
-        "sass-embedded-linux-arm64": "1.86.0",
-        "sass-embedded-linux-ia32": "1.86.0",
-        "sass-embedded-linux-musl-arm": "1.86.0",
-        "sass-embedded-linux-musl-arm64": "1.86.0",
-        "sass-embedded-linux-musl-ia32": "1.86.0",
-        "sass-embedded-linux-musl-riscv64": "1.86.0",
-        "sass-embedded-linux-musl-x64": "1.86.0",
-        "sass-embedded-linux-riscv64": "1.86.0",
-        "sass-embedded-linux-x64": "1.86.0",
-        "sass-embedded-win32-arm64": "1.86.0",
-        "sass-embedded-win32-ia32": "1.86.0",
-        "sass-embedded-win32-x64": "1.86.0"
+        "sass-embedded-android-arm": "1.86.1",
+        "sass-embedded-android-arm64": "1.86.1",
+        "sass-embedded-android-ia32": "1.86.1",
+        "sass-embedded-android-riscv64": "1.86.1",
+        "sass-embedded-android-x64": "1.86.1",
+        "sass-embedded-darwin-arm64": "1.86.1",
+        "sass-embedded-darwin-x64": "1.86.1",
+        "sass-embedded-linux-arm": "1.86.1",
+        "sass-embedded-linux-arm64": "1.86.1",
+        "sass-embedded-linux-ia32": "1.86.1",
+        "sass-embedded-linux-musl-arm": "1.86.1",
+        "sass-embedded-linux-musl-arm64": "1.86.1",
+        "sass-embedded-linux-musl-ia32": "1.86.1",
+        "sass-embedded-linux-musl-riscv64": "1.86.1",
+        "sass-embedded-linux-musl-x64": "1.86.1",
+        "sass-embedded-linux-riscv64": "1.86.1",
+        "sass-embedded-linux-x64": "1.86.1",
+        "sass-embedded-win32-arm64": "1.86.1",
+        "sass-embedded-win32-ia32": "1.86.1",
+        "sass-embedded-win32-x64": "1.86.1"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.86.0.tgz",
-      "integrity": "sha512-NS8v6BCbzskXUMBtzfuB+j2yQMgiwg5edKHTYfQU7gAWai2hkRhS06YNEMff3aRxV0IFInxPRHOobd8xWPHqeA==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.86.1.tgz",
+      "integrity": "sha512-bcmKB67uCb9znune+QsE6cWIiKAHE9P+24/9vDPHwwN3BmmH1B/4mznNKKakdYMuxpgbeLrPcEScHEpQbdrIpA==",
       "cpu": [
         "arm"
       ],
@@ -28497,9 +28585,9 @@
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.86.0.tgz",
-      "integrity": "sha512-r7MZtlAI2VFUnKE8B5UOrpoE6OGpdf1dIB6ndoxb3oiURgMyfTVU7yvJcL12GGvtVwQ2boCj6dq//Lqq9CXPlQ==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.86.1.tgz",
+      "integrity": "sha512-SMY79YhNfq/gdz8MHqwEsnf/IjSnQFAmSEGDDv0vjL0yy9VZC/zhsxpsho8vbFEvTSEGFFlkGgPdzDuoozRrOg==",
       "cpu": [
         "arm64"
       ],
@@ -28514,9 +28602,9 @@
       }
     },
     "node_modules/sass-embedded-android-ia32": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.86.0.tgz",
-      "integrity": "sha512-UjfElrGaOTNOnxLZLxf6MFndFIe7zyK+81f83BioZ7/jcoAd6iCHZT8yQMvu8wINyVodPcaXZl8KxlKcl62VAA==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.86.1.tgz",
+      "integrity": "sha512-AX6I5qS8GbgcbBJ1o3uKVI5/7tq6evg/BO/wa0XaNqnzP4i/PojBaGh7EcZrg/spl//SfpS55eA18a0/AOi71w==",
       "cpu": [
         "ia32"
       ],
@@ -28531,9 +28619,9 @@
       }
     },
     "node_modules/sass-embedded-android-riscv64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.86.0.tgz",
-      "integrity": "sha512-TsqCLxHWLFS2mbpUkL/nge3jSkaPK2VmLkkoi5iO/EQT4SFvm1lNUgPwlLXu9DplZ+aqGVzRS9Y6Psjv+qW7kw==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.86.1.tgz",
+      "integrity": "sha512-Af6ZzRTRfIfx6KICJZ19je6OjOXhxo+v6z/lf/SXm5/1EaHGpGC5xIw4ivtj4nNINNoqkykfIDCjpzm1qWEPPQ==",
       "cpu": [
         "riscv64"
       ],
@@ -28548,9 +28636,9 @@
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.86.0.tgz",
-      "integrity": "sha512-8Q263GgwGjz7Jkf7Eghp7NrwqskDL95WO9sKrNm9iOd2re/M48W7RN/lpdcZwrUnEOhueks0RRyYyZYBNRz8Tg==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.86.1.tgz",
+      "integrity": "sha512-GW47z1AH8gXB7IG6EUbC5aDBDtiITeP5nUfEenE6vaaN0H17mBjIwSnEcKPPA1IdxzDpj+4bE/SGfiF0W/At4g==",
       "cpu": [
         "x64"
       ],
@@ -28565,9 +28653,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.86.0.tgz",
-      "integrity": "sha512-d8oMEaIweq1tjrb/BT43igDviOMS1TeDpc51QF7vAHkt9drSjPmqEmbqStdFYPAGZj1j0RA4WCRoVl6jVixi/w==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.86.1.tgz",
+      "integrity": "sha512-grBnDW5Rg+mEmZM7I9hJySS4MMXDwLMd+RyegQnr+SIJ3WA807Cw830+raALxgDY+UKKKhVEoq3FgbTo40Awgw==",
       "cpu": [
         "arm64"
       ],
@@ -28582,9 +28670,9 @@
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.86.0.tgz",
-      "integrity": "sha512-5NLRtn0ZUDBkfpKOsgLGl9B34po4Qui8Nff/lXTO+YkxBQFX4GoMkYNk9EJqHwoLLzICsxIhNDMMDiPGz7Fdrw==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.86.1.tgz",
+      "integrity": "sha512-XxSCMcmeADNouiJAr8G1oRnEhkivHKVLV5DRpfFnUK5FqtFCuSk3K18I+xIfpQDeZnjRL3t2VjsmEJuFiBYV8w==",
       "cpu": [
         "x64"
       ],
@@ -28599,9 +28687,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.86.0.tgz",
-      "integrity": "sha512-b6wm0+Il+blJDleRXAqA6JISGMjRb0/thTEg4NWgmiJwUoZjDycj5FTbfYPnLXjCEIMGaYmW3patrJ3JMJcT3Q==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.86.1.tgz",
+      "integrity": "sha512-Z57ZUcWPuoOHpnl3TiUf/x9wWF2dFtkjdv7hZQpFXYwK5eudHFeBErK6KNCos6jkif1KyeFELXT/HWOznitU/w==",
       "cpu": [
         "arm"
       ],
@@ -28616,9 +28704,9 @@
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.86.0.tgz",
-      "integrity": "sha512-50A+0rhahRDRkKkv+qS7GDAAkW1VPm2RCX4zY4JWydhV4NwMXr6HbkLnsJ2MGixCyibPh59iflMpNBhe7SEMNg==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.86.1.tgz",
+      "integrity": "sha512-zchms0BtaOrkvfvjRnl1PDWK931DxAeYEY2yKQceO/0OFtcBz1r480Kh/RjIffTNreJqIr9Mx4wFdP+icKwLpg==",
       "cpu": [
         "arm64"
       ],
@@ -28633,9 +28721,9 @@
       }
     },
     "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.86.0.tgz",
-      "integrity": "sha512-h0mr9w71TV3BRPk9JHr0flnRCznhkraY14gaj5T+t78vUFByOUMxp4hTr+JpZAR5mv0mIeoMwrQYwWJoqKI0mw==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.86.1.tgz",
+      "integrity": "sha512-WHntVnCgpiJPCmTeQrn5rtl1zJdd693TwpNGAFPzKD4FILPcVBKtWutl7COL6bKe/mKTf9OW0t6GBJ6mav2hAA==",
       "cpu": [
         "ia32"
       ],
@@ -28650,9 +28738,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.86.0.tgz",
-      "integrity": "sha512-KZU70jBMVykC9HzS+o2FhrJaprFLDk3LWXVPtBFxgLlkcQ/apCkUCh2WVNViLhI2U4NrMSnTvd4kDnC/0m8qIw==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.86.1.tgz",
+      "integrity": "sha512-DlPpyp3bIL8YMtxR22hkWBtuZY6ch3KAmQvqIONippPv96WTHi1iq5jclbE1YXpDtI8Wcus0x6apoDSKq8o95g==",
       "cpu": [
         "arm"
       ],
@@ -28667,9 +28755,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.86.0.tgz",
-      "integrity": "sha512-5OZjiJIUyhvKJIGNDEjyRUWDe+W91hq4Bji27sy8gdEuDzPWLx4NzwpKwsBUALUfyW/J5dxgi0ZAQnI3HieyQg==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.86.1.tgz",
+      "integrity": "sha512-CwuHMRWSJFByHpgqcVtCSt29dMWhr0lpUTjaBCh9xOl0Oyz89dIqOxA0aMq+XU+thaDtOziJtMIfW6l35ZeykQ==",
       "cpu": [
         "arm64"
       ],
@@ -28684,9 +28772,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.86.0.tgz",
-      "integrity": "sha512-vq9wJ7kaELrsNU6Ld6kvrIHxoIUWaD+5T6TQVj4SJP/iw1NjonyCDMQGGs6UgsIEzvaIwtlSlDbRewAq+4PchA==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.86.1.tgz",
+      "integrity": "sha512-yjvVpAW1YS0VQNnIUtZTf0IrRDMa0wRjFWUtsLthVIxuXyjLy44+YULlfduxqcZe3rvI4+EqT7GorvviWo9NfQ==",
       "cpu": [
         "ia32"
       ],
@@ -28701,9 +28789,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-riscv64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.86.0.tgz",
-      "integrity": "sha512-UZJPu4zKe3phEzoSVRh5jcSicBBPe+jEbVNALHSSz881iOAYnDQXHITGeQ4mM1/7e/LTyryHk6EPBoaLOv6JrA==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.86.1.tgz",
+      "integrity": "sha512-0zCUOMwX/hwPV1zimxM46dq/MdATSqbw6G646DwQ3/2V2Db1t9lfXBZqSavx8p/cqRp1JYTUPbJQV1gT4J7NYw==",
       "cpu": [
         "riscv64"
       ],
@@ -28718,9 +28806,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.86.0.tgz",
-      "integrity": "sha512-8taAgbWMk4QHneJcouWmWZJlmKa2O03g4I/CFo4bfMPL87bibY90pAsSDd+C+t81g0+2aK0/lY/BoB0r3qXLiA==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.86.1.tgz",
+      "integrity": "sha512-8KJ6kEj1N16V9E0g5PDSd4aVe1LwcVKROJcVqnzTKPMa/4j2VuNWep7D81OYchdQMm9Egn1RqV0jCwm0b2aSHQ==",
       "cpu": [
         "x64"
       ],
@@ -28735,9 +28823,9 @@
       }
     },
     "node_modules/sass-embedded-linux-riscv64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.86.0.tgz",
-      "integrity": "sha512-yREY6o2sLwiiA03MWHVpnUliLscz0flEmFW/wzxYZJDqg9eZteB3hUWgZD63eLm2PTZsYxDQpjAHpa48nnIEmA==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.86.1.tgz",
+      "integrity": "sha512-rNJ1EfIkQpvBfMS1fBdyb+Gsji4yK0AwsV1T7NEcy21yDxDt7mdCgkAJiaN9qf7UEXuCuueQoed7WZoDaSpjww==",
       "cpu": [
         "riscv64"
       ],
@@ -28752,9 +28840,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.86.0.tgz",
-      "integrity": "sha512-sH0F8np9PTgTbFcJWxfr1NzPkL5ID2NcpMtZyKPTdnn9NkE/L2UwXSo6xOvY0Duc4Hg+58wSrDnj6KbvdeHCPg==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.86.1.tgz",
+      "integrity": "sha512-DGCdUoYRRUKzRZz/q7plbB5Nean2+Uk4CqKF4RWAU0v1tHnDKKWmYfETryhWdB2WJM8QSn7O8qRebe6FCobB5g==",
       "cpu": [
         "x64"
       ],
@@ -28769,9 +28857,9 @@
       }
     },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.86.0.tgz",
-      "integrity": "sha512-4O1XVUxLTIjMOvrziYwEZgvFqC5sF6t0hTAPJ+h2uiAUZg9Joo0PvuEedXurjISgDBsb5W5DTL9hH9q1BbP4cQ==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.86.1.tgz",
+      "integrity": "sha512-qRLZR3yLuk/3y64YhcltkwGclhPoK6EdiLP1e5SVw5+kughcs+mNUZ3rdvSAmCSA4vDv+XOiOjRpjxmpeon95Q==",
       "cpu": [
         "arm64"
       ],
@@ -28786,9 +28874,9 @@
       }
     },
     "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.86.0.tgz",
-      "integrity": "sha512-zuSP2axkGm4VaJWt38P464H+4424Swr9bzFNfbbznxe3Ue4RuqSBqwiLiYdg9Q1cecTQ2WGH7G7WO56KK7WLwg==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.86.1.tgz",
+      "integrity": "sha512-o860a7/YGHZnGeY3l/e6yt3+ZMeDdDHmthTaKnw2wpJNEq0nmytYLTJQmjWPxEMz7O8AQ0LtcbDDrhivSog+KQ==",
       "cpu": [
         "ia32"
       ],
@@ -28803,9 +28891,9 @@
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.86.0.tgz",
-      "integrity": "sha512-GVX0CHtukr3kjqfqretSlPiJzV7V4JxUjpRZV+yC9gUMTiDErilJh2Chw1r0+MYiYvumCDUSDlticmvJs7v0tA==",
+      "version": "1.86.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.86.1.tgz",
+      "integrity": "sha512-7Z3wsVKfseJodmv689dDEV/JrXJH5TAclWNvHrEYW5BtoViOTU2pIDxRgLYzdKU9teIw5g6R0nJZb9M105oIKA==",
       "cpu": [
         "x64"
       ],
@@ -33083,7 +33171,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -33097,7 +33184,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-json-file": {
@@ -33587,9 +33673,9 @@
       }
     },
     "packages/components/node_modules/@nx/devkit": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.6.4.tgz",
-      "integrity": "sha512-lyEidfyPhTuHt1X6EsskugBREazS5VOKSPIcreQ8Qt0MaULxn0bQ9o0N6C+BQaw5Zu6RTaMRMWKGW0I0Qni0UA==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.7.0.tgz",
+      "integrity": "sha512-BzgeF7sVM6eLVVZIkhqwkSu8hzKx+Wa/bLyMithiU+aLJVGALWFQriDS68MBMA+MHyodKwV3QHQH9/9/UO6uyg==",
       "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.7",
@@ -33630,9 +33716,9 @@
       }
     },
     "packages/components/node_modules/@nx/nx-darwin-arm64": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.6.4.tgz",
-      "integrity": "sha512-urdLFCY0c2X11FBuokSgCktKTma7kjZKWJi8mVO8PbTJh0h2Qtp4l9/px8tv9EHeHuusA18p2Wq3ZM6c95qcBg==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.7.0.tgz",
+      "integrity": "sha512-SuPP4AlBGuQjfkgFaGAO66GEUll0Isir5HKa0w0LcehHmxncE9LT4YagEJONPDp6SVDIjpoFIRw71jf9toFvPQ==",
       "cpu": [
         "arm64"
       ],
@@ -33646,9 +33732,9 @@
       }
     },
     "packages/components/node_modules/@nx/nx-darwin-x64": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.6.4.tgz",
-      "integrity": "sha512-nNOXc9ccdsdmylC/InRud/F977ldat2zQuSWfhoI5+9exHIjMo0TNU8gZdT53t3S1OTQKOEbNXZcoEaURb6STA==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.7.0.tgz",
+      "integrity": "sha512-eJnGtZmXzhRqitBBSIU7CjUjEGyo7QMZlvTQsqIpkZDay3v3JyQ9tikdGe3L6BwnTgeFQsBxNfK3ddmwTyK19g==",
       "cpu": [
         "x64"
       ],
@@ -33662,9 +33748,9 @@
       }
     },
     "packages/components/node_modules/@nx/nx-freebsd-x64": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.6.4.tgz",
-      "integrity": "sha512-jPGzjdB9biMu8N4038qBe0VBfrQ+HDjXfxBhETqrVIJPBfgdxN1I8CXIhCqMPG2CHBAM6kDQCU6QCTMWADJcEw==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.7.0.tgz",
+      "integrity": "sha512-WhuK5XGy2c7WNMrVW2+mWMb0MCvgoOaSUxvxpl8OORdENYmgsUjYUDVnndjqRdSzcQTB/WfQX5G7bJQhySzaww==",
       "cpu": [
         "x64"
       ],
@@ -33678,9 +33764,9 @@
       }
     },
     "packages/components/node_modules/@nx/nx-linux-arm-gnueabihf": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.6.4.tgz",
-      "integrity": "sha512-j4ekxzZPc5lj+VbaLBpKJl6w2VyFXycLrT65CWQYAj9yqV5dUuDtTR33r50ddLtqQt3PVV5hJAj8+g7sGPXUWQ==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.7.0.tgz",
+      "integrity": "sha512-TZKDjO/YyOT/Zq449kIpkw9OUD4EQlmMk+aM8WW29VirJnnIfGxhjfCBkSRmVIOvwSlIf7GKLQjDuWwcObIZRg==",
       "cpu": [
         "arm"
       ],
@@ -33694,9 +33780,9 @@
       }
     },
     "packages/components/node_modules/@nx/nx-linux-arm64-gnu": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.6.4.tgz",
-      "integrity": "sha512-nYMB4Sh5yI7WbunizZ/mgR21MQgrs77frnAChs+6aPF5HA7N1VGEn3FMKX+ypd3DjTl14zuwB/R5ilwNgKzL+A==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.7.0.tgz",
+      "integrity": "sha512-wEkE/MRcPQHZK10SgocPGCEyqFksLDdsSeE2fyVZb+N+vUGSp5YBu7OE6mUKobIs3uUXgftqP4d7QXTlehb7gw==",
       "cpu": [
         "arm64"
       ],
@@ -33710,9 +33796,9 @@
       }
     },
     "packages/components/node_modules/@nx/nx-linux-arm64-musl": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.6.4.tgz",
-      "integrity": "sha512-ukjB1pmBvtinT0zeYJ1lWi7BAw6cDnPQnfXMbyV+afYnNRcgdDFzQaUpo3UUeai69Fo3TTr0SWx6DjMVifxJZw==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.7.0.tgz",
+      "integrity": "sha512-je7OmX7d41ihMzq4/q6AOsYGfiH5B3xIsAKBfXHSmlGcaijnxMCzSHzjR3znxhmOS0bMcfICXCCwm1AVcyUAUA==",
       "cpu": [
         "arm64"
       ],
@@ -33726,9 +33812,9 @@
       }
     },
     "packages/components/node_modules/@nx/nx-linux-x64-gnu": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.6.4.tgz",
-      "integrity": "sha512-+6DloqqB8ZzuZOY4A1PryuPD5hGoxbSafRN++sXUFvKx6mRYNyLGrn5APT3Kiq1qPBxkAxcsreexcu/wsTcrcw==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.7.0.tgz",
+      "integrity": "sha512-dF5/VJgtbydSgu9WjL1CrzNIXZR/9Z92b4f7lrvd/KO/LwBB3EVavgV0tSq0TAFuu4n5eSo66SA1j0miIBA1dg==",
       "cpu": [
         "x64"
       ],
@@ -33742,9 +33828,9 @@
       }
     },
     "packages/components/node_modules/@nx/nx-linux-x64-musl": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.6.4.tgz",
-      "integrity": "sha512-+ZuF6dobfGo5EN55syuUEdbYs9qxbLmTkGPMq66X7dZ/jm7kKTsVzDYnf9v3ynQCOq4DMFtdACneL32Ks22+NQ==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.7.0.tgz",
+      "integrity": "sha512-Jy760sdTDgzplpWerrUpfugmHnjQoNbCdcrNiBm1HaL2+P/6Wl2eZ2zLW3Uw5/D/wf7z8qsokMrPO9XdvnZ3cA==",
       "cpu": [
         "x64"
       ],
@@ -33758,9 +33844,9 @@
       }
     },
     "packages/components/node_modules/@nx/nx-win32-arm64-msvc": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.6.4.tgz",
-      "integrity": "sha512-z+Y8iwEPZ8L8SISh/tcyqEtAy9Ju6aB5kLe8E/E1Wwzy5DU/jNvqM9Wq4HRPMY0r1S4jzwC6x7W3/fkxeFjZ7A==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.7.0.tgz",
+      "integrity": "sha512-5UvJg1RfOeSwcMr/7ghQA5yH3kpU8wye81sCLtyKPfBeH312Ntm52+ckc1IiCFAIkVyo2rmWF9ogRzOTR1O9sw==",
       "cpu": [
         "arm64"
       ],
@@ -33774,9 +33860,9 @@
       }
     },
     "packages/components/node_modules/@nx/nx-win32-x64-msvc": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.6.4.tgz",
-      "integrity": "sha512-9LMVHZQqc1m2Fulvfz1nPZFHUKvFjmU7igxoWJXj/m+q+DyYWEbE710ARK9JtMibLg+xSRfERKOcIy11k6Ro1A==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.7.0.tgz",
+      "integrity": "sha512-Ddtk/owLLj1wRHB5MUuUjEfxn9h6sQntOpCC1qDYJLCLRGe3jCEx7MHxKWo5MlmtShXeHRrS27CrA5AGzSS+6w==",
       "cpu": [
         "x64"
       ],
@@ -34441,9 +34527,9 @@
       }
     },
     "packages/components/node_modules/nx": {
-      "version": "20.6.4",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-20.6.4.tgz",
-      "integrity": "sha512-mkRgGvPSZpezn65upZ9psuyywr03XTirHDsqlnRYp90qqDQqMH/I1FsHqqUG5qdy4gbm5qFkZ5Vvc8Z3RkN/jg==",
+      "version": "20.7.0",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-20.7.0.tgz",
+      "integrity": "sha512-IcrQr6alrSJTl5pb80Y/ytwK5Bsx7zC0LbJj5Ck5K+dctFKO2sEAvB2hKz5GiZx92NJzcfCVc5Lu44UeZST1bw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -34487,16 +34573,16 @@
         "nx-cloud": "bin/nx-cloud.js"
       },
       "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "20.6.4",
-        "@nx/nx-darwin-x64": "20.6.4",
-        "@nx/nx-freebsd-x64": "20.6.4",
-        "@nx/nx-linux-arm-gnueabihf": "20.6.4",
-        "@nx/nx-linux-arm64-gnu": "20.6.4",
-        "@nx/nx-linux-arm64-musl": "20.6.4",
-        "@nx/nx-linux-x64-gnu": "20.6.4",
-        "@nx/nx-linux-x64-musl": "20.6.4",
-        "@nx/nx-win32-arm64-msvc": "20.6.4",
-        "@nx/nx-win32-x64-msvc": "20.6.4"
+        "@nx/nx-darwin-arm64": "20.7.0",
+        "@nx/nx-darwin-x64": "20.7.0",
+        "@nx/nx-freebsd-x64": "20.7.0",
+        "@nx/nx-linux-arm-gnueabihf": "20.7.0",
+        "@nx/nx-linux-arm64-gnu": "20.7.0",
+        "@nx/nx-linux-arm64-musl": "20.7.0",
+        "@nx/nx-linux-x64-gnu": "20.7.0",
+        "@nx/nx-linux-x64-musl": "20.7.0",
+        "@nx/nx-win32-arm64-msvc": "20.7.0",
+        "@nx/nx-win32-x64-msvc": "20.7.0"
       },
       "peerDependencies": {
         "@swc-node/register": "^1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33301,7 +33301,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33363,7 +33363,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33374,7 +33374,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+        "@infineon/infineon-design-system-angular": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33394,7 +33394,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33403,16 +33403,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0"
+        "@infineon/infineon-design-system-stencil": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+        "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33426,11 +33426,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0"
+        "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33171,6 +33171,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -33184,6 +33185,7 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-json-file": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33301,7 +33301,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33363,7 +33363,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33374,7 +33374,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+        "@infineon/infineon-design-system-angular": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33394,7 +33394,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33403,16 +33403,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0"
+        "@infineon/infineon-design-system-stencil": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+        "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33426,11 +33426,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+      "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0"
+        "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3459,34 +3459,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -5512,14 +5484,6 @@
         "@inquirer/prompts": ">= 3 < 6"
       }
     },
-    "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
-      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
     "node_modules/@lit/react": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.7.tgz",
@@ -5527,17 +5491,6 @@
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "@types/react": "17 || 18 || 19"
-      }
-    },
-    "node_modules/@lit/reactive-element": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
-      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
@@ -9034,6 +8987,7 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9054,6 +9008,7 @@
       "version": "18.3.20",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -9139,14 +9094,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -9760,13 +9707,6 @@
       "engines": {
         "node": ">=8.9.0"
       }
-    },
-    "node_modules/ag-grid-community": {
-      "version": "31.3.4",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
-      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -11283,18 +11223,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/choices.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-10.2.0.tgz",
-      "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "deepmerge": "^4.2.2",
-        "fuse.js": "^6.6.2",
-        "redux": "^4.2.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -12364,6 +12292,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -14516,16 +14445,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -16775,14 +16694,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/jasmine-core": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
-      "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/jest": {
       "version": "29.7.0",
@@ -19932,43 +19843,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/lit": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
-      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit-element": "^4.1.0",
-        "lit-html": "^3.2.0"
-      }
-    },
-    "node_modules/lit-element": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
-      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.0.4",
-        "lit-html": "^3.2.0"
-      }
-    },
-    "node_modules/lit-html": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
-      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/lmdb": {
@@ -26973,22 +26847,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
     "node_modules/pretty-error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
@@ -27436,6 +27294,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -27757,16 +27616,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {
@@ -33452,7 +33301,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+      "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
@@ -33514,7 +33363,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+      "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33525,7 +33374,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+        "@infineon/infineon-design-system-angular": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33545,7 +33394,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+      "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33554,16 +33403,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1"
+        "@infineon/infineon-design-system-stencil": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+      "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+        "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33577,11 +33426,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+      "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "4.0.0",
-        "@infineon/infineon-design-system-stencil": "^32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1"
+        "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3459,6 +3459,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -8987,7 +9015,6 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/qs": {
@@ -9008,7 +9035,6 @@
       "version": "18.3.20",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -9707,6 +9733,13 @@
       "engines": {
         "node": ">=8.9.0"
       }
+    },
+    "node_modules/ag-grid-community": {
+      "version": "31.3.4",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.3.4.tgz",
+      "integrity": "sha512-jOxQO86C6eLnk1GdP24HB6aqaouFzMWizgfUwNY5MnetiWzz9ZaAmOGSnW/XBvdjXvC5Fpk3gSbvVKKQ7h9kBw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.3",
@@ -11223,6 +11256,18 @@
         "node": ">= 16"
       }
     },
+    "node_modules/choices.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-10.2.0.tgz",
+      "integrity": "sha512-8PKy6wq7BMjNwDTZwr3+Zry6G2+opJaAJDDA/j3yxvqSCnvkKe7ZIFfIyOhoc7htIWFhsfzF9tJpGUATcpUtPg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "fuse.js": "^6.6.2",
+        "redux": "^4.2.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -12292,7 +12337,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/custom-event": {
@@ -14445,6 +14489,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -27294,7 +27348,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -27616,6 +27669,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/reflect-metadata": {

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+    "@infineon/infineon-design-system-angular": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+    "@infineon/infineon-design-system-angular": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+    "@infineon/infineon-design-system-angular": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1"
+    "@infineon/infineon-design-system-stencil": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0"
+    "@infineon/infineon-design-system-stencil": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0"
+    "@infineon/infineon-design-system-stencil": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+    "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+    "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+    "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0"
+    "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0"
+    "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "4.0.0",
-    "@infineon/infineon-design-system-stencil": "^32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1"
+    "@infineon/infineon-design-system-stencil": "^32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.9.0--canary.1690.97fe3764ef843f1212540449b20e75dfa844f483.1",
+  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "32.9.1--canary.1807.cb4f8690776423d0e6ca0cbd55c5923849a12f20.0",
+  "version": "32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/text-field/readme.md
+++ b/packages/components/src/components/text-field/readme.md
@@ -14,7 +14,7 @@
 | `disabled`       | `disabled`         |             | `boolean`              | `false`         |
 | `error`          | `error`            |             | `boolean`              | `false`         |
 | `icon`           | `icon`             |             | `string`               | `""`            |
-| `internalId`     | `internal-id`      |             | `string`               | `""`            |
+| `internalId`     | `internal-id`      |             | `string`               | `"text-field"`  |
 | `label`          | `label`            |             | `string`               | `""`            |
 | `maxlength`      | `maxlength`        |             | `number`               | `undefined`     |
 | `optional`       | `optional`         |             | `boolean`              | `false`         |

--- a/packages/components/src/components/text-field/readme.md
+++ b/packages/components/src/components/text-field/readme.md
@@ -14,6 +14,7 @@
 | `disabled`       | `disabled`         |             | `boolean`              | `false`         |
 | `error`          | `error`            |             | `boolean`              | `false`         |
 | `icon`           | `icon`             |             | `string`               | `""`            |
+| `internalId`     | `internal-id`      |             | `string`               | `""`            |
 | `label`          | `label`            |             | `string`               | `""`            |
 | `maxlength`      | `maxlength`        |             | `number`               | `undefined`     |
 | `optional`       | `optional`         |             | `boolean`              | `false`         |

--- a/packages/components/src/components/text-field/text-field.stories.ts
+++ b/packages/components/src/components/text-field/text-field.stories.ts
@@ -21,7 +21,8 @@ export default {
     maxlength: '',
     value: '',
     autocomplete: 'on',
-    type: 'text'
+    type: 'text',
+    internalId: 'text-field'
   },
 
   argTypes: {
@@ -143,6 +144,19 @@ export default {
         }
       }
     },
+    internalId: {
+      description: 'Sets the ID of the internal input and the value of htmlFor for the label element',
+      control: 'text',
+      table: {
+        category: 'ifx-text-field props',
+        defaultValue: {
+          summary: 'text-field'
+        },
+        type: {
+          summary: 'string'
+        }
+      }
+    },
     autocomplete: {
       description: 'Sets the autocomplete attribute. "on" by default.',
       control: 'text',
@@ -182,7 +196,7 @@ export default {
   },
 };
 
-const DefaultTemplate = ({ error, disabled, success, size, placeholder, label, caption, icon, required, optional, name, maxlength, showDeleteIcon, value, autocomplete, type }) => {
+const DefaultTemplate = ({ error, disabled, success, size, placeholder, label, caption, icon, required, optional, name, maxlength, showDeleteIcon, value, autocomplete, type, internalId }) => {
   const element = document.createElement('ifx-text-field');
   element.setAttribute('error', error);
   element.setAttribute('disabled', disabled);
@@ -198,6 +212,7 @@ const DefaultTemplate = ({ error, disabled, success, size, placeholder, label, c
   element.setAttribute('value', value);
   element.setAttribute('autocomplete', autocomplete);
   element.setAttribute('type', type);
+  element.setAttribute('internal-id', internalId);
   if (maxlength) element.setAttribute('maxlength', maxlength);
 
   element.addEventListener('ifxInput', action('ifxInput'));

--- a/packages/components/src/components/text-field/text-field.tsx
+++ b/packages/components/src/components/text-field/text-field.tsx
@@ -26,6 +26,7 @@ export class TextField {
   @Prop() showDeleteIcon: boolean = false;
   @Prop() autocomplete: string = 'on'
   @Prop() type: 'text' | 'password' = 'text';
+  @Prop() internalId: string = "text-field"
   @State() internalType: string;
   @Event() ifxInput: EventEmitter<String>;
   // @Prop({ reflect: true })
@@ -76,7 +77,7 @@ export class TextField {
     return (
       <div aria-label="a text field for user input" aria-value={this.value} aria-disabled={this.disabled} class={`textInput__container ${this.disabled ? 'disabled' : ""}`}>
         <div class="textInput__top-wrapper">
-          <label htmlFor="text-field">
+          <label htmlFor={this.internalId}>
             <slot></slot>
             {this.optional && this.required ? (
               <span class="optional-required">(optional) *</span>
@@ -98,7 +99,7 @@ export class TextField {
               disabled={this.disabled}
               autocomplete={this.autocomplete}
               type={this.internalType}
-              id='text-field'
+              id={this.internalId}
               value={this.value}
               onInput={() => this.handleInput()}
               placeholder={this.placeholder}


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

The PR makes the id of the internal input and its attached label customizable via a prop, so users can set it manually in order to prevent synced autofilling. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1
  # or 
  yarn add @infineon/infineon-design-system-stencil@32.9.1--canary.1807.21c4782cf65ca03365682865b763e8b64c4208df.1
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
