### PR TITLE
Pagination: fires event only on page change

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+    "@infineon/infineon-design-system-react": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+    "@infineon/infineon-design-system-vue": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+  "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33785,7 +33785,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+      "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -33847,7 +33847,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+      "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33858,7 +33858,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+        "@infineon/infineon-design-system-angular": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33878,7 +33878,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+      "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33887,16 +33887,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0"
+        "@infineon/infineon-design-system-stencil": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+      "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+        "@infineon/infineon-design-system-stencil": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33910,11 +33910,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+      "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0"
+        "@infineon/infineon-design-system-stencil": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+  "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+    "@infineon/infineon-design-system-angular": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+  "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0"
+    "@infineon/infineon-design-system-stencil": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+  "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+    "@infineon/infineon-design-system-stencil": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+  "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0"
+    "@infineon/infineon-design-system-stencil": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "33.1.6--canary.1842.b7d30ec0bd0865543b472ba538ac37100e4b65ad.0",
+  "version": "33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/pagination/pagination.tsx
+++ b/packages/components/src/components/pagination/pagination.tsx
@@ -154,7 +154,10 @@ export class Pagination {
       paginationContainer.dataset[this.DATA_KEY] = currActive;
     }
 
-    this.handleEventEmission(currActive)
+    if(!initialValue) { 
+      this.handleEventEmission(currActive)
+    }
+
 
     listItems[currActive].classList.add(this.CLASS_ACTIVE);
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Adds a condition to prevent event being fired on load time. Only on page change

Reference: https://github.com/Infineon/infineon-design-system-stencil/issues/1836
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@33.1.7--canary.1843.7c07b25e9716a353a8d1d4194d7da2c569a4bd8c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
