### PR TITLE
Bugfix: Fonts dont get displayed on Mac or iPhone

### DIFF
--- a/.github/workflows/shipit_pr_and_example_apps_deployment.yml
+++ b/.github/workflows/shipit_pr_and_example_apps_deployment.yml
@@ -89,28 +89,40 @@ jobs:
           echo "CANARY_VERSION: $CANARY_VERSION"
           echo "Installing Stencil library for Angular, Vue and React: $CANARY_VERSION"
           lerna version $CANARY_VERSION --no-git-tag-version --y
-      
+
           # Update Angular package
           cd packages/components-angular/projects/component-library
-          jq --arg CANARY_VERSION "$CANARY_VERSION" '.peerDependencies["@infineon/infineon-design-system-stencil"] = $CANARY_VERSION' package.json > package.json.tmp && mv package.json.tmp package.json
+          jq 'del(.peerDependencies["@infineon/infineon-design-system-stencil"])' package.json > tmp && mv tmp package.json
+          jq --arg CANARY_VERSION "$CANARY_VERSION" '.peerDependencies["@infineon/infineon-design-system-stencil"] = $CANARY_VERSION' package.json > tmp && mv tmp package.json
           cd ../../../../
-      
+
           # Update Vue package
           cd packages/components-vue
-          jq --arg CANARY_VERSION "$CANARY_VERSION" '.dependencies["@infineon/infineon-design-system-stencil"] = $CANARY_VERSION' package.json > package.json.tmp && mv package.json.tmp package.json
-      
+          CANARY_VERSION_CLEAN=$(echo "$CANARY_VERSION" | sed 's/^[\^~]*//') # strip any leading ^ or ~ just in case
+          jq 'del(.dependencies["@infineon/infineon-design-system-stencil"])' package.json > tmp && mv tmp package.json
+          jq --arg v "$CANARY_VERSION_CLEAN" '.dependencies["@infineon/infineon-design-system-stencil"] = $v' package.json > tmp && mv tmp package.json
+ 
           # Update React package
           cd ../components-react
-          jq --arg CANARY_VERSION "$CANARY_VERSION" \
-            '.dependencies["@infineon/infineon-design-system-stencil"] = $CANARY_VERSION' \
-            package.json > package.json.tmp && mv package.json.tmp package.json
+          jq 'del(.dependencies["@infineon/infineon-design-system-stencil"])' package.json > tmp && mv tmp package.json
+          jq --arg CANARY_VERSION "$CANARY_VERSION" '.dependencies["@infineon/infineon-design-system-stencil"] = $CANARY_VERSION' package.json > tmp && mv tmp package.json
 
-          # Install the updated dependency
-          npm install @infineon/infineon-design-system-stencil@$CANARY_VERSION
+          # Retry install of published Stencil package (race condition safe)
+          RETRIES=5
+          for i in $(seq 1 $RETRIES); do
+            echo "Attempt $i to install Stencil version: $CANARY_VERSION"
+            if npm install "@infineon/infineon-design-system-stencil@$CANARY_VERSION" --save-exact; then
+              echo "✅ Installed successfully on attempt $i"
+              break
+            else
+              echo "❌ Failed, retrying in $((i * 5)) seconds..."
+              sleep $((i * 5))
+            fi
+          done
+
           cd ../../
-                 
           npm install
-      
+
           # Verify updates
           echo "Verifying updates in Angular package"
           jq '.peerDependencies["@infineon/infineon-design-system-stencil"]' packages/components-angular/projects/component-library/package.json
@@ -118,6 +130,7 @@ jobs:
           jq '.dependencies["@infineon/infineon-design-system-stencil"]' packages/components-vue/package.json
           echo "Verifying updates in React package"
           jq '.dependencies["@infineon/infineon-design-system-stencil"]' packages/components-react/package.json
