### PR TITLE
Date-picker: emit events on value change only 

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+    "@infineon/infineon-design-system-react": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+    "@infineon/infineon-design-system-vue": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33785,7 +33785,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+      "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -33847,7 +33847,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+      "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33858,7 +33858,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+        "@infineon/infineon-design-system-angular": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33878,7 +33878,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+      "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33887,16 +33887,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3"
+        "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+      "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+        "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33910,11 +33910,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+      "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3"
+        "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+    "@infineon/infineon-design-system-angular": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3"
+    "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+    "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3"
+    "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "33.1.5--canary.1839.2996fc47c4d8dee97891b8c8cb0d06b9ecaa424c.3",
+  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -100,6 +100,9 @@ export class DatePicker {
 
   componentDidLoad() { 
     this.setFireFoxClasses()
+  }
+
+  componentWillUpdate() { 
     if (this.value) {
       this.getDate({ target: { value: this.value } });
     }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Moved the event emission from load time to update lifecycle method so they can be emitted only on value change

Reference: https://github.com/Infineon/infineon-design-system-stencil/issues/1825
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
