### PR TITLE
Content-switcher: fixes bug where divider is visible when item is pre-selected

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+    "@infineon/infineon-design-system-react": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/src/components/ContentSwitcher/ContentSwitcher.jsx
+++ b/examples/wrapper-components/react-vite-js/src/components/ContentSwitcher/ContentSwitcher.jsx
@@ -1,15 +1,17 @@
-
 import { IfxContentSwitcher, IfxContentSwitcherItem, IfxIcon } from '@infineon/infineon-design-system-react';
 
 function ContentSwitcher() {
-
+ 
   return (
     <div>
-      <IfxContentSwitcher>
-          <IfxContentSwitcherItem><IfxIcon icon="applications-16"/>Item 1</IfxContentSwitcherItem>
-          <IfxContentSwitcherItem><IfxIcon icon="applications-16"/>Item 2</IfxContentSwitcherItem>
-          <IfxContentSwitcherItem><IfxIcon icon="applications-16"/>Item 3</IfxContentSwitcherItem>
-          <IfxContentSwitcherItem><IfxIcon icon="applications-16"/>Item 4</IfxContentSwitcherItem>
+   <IfxContentSwitcher>
+        <IfxContentSwitcherItem value="gallery" selected={true}>
+          Gallery1
+        </IfxContentSwitcherItem>
+        <IfxContentSwitcherItem value="analysis">
+          Analysis2
+        </IfxContentSwitcherItem>
+        <IfxContentSwitcherItem><IfxIcon icon="applications-16"/>Item 1</IfxContentSwitcherItem>
       </IfxContentSwitcher>
     </div>
   );

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+    "@infineon/infineon-design-system-vue": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+  "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -33751,7 +33751,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+      "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -33813,7 +33813,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+      "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.0.0",
@@ -33824,7 +33824,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
-        "@infineon/infineon-design-system-angular": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+        "@infineon/infineon-design-system-angular": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.4.4",
@@ -33844,7 +33844,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+      "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -33853,16 +33853,16 @@
         "@angular/common": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0"
+        "@infineon/infineon-design-system-stencil": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+      "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+        "@infineon/infineon-design-system-stencil": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -33876,11 +33876,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+      "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0"
+        "@infineon/infineon-design-system-stencil": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+  "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -26,7 +26,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
-    "@infineon/infineon-design-system-angular": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+    "@infineon/infineon-design-system-angular": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.4.4",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+  "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0"
+    "@infineon/infineon-design-system-stencil": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+  "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+    "@infineon/infineon-design-system-stencil": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+  "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0"
+    "@infineon/infineon-design-system-stencil": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "34.3.0--canary.1882.35c91e8b16572828f70845ae049cb97925bb7a1b.0",
+  "version": "34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/content-switcher/content-switcher.tsx
+++ b/packages/components/src/components/content-switcher/content-switcher.tsx
@@ -2,6 +2,10 @@ import { Component, h, Element, Event, EventEmitter, Host, State } from '@stenci
 
 export type ChangeEvent = { oldValue: string; newValue: string };
 
+type ContentSwitcherItem = Element & {
+  selected: boolean;
+};
+
 @Component({
   tag: 'ifx-content-switcher',
   styleUrl: './content-switcher.scss',
@@ -79,16 +83,15 @@ export class ContentSwitcher {
     this.eventHandlers.clear();
   }
 
-  /**
-   * Ensure that only one item is selected at a time.
-   */
   ensureSingleSelectedItem() {
     this.items.forEach((item, index) => {
-      if (item.hasAttribute('selected')) {
+      const isSelected = (item.getAttribute('selected') === 'true') || (item as ContentSwitcherItem).selected;
+      if (isSelected) {
         if (this.activeIndex < 0) {
           this.selectItem(index);
         } else {
           item.removeAttribute('selected');
+          (item as ContentSwitcherItem).selected = false;
         }
       }
     });


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

- Ensures component attributes are properly read


Reference: https://github.com/Infineon/infineon-design-system-stencil/issues/1878?reload=1?reload=1
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@34.3.1--canary.1884.07f4be03de2f4b8f76fbad6515cfa506dcfeb75a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