+
             
       - name: Build and deploy Angular, Vue and React packages
         if: steps.build.outputs.SKIP_REMAINING == 'false'

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+    "@infineon/infineon-design-system-react": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+    "@infineon/infineon-design-system-react": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+    "@infineon/infineon-design-system-vue": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+    "@infineon/infineon-design-system-vue": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,12 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
   "command": {
     "publish": {
       "verifyAccess": false
+    },
+    "version": {
+      "exact": true
     }
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+  "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33301,7 +33301,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+      "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -33363,7 +33363,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+      "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33374,7 +33374,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+        "@infineon/infineon-design-system-angular": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33394,7 +33394,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+      "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33403,16 +33403,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0"
+        "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+      "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+        "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33426,11 +33426,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+      "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0"
+        "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33301,7 +33301,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+      "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -33363,7 +33363,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+      "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33374,7 +33374,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "^33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+        "@infineon/infineon-design-system-angular": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33394,7 +33394,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+      "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33403,16 +33403,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1"
+        "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+      "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "^33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+        "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33426,11 +33426,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+      "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "^33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1"
+        "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "^33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+    "@infineon/infineon-design-system-angular": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+  "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+    "@infineon/infineon-design-system-angular": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1"
+    "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+  "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0"
+    "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "^33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+    "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+  "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+    "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+  "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0"
+    "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "^33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1"
+    "@infineon/infineon-design-system-stencil": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/.storybook/exported-sass-array.json
+++ b/packages/components/.storybook/exported-sass-array.json
@@ -761,8 +761,8 @@
   },
   {
     "name": "$ifxLineHeight7xl",
-    "value": "3.25rem",
-    "compiledValue": "3.25rem"
+    "value": "3.5rem",
+    "compiledValue": "3.5rem"
   },
   {
     "name": "$ifxLineHeight8xl",
@@ -856,8 +856,8 @@
   },
   {
     "name": "$ifxHeadingHeading01",
-    "value": "600 2.75rem/3.25rem 'Source Sans 3'",
-    "compiledValue": "600 2.75rem/3.25rem Source Sans 3"
+    "value": "600 2.75rem/3.5rem 'Source Sans 3'",
+    "compiledValue": "600 2.75rem/3.5rem Source Sans 3"
   },
   {
     "name": "$ifxHeadingHeadingCompact01",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
+  "version": "33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "33.1.0--canary.1811.4ac04cfa69fd0fdda43c50ce117eefa120588bc0.1",
+  "version": "33.1.1--canary.1818.9d0a456ff7511e284942d424fe3fbe95edc8d85e.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/accordion/accordion.scss
+++ b/packages/components/src/components/accordion/accordion.scss
@@ -10,6 +10,6 @@
   display: flex;
   flex-direction: column;
   gap: tokens.$ifxSpace100;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
 }

--- a/packages/components/src/components/accordion/accordionItem.scss
+++ b/packages/components/src/components/accordion/accordionItem.scss
@@ -7,7 +7,7 @@
   border-radius: 3px;
   overflow: hidden;
   transition: all 0.3s;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
 }
 

