### PR TITLE
Modal: fixes bug where correct window height is not detected on Edge browser causing content overflow

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+    "@infineon/infineon-design-system-react": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+    "@infineon/infineon-design-system-react": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+    "@infineon/infineon-design-system-vue": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+    "@infineon/infineon-design-system-vue": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+  "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -35038,7 +35038,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+      "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -35100,7 +35100,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+      "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/build-angular": "^20.0.1",
@@ -35110,7 +35110,7 @@
         "@angular/forms": "^20.0.0",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
-        "@infineon/infineon-design-system-angular": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+        "@infineon/infineon-design-system-angular": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.8.2",
@@ -35129,7 +35129,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+      "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -35138,16 +35138,16 @@
         "@angular/common": "^20.0.0",
         "@angular/core": "^20.0.0",
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0"
+        "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+      "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+        "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -35161,11 +35161,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+      "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0"
+        "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35038,7 +35038,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+      "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -35100,7 +35100,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+      "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/build-angular": "^20.0.1",
@@ -35110,7 +35110,7 @@
         "@angular/forms": "^20.0.0",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
-        "@infineon/infineon-design-system-angular": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+        "@infineon/infineon-design-system-angular": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.8.2",
@@ -35129,7 +35129,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+      "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -35138,16 +35138,16 @@
         "@angular/common": "^20.0.0",
         "@angular/core": "^20.0.0",
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0"
+        "@infineon/infineon-design-system-stencil": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+      "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+        "@infineon/infineon-design-system-stencil": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -35161,11 +35161,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+      "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0"
+        "@infineon/infineon-design-system-stencil": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+  "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -25,7 +25,7 @@
     "@angular/forms": "^20.0.0",
     "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
-    "@infineon/infineon-design-system-angular": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+    "@infineon/infineon-design-system-angular": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.8.2",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -25,7 +25,7 @@
     "@angular/forms": "^20.0.0",
     "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
-    "@infineon/infineon-design-system-angular": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+    "@infineon/infineon-design-system-angular": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.8.2",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^20.0.0",
     "@angular/core": "^20.0.0",
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0"
+    "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+  "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^20.0.0",
     "@angular/core": "^20.0.0",
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0"
+    "@infineon/infineon-design-system-stencil": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+  "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+    "@infineon/infineon-design-system-stencil": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+    "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+  "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0"
+    "@infineon/infineon-design-system-stencil": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0"
+    "@infineon/infineon-design-system-stencil": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "34.5.2--canary.1866.9e293b730484e4fc5508e5eac06d356ec3ebfcc7.0",
+  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "34.5.3--canary.1899.723432143f4d68b765ebb0ef2d907ad849487fff.0",
+  "version": "34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/modal/modal.tsx
+++ b/packages/components/src/components/modal/modal.tsx
@@ -198,12 +198,16 @@ export class IfxModal {
     }
   }
 
-  isModalContentContainerHeightReachedViewport() {
-    const modalContent = this.hostElement.shadowRoot.querySelector('.modal-content') as HTMLElement;
-    const viewportHeight = window.innerHeight;
-    const modalContentHeight = modalContent.offsetHeight;
-    return modalContentHeight >= viewportHeight * 0.9;
-  }
+ isModalContentContainerHeightReachedViewport() {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      const modalContent = this.hostElement.shadowRoot.querySelector('.modal-content') as HTMLElement;
+      const modalContentHeight = modalContent.offsetHeight;
+      const viewportHeight = window.innerHeight;
+      resolve(modalContentHeight >= viewportHeight * 0.9);
+    }, 100);
+  });
+}
 
 
   render() {

--- a/packages/components/src/components/modal/modal.tsx
+++ b/packages/components/src/components/modal/modal.tsx
@@ -199,6 +199,7 @@ export class IfxModal {
   }
 
  isModalContentContainerHeightReachedViewport() {
+  //Adding timeout for proper height detection on Edge browser
   return new Promise(resolve => {
     setTimeout(() => {
       const modalContent = this.hostElement.shadowRoot.querySelector('.modal-content') as HTMLElement;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

- Adds timeOut to ensure proper viewport detection on Edge browser

Reference: https://github.com/Infineon/infineon-design-system-stencil/issues/1892
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@34.6.0--canary.1899.b054399e243a41e7a7a49ca9c4cccffa73bcbd53.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
