### PR TITLE
Slider: makes container's width 100% of its parent

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+    "@infineon/infineon-design-system-react": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+    "@infineon/infineon-design-system-vue": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+  "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -35693,7 +35693,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+      "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -35755,7 +35755,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+      "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/build-angular": "^20.0.1",
@@ -35765,7 +35765,7 @@
         "@angular/forms": "^20.0.0",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
-        "@infineon/infineon-design-system-angular": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+        "@infineon/infineon-design-system-angular": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "typescript": "~5.8.2",
@@ -35784,7 +35784,7 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+      "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -35793,16 +35793,16 @@
         "@angular/common": "^20.0.0",
         "@angular/core": "^20.0.0",
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0"
+        "@infineon/infineon-design-system-stencil": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0"
       }
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+      "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+        "@infineon/infineon-design-system-stencil": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
         "@stencil/react-output-target": "^0.7.1"
       },
       "devDependencies": {
@@ -35816,11 +35816,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+      "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0"
+        "@infineon/infineon-design-system-stencil": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+  "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -25,7 +25,7 @@
     "@angular/forms": "^20.0.0",
     "@angular/platform-browser": "^20.0.0",
     "@angular/router": "^20.0.0",
-    "@infineon/infineon-design-system-angular": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+    "@infineon/infineon-design-system-angular": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "typescript": "~5.8.2",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+  "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "@angular/common": "^20.0.0",
     "@angular/core": "^20.0.0",
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0"
+    "@infineon/infineon-design-system-stencil": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+  "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+    "@infineon/infineon-design-system-stencil": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
     "@stencil/react-output-target": "^0.7.1"
   },
   "auto": {

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+  "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0"
+    "@infineon/infineon-design-system-stencil": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "35.4.0--canary.1921.8f0533a71147ba665041d080077dedb9de0b7845.0",
+  "version": "35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/slider/slider.scss
+++ b/packages/components/src/components/slider/slider.scss
@@ -1,10 +1,8 @@
 @use "~@infineon/design-system-tokens/dist/tokens";
 @use "../../global/font.scss";
 
-
-// ifx-slider.scss
 :host {
-  display: inline-block;
+  display: block;
 }
 
 .left-icon,
@@ -94,7 +92,7 @@
   
   & .range-slider__wrapper {
     position: relative;
-    width: 129px;
+    width: 100%;
     height: 4px;
     display: flex;
     align-items: center;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

- replaced display: inline-block with block on the host element
- removed fixed width on the container of the double variant

Reference: https://github.com/Infineon/infineon-design-system-stencil/issues/1927
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@35.4.1--canary.1932.357f873649b2b713e4aa49283f91e30f2d6263ca.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