--- a/packages/components/src/components/alert/alert.scss
+++ b/packages/components/src/components/alert/alert.scss
@@ -8,9 +8,8 @@
 .alert__info-wrapper {
   display: flex;
   padding: 16px 24px;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   box-shadow: 0px 6px 9px 0px #1D1D1D1A;
-
 
   & .info__text-wrapper {
     display: flex;
@@ -78,7 +77,7 @@
   border-radius: tokens.$ifxBorderRadius12;
   color: tokens.$ifxColorBaseBlack;
   background-color: tokens.$ifxColorBaseWhite;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   box-shadow: 0px 6px 9px 0px #1D1D1D1A;
 
 

--- a/packages/components/src/components/badge/badge.scss
+++ b/packages/components/src/components/badge/badge.scss
@@ -14,7 +14,7 @@
   border: 1px solid tokens.$ifxColorEngineering200;
   background-color: tokens.$ifxColorEngineering200;
   border-radius: 100px;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   font-size: tokens.$ifxFontSizeS;
   line-height: tokens.$ifxLineHeightS;
   font-weight: 400;

--- a/packages/components/src/components/breadcrumb/breadcrumb-item.scss
+++ b/packages/components/src/components/breadcrumb/breadcrumb-item.scss
@@ -35,7 +35,7 @@
     & a {
       text-decoration: none;
       color: tokens.$ifxColorBaseBlack;
-      font-family: var(--ifx-font-family);
+      font-family: tokens.$ifxFontFamilyBody;
       font-style: normal;
       font-weight: 400;
       font-size: tokens.$ifxFontSizeS;

--- a/packages/components/src/components/breadcrumb/breadcrumb.scss
+++ b/packages/components/src/components/breadcrumb/breadcrumb.scss
@@ -11,7 +11,7 @@
   margin: 0px;
   display: flex;
   flex-direction: row;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   font-size: tokens.$ifxFontSizeS;
   align-items: flex-start;
   //gap: tokens.$ifxSpace200; //this is where the gap comes from

--- a/packages/components/src/components/button/button.scss
+++ b/packages/components/src/components/button/button.scss
@@ -19,7 +19,7 @@
   font-weight: tokens.$ifxFontWeightSemibold;
   border-radius: tokens.$ifxBorderRadius12;
   line-height: tokens.$ifxLineHeightM;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   font-style: normal;
   text-decoration: none;
   user-select: none;

--- a/packages/components/src/components/card/card-headline/card-headline.scss
+++ b/packages/components/src/components/card/card-headline/card-headline.scss
@@ -16,7 +16,7 @@
 .card-headline {
   margin-top: 0;
   padding-top: 0;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   font-weight: tokens.$ifxFontWeightSemibold;
   font-size: tokens.$ifxFontSize3xl;
   line-height: tokens.$ifxLineHeight3xl;

--- a/packages/components/src/components/card/card.scss
+++ b/packages/components/src/components/card/card.scss
@@ -17,7 +17,7 @@
   //width: 22rem;
   width: 350px;
   height: auto;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   // when the link is focused or hovered, the border color changes
   &:has(.card-href:focus), &:has(.card-href:hover) {

--- a/packages/components/src/components/checkbox-group/checkbox-group.scss
+++ b/packages/components/src/components/checkbox-group/checkbox-group.scss
@@ -8,7 +8,7 @@
 
 .checkbox-group {
     display: flex;
-    font-family: var(--ifx-font-family);
+    font-family: tokens.$ifxFontFamilyBody;
     gap: tokens.$ifxSpace100;
 
     &.horizontal {

--- a/packages/components/src/components/checkbox/checkbox.scss
+++ b/packages/components/src/components/checkbox/checkbox.scss
@@ -12,7 +12,7 @@
     align-items: top;
     padding: 0px;
     gap: tokens.$ifxSpace100;
-    font-family: var(--ifx-font-family);
+    font-family: tokens.$ifxFontFamilyBody;
 
     & .checkbox__wrapper {
         box-sizing: border-box;

--- a/packages/components/src/components/dropdown/dropdown-header/dropdown-header.scss
+++ b/packages/components/src/components/dropdown/dropdown-header/dropdown-header.scss
@@ -8,12 +8,12 @@
   gap: 8px;
   align-self: stretch;
   border-bottom: 1px solid tokens.$ifxColorEngineering200;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
 
   & span {
     color: tokens.$ifxColorEngineering500;
-    font-family: var(--ifx-font-family);
+    font-family: tokens.$ifxFontFamilyBody;
     font-size: 14px;
     font-style: normal;
     font-weight: 400;

--- a/packages/components/src/components/dropdown/dropdown-item/dropdown-item.scss
+++ b/packages/components/src/components/dropdown/dropdown-item/dropdown-item.scss
@@ -8,7 +8,7 @@
   align-items: center;
   padding: 8px 16px;
   gap: tokens.$ifxSize100;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &.hide {
     display: none;

--- a/packages/components/src/components/dropdown/dropdown-menu/dropdown-menu.scss
+++ b/packages/components/src/components/dropdown/dropdown-menu/dropdown-menu.scss
@@ -17,7 +17,7 @@
   box-shadow: 0px 6px 9px 0px #1d1d1d1a;
   border: 1px solid tokens.$ifxColorEngineering200;
   padding: 8px 0px;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &.small {
     max-height: 266px;

--- a/packages/components/src/components/footer/footer-column.scss
+++ b/packages/components/src/components/footer/footer-column.scss
@@ -8,7 +8,7 @@
   gap: tokens.$ifxSpace150;
   padding-right: 8px;
   color: tokens.$ifxColorBaseBlack;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   & ::slotted([slot=title]) {
     box-sizing: border-box;

--- a/packages/components/src/components/footer/footer.scss
+++ b/packages/components/src/components/footer/footer.scss
@@ -14,7 +14,7 @@
   justify-content: center;
   align-items: center;
   background-color: tokens.$ifxColorBaseWhite;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   & .footer__wrapper {
     display: flex;

--- a/packages/components/src/components/icon-button/icon-button.scss
+++ b/packages/components/src/components/icon-button/icon-button.scss
@@ -18,7 +18,7 @@
   border-radius: tokens.$ifxBorderRadius12;
   line-height: tokens.$ifxLineHeightM;
   outline: none;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   text-decoration: none;
   user-select: none;
   border: 1px solid rgba(0, 0, 0, 0);

--- a/packages/components/src/components/link/link.scss
+++ b/packages/components/src/components/link/link.scss
@@ -14,7 +14,7 @@
   color: tokens.$ifxColorOcean500;
   gap: tokens.$ifxSpace100;
   line-height: 1.6;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &:hover { 
     cursor: pointer;

--- a/packages/components/src/components/modal/modal.scss
+++ b/packages/components/src/components/modal/modal.scss
@@ -16,7 +16,7 @@
   height: 100%;
   z-index: 1060;
   overflow-y: auto;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
 }
 

--- a/packages/components/src/components/navigation/navbar/navbar-item.scss
+++ b/packages/components/src/components/navigation/navbar/navbar-item.scss
@@ -13,7 +13,7 @@
   flex: none;
   order: 0;
   flex-grow: 0;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   text-decoration: none;
   font-weight: 400;
   font-size: 16px;
@@ -229,7 +229,7 @@
   box-shadow: 0px 6px 9px 0px #1d1d1d1a;
   border: 1px solid tokens.$ifxColorEngineering200;
   padding: 8px 0px;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &.open:not(.itemInMobileMenu) {
     display: flex;
@@ -290,7 +290,7 @@
     justify-content: space-between;
     padding: 8px 16px;
     gap: 8px;
-    font-family: var(--ifx-font-family);
+    font-family: tokens.$ifxFontFamilyBody;
   
     &.hide {
       display: none;

--- a/packages/components/src/components/navigation/navbar/navbar.scss
+++ b/packages/components/src/components/navigation/navbar/navbar.scss
@@ -8,7 +8,7 @@
 
 
 .navbar__wrapper {
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   height: 63px;
   position: sticky;
   //overflow: hidden;
@@ -268,7 +268,7 @@
   padding: 8px 40px;
   gap: 16px;
   background-color: tokens.$ifxColorBaseWhite;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &.expanded { 
     justify-content: initial;

--- a/packages/components/src/components/navigation/sidebar/sidebar-item.scss
+++ b/packages/components/src/components/navigation/sidebar/sidebar-item.scss
@@ -63,7 +63,7 @@
   text-decoration: none;
   color: tokens.$ifxColorBaseBlack;
   cursor: pointer;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &.extra-padding__bottom {
     padding: 8px 0px 16px 0px;

--- a/packages/components/src/components/navigation/sidebar/sidebar.scss
+++ b/packages/components/src/components/navigation/sidebar/sidebar.scss
@@ -16,7 +16,7 @@
   border-right: 1px solid #EEEDED;
   width: 264px;
   height: 100%;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   & .sidebar__top-container {
     display: flex;

--- a/packages/components/src/components/notification/notification.scss
+++ b/packages/components/src/components/notification/notification.scss
@@ -9,7 +9,7 @@
   padding: tokens.$ifxSpace100 tokens.$ifxSpace200;
 
   background-color: tokens.$ifxColorBaseWhite;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   color: tokens.$ifxColorBaseBlack;
 
   border: tokens.$ifxBorderWidth12 solid tokens.$ifxColorEngineering200;

--- a/packages/components/src/components/pagination/pagination.scss
+++ b/packages/components/src/components/pagination/pagination.scss
@@ -10,7 +10,7 @@
   justify-content: center;
   align-items: center;
   gap: 32px;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
 
   & .items__per-page-wrapper {

--- a/packages/components/src/components/progress-bar/progress-bar.scss
+++ b/packages/components/src/components/progress-bar/progress-bar.scss
@@ -18,7 +18,7 @@
   width: 100%; // Ensure the bar itself can grow up to 100% width
   overflow: hidden; // Ensures that the inner progress bar doesn't exceed the width of the outer progress bar
   background-color: tokens.$ifxColorEngineering200;
-  font-family: var(--ifx-font-family, sans-serif);
+  font-family: tokens.$ifxFontFamilyBody;  
   
   &.s {
     height: 4px;

--- a/packages/components/src/components/radio-button-group/radio-button-group.scss
+++ b/packages/components/src/components/radio-button-group/radio-button-group.scss
@@ -8,7 +8,7 @@
 
 .radio-button-group {
     display: flex;
-    font-family: var(--ifx-font-family);
+    font-family: tokens.$ifxFontFamilyBody;
     gap: tokens.$ifxSpace100;
 
     &.horizontal {

--- a/packages/components/src/components/radio-button/radio-button.scss
+++ b/packages/components/src/components/radio-button/radio-button.scss
@@ -26,7 +26,7 @@
     padding: 0px;
     gap: tokens.$ifxSpace100;
     cursor: pointer;
-    font-family: var(--ifx-font-family);
+    font-family: tokens.$ifxFontFamilyBody;
 
     &.m .radioButton__wrapper {
         width: tokens.$ifxSize300;

--- a/packages/components/src/components/search-bar/search-bar.scss
+++ b/packages/components/src/components/search-bar/search-bar.scss
@@ -14,7 +14,7 @@
   flex-direction: row;
   align-items: center;
   width: 100%;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &.closed {
     display: flex;

--- a/packages/components/src/components/search-field/search-field.scss
+++ b/packages/components/src/components/search-field/search-field.scss
@@ -9,7 +9,7 @@
   box-sizing: border-box;
   background-color: tokens.$ifxColorBaseWhite;
   width: 100%;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
 
   .search-field__wrapper {

--- a/packages/components/src/components/select/multi-select/multiselect.scss
+++ b/packages/components/src/components/select/multi-select/multiselect.scss
@@ -5,7 +5,7 @@
 .ifx-multiselect-container {
   position: relative;
   box-sizing: border-box;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &.small-select {
     height: 36px;

--- a/packages/components/src/components/select/single-select/select.scss
+++ b/packages/components/src/components/select/single-select/select.scss
@@ -9,7 +9,7 @@
 
 .ifx-select-container {
   box-sizing: border-box;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &.small-select {
     height: 36px;

--- a/packages/components/src/components/status/status.scss
+++ b/packages/components/src/components/status/status.scss
@@ -11,7 +11,7 @@
   align-items: center;
   padding: 0 tokens.$ifxSpace100;
   border-radius: tokens.$ifxBorderRadiusRound;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &.no-border {
     padding: 0; // Remove padding when border is not present

--- a/packages/components/src/components/table-advanced-version/filter-type-group/filter-search/filter-search.scss
+++ b/packages/components/src/components/table-advanced-version/filter-type-group/filter-search/filter-search.scss
@@ -9,7 +9,7 @@
   align-items: flex-start;
   align-self: stretch;
   gap: tokens.$ifxSpace50;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   background: tokens.$ifxColorEngineering200;
 }
 
@@ -19,7 +19,7 @@
   align-items: flex-start;
   align-self: stretch;
   gap: tokens.$ifxSpace50;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 }
 
 .topbar-filter-search-wrapper ifx-search-field {

--- a/packages/components/src/components/table-advanced-version/table.scss
+++ b/packages/components/src/components/table-advanced-version/table.scss
@@ -164,7 +164,7 @@
   font-weight: 600;
   line-height: 20px;
   color: tokens.$ifxColorBaseBlack;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
 }
 

--- a/packages/components/src/components/table-basic-version/table.scss
+++ b/packages/components/src/components/table-basic-version/table.scss
@@ -102,7 +102,7 @@
   font-weight: 600;
   line-height: 20px;
   color: tokens.$ifxColorBaseBlack;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
 }
 

--- a/packages/components/src/components/tabs/tabs.scss
+++ b/packages/components/src/components/tabs/tabs.scss
@@ -8,7 +8,7 @@
 
 .tabs {
   display: flex;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
   width: 100%;
 }
 

--- a/packages/components/src/components/tag/tag.scss
+++ b/packages/components/src/components/tag/tag.scss
@@ -13,7 +13,7 @@
   border-radius: tokens.$ifxBorderRadiusRound;
   background-color: tokens.$ifxColorBaseWhite;
   gap: tokens.$ifxSpace100;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
   &:hover {
     cursor: pointer;

--- a/packages/components/src/components/text-field/text-field.scss
+++ b/packages/components/src/components/text-field/text-field.scss
@@ -15,7 +15,7 @@
   order: 0;
   align-self: stretch;
   flex-grow: 0;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
 
   &.disabled {

--- a/packages/components/src/components/tooltip/tooltip.scss
+++ b/packages/components/src/components/tooltip/tooltip.scss
@@ -9,7 +9,7 @@
   display: inline-flex;
   flex-direction: column;
   position: relative;
-  font-family: var(--ifx-font-family);
+  font-family: tokens.$ifxFontFamilyBody;
 
 }
 

--- a/packages/components/src/global/font-import.ts
+++ b/packages/components/src/global/font-import.ts
@@ -1,0 +1,1 @@
+import '@infineon/design-system-tokens/dist/fonts/ifx-fonts.css';

--- a/packages/components/src/global/font.scss
+++ b/packages/components/src/global/font.scss
@@ -2,6 +2,6 @@
 
 
 :root {
-  --ifx-font-family: "#{tokens.$ifxFontFamilyBody}";
-  font-family: var(--ifx-font-family, sans-serif);
+  // --ifx-font-family: tokens.$ifxFontFamilyBody;
+  font-family: tokens.$ifxFontFamilyBody, sans-serif;
 }

--- a/packages/components/src/global/global.scss
+++ b/packages/components/src/global/global.scss
@@ -1,5 +1,5 @@
 @import "~@infineon/design-system-tokens/dist/fonts/ifx-fonts.css";
-
+@import "./font.scss";
 // * {
 //   box-sizing: border-box;
 //   line-height: tokens.$ifxLineHeightXl;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,1 +1,2 @@
+import './global/font-import'; // CSS gets loaded
 export * from './components';

--- a/packages/components/src/stories/setup-and-installation/GettingStarted.mdx
+++ b/packages/components/src/stories/setup-and-installation/GettingStarted.mdx
@@ -121,7 +121,7 @@ Include the following script tag in your index.html
 
 ```
 <script type="module" src="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil/dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>'
-
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil/dist/infineon-design-system-stencil/infineon-design-system-stencil.css">
 ```
 
 ## <h2 id="icons-only">Using only the Icons</h2>


### PR DESCRIPTION
Fonts dont get displayed on Macbook or iPhone.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description:

1. One issue is that global styles are not scoped: The [globalStyle] .scss file is applied globally, but if the consumer application does not include or respect the global styles (e.g., due to Shadow DOM encapsulation or conflicting styles), the font may not be applied.
2. Another issue was when using the CDN, the fonts werent downloaded.

Solution: 
1. Will set the font-family directly as defined in the tokens project instead of using the custom css variable.
2. In order for the fonts to be downloaded when using the CDN link (with specified canary version or not). 
Currently in index.html: 
` <script type="module" src="./dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>`
ADD THIS: 
` <link rel="stylesheet" href="./dist/infineon-design-system-stencil/infineon-design-system-stencil.css">`

(Description in Storybook setup guide)

Follow-up issue:
Another issue that arised was that these latest changes were not reflected due to a race condition in the github actions workflow, when deploying to NPM and then directly re-using the newly deployed package. This has been fixed and versions been specified as exact versions to avoid issues in the future.
Tested on Mac for Vue + React + Vanilla (using CDN link with Canary version).

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@33.1.1--canary.1818.59e7a8854f2402b8ff5f692db1b6747cdf09ddfd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
