### PR TITLE
Updates the repository README to document the additional steps for Mac users when using the CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,17 @@ This can also be achieved by updating your start script in the ``package.json`` 
 Include the following script tag in your index.html
 
 ```bash
-<script type="module" src="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil/dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>'
-
+<script type="module" src="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil/dist/infineon-design-system-stencil/infineon-design-system-stencil.esm.js"></script>
 ```
+
+For Mac users, please also reference our custom stylesheet together with the above mentioned script link
+
+```bash
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@infineon/infineon-design-system-stencil/dist/infineon-design-system-stencil/infineon-design-system-stencil.css"></link>
+```
+
+
+
 
 <p align="right"><a href="#tableContent">back to top</a></p>
 

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+    "@infineon/infineon-design-system-react": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+    "@infineon/infineon-design-system-vue": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+  "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -35030,7 +35030,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+      "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -35092,7 +35092,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+      "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/build-angular": "^20.0.1",
@@ -35102,7 +35102,7 @@
         "@angular/forms": "^20.0.0",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
-        "@infineon/infineon-design-system-angular": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+        "@infineon/infineon-design-system-angular": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.8.2",
@@ -35121,7 +35121,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+      "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -35130,16 +35130,16 @@
         "@angular/common": "^20.0.0",
         "@angular/core": "^20.0.0",
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0"
+        "@infineon/infineon-design-system-stencil": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+      "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+        "@infineon/infineon-design-system-stencil": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -35153,11 +35153,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+      "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0"
+        "@infineon/infineon-design-system-stencil": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+  "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -25,7 +25,7 @@
     "@angular/forms": "^20.0.0",
     "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
-    "@infineon/infineon-design-system-angular": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+    "@infineon/infineon-design-system-angular": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.8.2",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+  "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^20.0.0",
     "@angular/core": "^20.0.0",
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0"
+    "@infineon/infineon-design-system-stencil": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+  "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+    "@infineon/infineon-design-system-stencil": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+  "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0"
+    "@infineon/infineon-design-system-stencil": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "34.5.0--canary.1889.856b07c14a210cb26a2eaca77807234ecceb8a89.0",
+  "version": "34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Mac users who use the CDN must also reference the stylesheet from now on. This is needed for having the correct fonts

Reference: https://github.com/Infineon/infineon-design-system-stencil/issues/1890
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@34.5.1--canary.1894.b80986dcee23b53bd4c7cfb7bf6a88f099b4592a.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
