### PR TITLE
File-upload: fixes event emission bug. ifxFileUploadAllComplete now fires even when some tasks fail, and it only includes successful files

### DIFF
--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+    "@infineon/infineon-design-system-react": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "38.3.0",
+    "@infineon/infineon-design-system-react": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/react-vite-js/package.json
+++ b/examples/wrapper-components/react-vite-js/package.json
@@ -18,7 +18,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-react": "38.4.0",
+    "@infineon/infineon-design-system-react": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
     "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+    "@infineon/infineon-design-system-vue": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "38.3.0",
+    "@infineon/infineon-design-system-vue": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/examples/wrapper-components/vue-javascript/package.json
+++ b/examples/wrapper-components/vue-javascript/package.json
@@ -15,7 +15,7 @@
     "test:local": "run-p preview:link watch:library"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-vue": "38.4.0",
+    "@infineon/infineon-design-system-vue": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
     "@vitejs/plugin-vue": "^4.0.0",
     "@vitejs/plugin-vue-jsx": "^4.0.0",
     "vite": "^5.0.12",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+  "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "38.3.0",
+  "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "38.4.0",
+  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -38202,7 +38202,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "38.4.0",
+      "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -38267,7 +38267,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "38.4.0",
+      "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/build-angular": "^20.0.1",
@@ -42314,10 +42314,10 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "38.4.0",
+      "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
       "license": "MIT",
       "dependencies": {
-        "@infineon/infineon-design-system-stencil": "38.4.0",
+        "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
@@ -42329,7 +42329,7 @@
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "38.4.0",
+      "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -43650,11 +43650,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "38.4.0",
+      "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "38.4.0"
+        "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37522,7 +37522,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "38.3.0",
+      "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -37587,7 +37587,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "38.3.0",
+      "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/build-angular": "^20.0.1",
@@ -41304,10 +41304,10 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "38.3.0",
+      "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
       "license": "MIT",
       "dependencies": {
-        "@infineon/infineon-design-system-stencil": "38.3.0",
+        "@infineon/infineon-design-system-stencil": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
@@ -41319,7 +41319,7 @@
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "38.3.0",
+      "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -42433,11 +42433,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "38.3.0",
+      "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "38.3.0"
+        "@infineon/infineon-design-system-stencil": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38202,7 +38202,7 @@
     },
     "packages/components": {
       "name": "@infineon/infineon-design-system-stencil",
-      "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+      "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -38267,7 +38267,7 @@
       }
     },
     "packages/components-angular": {
-      "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+      "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
       "license": "MIT",
       "dependencies": {
         "@angular-devkit/build-angular": "^20.0.1",
@@ -42314,10 +42314,10 @@
     },
     "packages/components-angular/projects/component-library": {
       "name": "@infineon/infineon-design-system-angular",
-      "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+      "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
       "license": "MIT",
       "dependencies": {
-        "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+        "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
@@ -42329,7 +42329,7 @@
     },
     "packages/components-react": {
       "name": "@infineon/infineon-design-system-react",
-      "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+      "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
@@ -43650,11 +43650,11 @@
     },
     "packages/components-vue": {
       "name": "@infineon/infineon-design-system-vue",
-      "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+      "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
       "license": "MIT",
       "dependencies": {
         "@infineon/design-system-tokens": "5.0.0",
-        "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0"
+        "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0"
       },
       "devDependencies": {
         "@babel/types": "^7.22.5",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "38.3.0",
+  "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+  "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "components-angular",
-  "version": "38.4.0",
+  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "38.4.0",
+  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -14,7 +14,7 @@
     "@infineon/infineon-design-system-stencil": "38.1.1"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-stencil": "38.4.0",
+    "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
     "tslib": "^2.3.0"
   },
   "sideEffects": false,

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "38.3.0",
+  "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -14,7 +14,7 @@
     "@infineon/infineon-design-system-stencil": "38.1.1"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-stencil": "38.3.0",
+    "@infineon/infineon-design-system-stencil": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
     "tslib": "^2.3.0"
   },
   "sideEffects": false,

--- a/packages/components-angular/projects/component-library/package.json
+++ b/packages/components-angular/projects/component-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-angular",
-  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+  "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
   "description": "Infineon design system Stencil web components for Angular",
   "author": "Verena Lechner",
   "license": "MIT",
@@ -14,7 +14,7 @@
     "@infineon/infineon-design-system-stencil": "38.1.1"
   },
   "dependencies": {
-    "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+    "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
     "tslib": "^2.3.0"
   },
   "sideEffects": false,

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "38.4.0",
+  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+  "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-react",
-  "version": "38.3.0",
+  "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
   "description": "Infineon design system Stencil web components for React",
   "main": "./dist/index.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/components-react/src/components.ts
+++ b/packages/components-react/src/components.ts
@@ -477,7 +477,7 @@ type IfxFileUploadEvents = {
     onIfxFileUploadAdd: EventName<IfxFileUploadCustomEvent<{ addedFiles: File[]; files: File[] }>>,
     onIfxFileUploadRemove: EventName<IfxFileUploadCustomEvent<{ removedFile: File; files: File[] }>>,
     onIfxFileUploadChange: EventName<IfxFileUploadCustomEvent<{ files: File[] }>>,
-    onIfxFileUploadError: EventName<IfxFileUploadCustomEvent<{ errorType: string; file: File; message: string; reason?: string; }>>,
+    onIfxFileUploadError: EventName<IfxFileUploadCustomEvent<{ errorType: string; file: File; message: string; reason?: string }>>,
     onIfxFileUploadInvalid: EventName<IfxFileUploadCustomEvent<{ file: File; reason: string }>>,
     onIfxFileUploadStart: EventName<IfxFileUploadCustomEvent<{ file: File }>>,
     onIfxFileUploadComplete: EventName<IfxFileUploadCustomEvent<{ file: File }>>,

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "38.4.0",
+  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "38.4.0"
+    "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+  "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0"
+    "@infineon/infineon-design-system-stencil": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components-vue/package.json
+++ b/packages/components-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-vue",
-  "version": "38.3.0",
+  "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
   "description": "Infineon design system Stencil web components for Vue",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@infineon/design-system-tokens": "5.0.0",
-    "@infineon/infineon-design-system-stencil": "38.3.0"
+    "@infineon/infineon-design-system-stencil": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0"
   },
   "auto": {
     "plugins": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "38.4.0",
+  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "38.3.0",
+  "version": "38.3.1--canary.2094.f22d83a9fa296ad1d6e6302ef46570a8def3426c.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infineon/infineon-design-system-stencil",
-  "version": "38.5.0--canary.2094.c45061ac9f5158f47476865ab7e52889b8dbb04c.0",
+  "version": "38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0",
   "private": false,
   "description": "Infineon design system Stencil web components",
   "homepage": "https://infineon.github.io/infineon-design-system-stencil",

--- a/packages/components/src/components/file-upload/file-upload.tsx
+++ b/packages/components/src/components/file-upload/file-upload.tsx
@@ -466,8 +466,16 @@ export class FileUpload {
         this.ifxFileUploadComplete.emit({ file });
         this.ifxFileUploadChange.emit({ files: this.files });
 
-        if (this.uploadTasks.every(t => t.completed)) {
-          this.ifxFileUploadAllComplete.emit({ files: this.files });
+        // Check if all tasks are finished AND at least one was successful
+        if (this.uploadTasks.every(t => t.completed || t.error)) {
+          const hasSuccessfulUploads = this.uploadTasks.some(t => t.completed && !t.error);
+          if (hasSuccessfulUploads) {
+            // Only include successfully uploaded files in the event
+            const successfulFiles = this.uploadTasks
+              .filter(t => t.completed && !t.error)
+              .map(t => t.file);
+            this.ifxFileUploadAllComplete.emit({ files: successfulFiles });
+          }
         }
       }).catch(() => {
         task.error = true;
@@ -478,6 +486,18 @@ export class FileUpload {
           message: 'Upload handler rejected file',
           reason: 'custom'
         });
+
+        // Check if all tasks are finished AND at least one was successful
+        if (this.uploadTasks.every(t => t.completed || t.error)) {
+          const hasSuccessfulUploads = this.uploadTasks.some(t => t.completed && !t.error);
+          if (hasSuccessfulUploads) {
+            // Only include successfully uploaded files in the event
+            const successfulFiles = this.uploadTasks
+              .filter(t => t.completed && !t.error)
+              .map(t => t.file);
+            this.ifxFileUploadAllComplete.emit({ files: successfulFiles });
+          }
+        }
       });
     } else {
       const totalSize = file.size;
@@ -498,14 +518,20 @@ export class FileUpload {
           this.ifxFileUploadComplete.emit({ file });
           this.ifxFileUploadChange.emit({ files: this.files });
 
-          if (this.uploadTasks.every(t => t.completed)) {
-            this.ifxFileUploadAllComplete.emit({ files: this.files });
+          // Check if all tasks are finished AND at least one was successful
+          if (this.uploadTasks.every(t => t.completed || t.error)) {
+            const hasSuccessfulUploads = this.uploadTasks.some(t => t.completed && !t.error);
+            if (hasSuccessfulUploads) {
+              // Only include successfully uploaded files in the event
+              const successfulFiles = this.uploadTasks
+                .filter(t => t.completed && !t.error)
+                .map(t => t.file);
+              this.ifxFileUploadAllComplete.emit({ files: successfulFiles });
+            }
           }
         }
       }, 200);
     }
-
-    this.uploadTasks = [...this.uploadTasks, task];
   }
 
   cancelUpload(file: File) {

--- a/packages/components/src/components/file-upload/file-upload.tsx
+++ b/packages/components/src/components/file-upload/file-upload.tsx
@@ -11,19 +11,12 @@ interface UploadTask {
   error?: boolean;
 }
 
-export type FileUploadErrorReason =
-  | 'network-error'
-  | 'timeout'
-  | 'file-too-large'
-  | 'unsupported-type'
-  | 'invalid-type'
-  | 'custom'
-  | (string & {});
+export type FileUploadErrorReason = 'network-error' | 'timeout' | 'file-too-large' | 'unsupported-type' | 'invalid-type' | 'custom' | (string & {});
 
 @Component({
   tag: 'ifx-file-upload',
   styleUrl: 'file-upload.scss',
-  shadow: true
+  shadow: true,
 })
 export class FileUpload {
   @Element() hostElement: HTMLElement;
@@ -91,11 +84,10 @@ export class FileUpload {
   @State() requiredError: boolean = false;
   @State() statusMessage: { type: 'error' | 'info' | 'success'; text: string } | null = null;
 
-
   @Event() ifxFileUploadAdd: EventEmitter<{ addedFiles: File[]; files: File[] }>;
   @Event() ifxFileUploadRemove: EventEmitter<{ removedFile: File; files: File[] }>;
   @Event() ifxFileUploadChange: EventEmitter<{ files: File[] }>;
-  @Event() ifxFileUploadError: EventEmitter<{ errorType: string; file: File; message: string; reason?: string; }>;
+  @Event() ifxFileUploadError: EventEmitter<{ errorType: string; file: File; message: string; reason?: string }>;
   @Event() ifxFileUploadInvalid: EventEmitter<{ file: File; reason: string }>;
   @Event() ifxFileUploadStart: EventEmitter<{ file: File }>;
   @Event() ifxFileUploadComplete: EventEmitter<{ file: File }>;
@@ -153,7 +145,7 @@ export class FileUpload {
     xml: 'application/xml',
     html: 'text/html',
     css: 'text/css',
-    js: 'application/javascript'
+    js: 'application/javascript',
   };
 
   private validateRequired(): void {
@@ -163,7 +155,7 @@ export class FileUpload {
       if (this.statusMessage?.text !== this.labelRequiredError) {
         this.statusMessage = {
           type: 'error',
-          text: this.labelRequiredError
+          text: this.labelRequiredError,
         };
       }
 
@@ -237,9 +229,7 @@ export class FileUpload {
 
     // Check against allowedFileTypes (predefined extensions)
     const normalizedTypes = this.getNormalizedFileTypes();
-    const allowedMimes = normalizedTypes
-      .map(ext => this.extensionToMimeMap[ext.toLowerCase()])
-      .filter(Boolean);
+    const allowedMimes = normalizedTypes.map(ext => this.extensionToMimeMap[ext.toLowerCase()]).filter(Boolean);
 
     if (allowedMimes.includes(file.type)) {
       return true;
@@ -312,7 +302,7 @@ export class FileUpload {
       this.ifxFileUploadDrop.emit({
         droppedFiles,
         acceptedFiles,
-        rejectedFiles
+        rejectedFiles,
       });
 
       this.processFiles(event.dataTransfer.files);
@@ -341,9 +331,7 @@ export class FileUpload {
     selectedFiles.forEach(file => {
       const isValidType = this.isFileTypeAllowed(file);
       const isValidSize = file.size <= this.maxFileSizeMB * 1024 * 1024;
-      const isDuplicate = this.files.some(existing =>
-        existing.name === file.name && existing.size === file.size
-      );
+      const isDuplicate = this.files.some(existing => existing.name === file.name && existing.size === file.size);
 
       if (isDuplicate) {
         this.ifxFileUploadInvalid.emit({ file, reason: 'duplicate' });
@@ -351,7 +339,7 @@ export class FileUpload {
           file,
           errorType: 'duplicate',
           message: `File "${file.name}" is already added`,
-          reason: 'duplicate'
+          reason: 'duplicate',
         });
         return;
       }
@@ -371,7 +359,7 @@ export class FileUpload {
           file,
           errorType: !isValidType ? 'invalid-type' : 'file-too-large',
           message: 'Invalid file rejected',
-          reason: !isValidType ? 'unsupported-type' : 'file-too-large'
+          reason: !isValidType ? 'unsupported-type' : 'file-too-large',
         });
       }
     });
@@ -399,26 +387,23 @@ export class FileUpload {
           file,
           errorType: 'too-many-files',
           message: `Upload limit exceeded. Max ${this.maxFiles} files allowed.`,
-          reason: 'too-many-files'
+          reason: 'too-many-files',
         });
       });
 
       if (overflowFiles.length > 0) {
         this.statusMessage = {
           type: 'error',
-          text: this.labelMaxFilesExceeded
-            .replace('{{count}}', this.maxFiles.toString())
-            .replace('{{files}}', this.pluralize(this.maxFiles))
+          text: this.labelMaxFilesExceeded.replace('{{count}}', this.maxFiles.toString()).replace('{{files}}', this.pluralize(this.maxFiles)),
         };
         this.ifxFileUploadMaxFilesExceeded.emit({
           maxFiles: this.maxFiles,
-          attempted: this.files.length + validFiles.length
+          attempted: this.files.length + validFiles.length,
         });
       }
 
       return;
     }
-
 
     validFiles.forEach(file => this.startUpload(file));
     this.files = [...this.files, ...validFiles];
@@ -441,74 +426,74 @@ export class FileUpload {
     this.startUpload(file);
   }
 
+  private checkAndEmitAllComplete(): void {
+    if (this.uploadTasks.every(t => t.completed || t.error)) {
+      const hasSuccessfulUploads = this.uploadTasks.some(t => t.completed && !t.error);
+      if (hasSuccessfulUploads) {
+        const successfulFiles = this.uploadTasks.filter(t => t.completed && !t.error).map(t => t.file);
+        this.ifxFileUploadAllComplete.emit({ files: successfulFiles });
+      }
+    }
+  }
+
+  private resetFileInput(): void {
+    if (this.fileInputEl) {
+      this.fileInputEl.value = '';
+    }
+  }
+
+  private updateTaskProgress(file: File, progress: number): void {
+    const task = this.uploadTasks.find(t => t.file === file);
+    if (task) {
+      const newProgress = Math.max(task.progress, Math.min(100, progress));
+      if (newProgress !== task.progress) {
+        task.progress = newProgress;
+        this.uploadTasks = [...this.uploadTasks];
+      }
+    }
+  }
+
   startUpload(file: File) {
     this.ifxFileUploadStart.emit({ file });
-
     const task: UploadTask = {
       file,
       progress: 3, // Start with initial progress for better UX
       intervalId: null,
       completed: false,
     };
-
     this.uploadTasks = [...this.uploadTasks, task];
 
     if (this.uploadHandler) {
       this.uploadHandler(file, (percent: number) => {
-        if (percent > task.progress) {
-          task.progress = Math.min(100, percent);
+        this.updateTaskProgress(file, percent);
+      })
+        .then(() => {
+          task.progress = 100;
+          task.completed = true;
           this.uploadTasks = [...this.uploadTasks];
-        }
-      }).then(() => {
-        task.progress = 100;
-        task.completed = true;
-        this.uploadTasks = [...this.uploadTasks];
-        this.ifxFileUploadComplete.emit({ file });
-        this.ifxFileUploadChange.emit({ files: this.files });
-
-        // Check if all tasks are finished AND at least one was successful
-        if (this.uploadTasks.every(t => t.completed || t.error)) {
-          const hasSuccessfulUploads = this.uploadTasks.some(t => t.completed && !t.error);
-          if (hasSuccessfulUploads) {
-            // Only include successfully uploaded files in the event
-            const successfulFiles = this.uploadTasks
-              .filter(t => t.completed && !t.error)
-              .map(t => t.file);
-            this.ifxFileUploadAllComplete.emit({ files: successfulFiles });
-          }
-        }
-      }).catch(() => {
-        task.error = true;
-        this.uploadTasks = [...this.uploadTasks];
-        this.ifxFileUploadError.emit({
-          file,
-          errorType: 'upload-failed',
-          message: 'Upload handler rejected file',
-          reason: 'custom'
+          this.ifxFileUploadComplete.emit({ file });
+          this.ifxFileUploadChange.emit({ files: this.files });
+          this.checkAndEmitAllComplete();
+        })
+        .catch(() => {
+          task.error = true;
+          this.uploadTasks = [...this.uploadTasks];
+          this.ifxFileUploadError.emit({
+            file,
+            errorType: 'upload-failed',
+            message: 'Upload handler rejected file',
+            reason: 'custom',
+          });
+          this.checkAndEmitAllComplete();
         });
-
-        // Check if all tasks are finished AND at least one was successful
-        if (this.uploadTasks.every(t => t.completed || t.error)) {
-          const hasSuccessfulUploads = this.uploadTasks.some(t => t.completed && !t.error);
-          if (hasSuccessfulUploads) {
-            // Only include successfully uploaded files in the event
-            const successfulFiles = this.uploadTasks
-              .filter(t => t.completed && !t.error)
-              .map(t => t.file);
-            this.ifxFileUploadAllComplete.emit({ files: successfulFiles });
-          }
-        }
-      });
     } else {
       const totalSize = file.size;
       const fakeUploadSpeed = 100000;
       let uploaded = 0;
-
       task.intervalId = window.setInterval(() => {
         uploaded += fakeUploadSpeed / 5;
         const progress = Math.min(100, Math.round((uploaded / totalSize) * 100));
-        task.progress = progress;
-        this.uploadTasks = [...this.uploadTasks];
+        this.updateTaskProgress(file, progress);
 
         if (progress >= 100) {
           clearInterval(task.intervalId!);
@@ -517,18 +502,7 @@ export class FileUpload {
           this.uploadTasks = [...this.uploadTasks];
           this.ifxFileUploadComplete.emit({ file });
           this.ifxFileUploadChange.emit({ files: this.files });
-
-          // Check if all tasks are finished AND at least one was successful
-          if (this.uploadTasks.every(t => t.completed || t.error)) {
-            const hasSuccessfulUploads = this.uploadTasks.some(t => t.completed && !t.error);
-            if (hasSuccessfulUploads) {
-              // Only include successfully uploaded files in the event
-              const successfulFiles = this.uploadTasks
-                .filter(t => t.completed && !t.error)
-                .map(t => t.file);
-              this.ifxFileUploadAllComplete.emit({ files: successfulFiles });
-            }
-          }
+          this.checkAndEmitAllComplete();
         }
       }, 200);
     }
@@ -546,9 +520,7 @@ export class FileUpload {
     this.files = this.files.filter(f => f.name !== file.name);
     this.ifxFileUploadAbort.emit({ file });
     this.ifxFileUploadChange.emit({ files: this.files });
-    if (this.fileInputEl) {
-      this.fileInputEl.value = '';
-    }
+    this.resetFileInput();
     this.validateRequired();
   }
 
@@ -559,19 +531,12 @@ export class FileUpload {
     this.ifxFileUploadChange.emit({ files: this.files });
     this.validateRequired();
 
-    if (this.fileInputEl) {
-      this.fileInputEl.value = '';
-    }
+    this.resetFileInput();
 
-    if (
-      this.maxFiles &&
-      this.files.length < this.maxFiles &&
-      this.statusMessage?.text !== this.labelRequiredError
-    ) {
+    if (this.maxFiles && this.files.length < this.maxFiles && this.statusMessage?.text !== this.labelRequiredError) {
       this.statusMessage = null;
     }
   }
-
 
   clearRejectedFile(fileName: string, type: 'size' | 'type') {
     if (type === 'size') {
@@ -580,9 +545,7 @@ export class FileUpload {
       this.rejectedTypeFiles = this.rejectedTypeFiles.filter(f => f !== fileName);
     }
 
-    if (this.fileInputEl) {
-      this.fileInputEl.value = '';
-    }
+    this.resetFileInput();
 
     if (this.maxFiles && this.files.length < this.maxFiles) {
       this.statusMessage = null;
@@ -597,21 +560,28 @@ export class FileUpload {
     if (dotIndex === -1) return { base: name, ext: '' };
     return {
       base: name.substring(0, dotIndex),
-      ext: name.substring(dotIndex)
+      ext: name.substring(dotIndex),
     };
   }
 
   getFileIcon(file: File): string {
     const extension = file.name.split('.').pop()?.toLowerCase();
     switch (extension) {
-      case 'pdf': return 'file-pdf-16';
+      case 'pdf':
+        return 'file-pdf-16';
       case 'jpg':
-      case 'jpeg': return 'file-jpg-16';
-      case 'png': return 'file-png-16';
-      case 'mov': return 'file-mov-16';
-      case 'mp3': return 'file-mp3-16';
-      case 'mp4': return 'file-mp4-16';
-      default: return 'file-16';
+      case 'jpeg':
+        return 'file-jpg-16';
+      case 'png':
+        return 'file-png-16';
+      case 'mov':
+        return 'file-mov-16';
+      case 'mp3':
+        return 'file-mp3-16';
+      case 'mp4':
+        return 'file-mp4-16';
+      default:
+        return 'file-16';
     }
   }
 
@@ -671,9 +641,7 @@ export class FileUpload {
       let text = `All file types allowed. Max file size: ${this.maxFileSizeMB}MB.`;
       if (this.labelMaxFilesInfo && this.maxFiles) {
         const fileWord = this.pluralize(this.maxFiles);
-        const maxFilesText = this.labelMaxFilesInfo
-          .replace('{{count}}', this.maxFiles.toString())
-          .replace('{{files}}', fileWord);
+        const maxFilesText = this.labelMaxFilesInfo.replace('{{count}}', this.maxFiles.toString()).replace('{{files}}', fileWord);
         text += ` ${maxFilesText}`;
       }
       return text;
@@ -698,15 +666,11 @@ export class FileUpload {
 
     const typesLabel = allTypes.join(', ');
 
-    let text = this.labelSupportedFormatsTemplate
-      .replace('{{types}}', typesLabel)
-      .replace('{{size}}', this.maxFileSizeMB.toString());
+    let text = this.labelSupportedFormatsTemplate.replace('{{types}}', typesLabel).replace('{{size}}', this.maxFileSizeMB.toString());
 
     if (this.labelMaxFilesInfo && this.maxFiles) {
       const fileWord = this.pluralize(this.maxFiles);
-      const maxFilesText = this.labelMaxFilesInfo
-        .replace('{{count}}', this.maxFiles.toString())
-        .replace('{{files}}', fileWord);
+      const maxFilesText = this.labelMaxFilesInfo.replace('{{count}}', this.maxFiles.toString()).replace('{{files}}', fileWord);
       text += ` ${maxFilesText}`;
     }
 
@@ -722,9 +686,7 @@ export class FileUpload {
 
     return (
       <div class={`file-upload-status file-upload-status__${this.statusMessage.type}`}>
-        {this.statusMessage.type === 'error' && (
-          <ifx-icon icon="c-warning-16"></ifx-icon>
-        )}
+        {this.statusMessage.type === 'error' && <ifx-icon icon="c-warning-16"></ifx-icon>}
         {this.statusMessage.text}
       </div>
     );
@@ -735,9 +697,9 @@ export class FileUpload {
   }
 
   async componentDidLoad() {
-    if(!isNestedInIfxComponent(this.hostElement)) {
+    if (!isNestedInIfxComponent(this.hostElement)) {
       const framework = detectFramework();
-      trackComponent('ifx-file-upload', await framework)
+      trackComponent('ifx-file-upload', await framework);
     }
 
     if (this.hostElement.hasAttribute('show-demo-states')) {
@@ -765,34 +727,30 @@ export class FileUpload {
     this.uploadTasks = [
       { file: uploaded, progress: 100, intervalId: null, completed: true },
       { file: uploading, progress: 40, intervalId: null, completed: false },
-      { file: failed, progress: 80, intervalId: null, completed: false, error: true }
+      { file: failed, progress: 80, intervalId: null, completed: false, error: true },
     ];
     this.rejectedSizeFiles = [tooLarge.name];
     this.rejectedTypeFiles = [unsupported.name];
   }
 
-
-
   // Storybook Demo
   @Method()
-    async triggerDemoValidation(): Promise<void> {
-      this.validateRequired();
-    }
+  async triggerDemoValidation(): Promise<void> {
+    this.validateRequired();
+  }
 
   render() {
     return (
       <div
         class={{
           'file-upload-wrapper': true,
-          'disabled': this.disabled
+          'disabled': this.disabled,
         }}
       >
         {this.label && (
           <label class="file-upload-label" htmlFor={this.internalId}>
             {this.label}
-            {this.required && (
-              <span class={`required ${this.requiredError ? 'error' : ''}`}>*</span>
-            )}
+            {this.required && <span class={`required ${this.requiredError ? 'error' : ''}`}>*</span>}
           </label>
         )}
 
@@ -864,7 +822,7 @@ export class FileUpload {
                 </li>
               ))}
 
-              {this.files.map((file) => {
+              {this.files.map(file => {
                 const task = this.uploadTasks.find(t => t.file.name === file.name);
                 const progress = task?.progress ?? 100;
                 const isUploading = task && !task.completed;
@@ -939,11 +897,7 @@ export class FileUpload {
 
                       {isUploading && task && !task.error && (
                         <div class="file-progress-row">
-                          <ifx-progress-bar
-                            size="s"
-                            value={progress}
-                            show-label="true"
-                          ></ifx-progress-bar>
+                          <ifx-progress-bar size="s" value={progress} show-label="true"></ifx-progress-bar>
                         </div>
                       )}
                     </div>
@@ -964,12 +918,7 @@ export class FileUpload {
 
     return (
       <div class={{ 'upload-button': true }}>
-        <ifx-button
-          variant="secondary"
-          onClick={() => this.fileInputEl?.click()}
-          disabled={this.isInputDisabled()}
-          aria-label={this.ariaLabelBrowseFiles}
-        >
+        <ifx-button variant="secondary" onClick={() => this.fileInputEl?.click()} disabled={this.isInputDisabled()} aria-label={this.ariaLabelBrowseFiles}>
           <ifx-icon icon="upload-16"></ifx-icon>
           {this.labelBrowseFiles}
         </ifx-button>
@@ -979,19 +928,16 @@ export class FileUpload {
           type="file"
           accept={this.getAcceptAttribute()}
           multiple
-          onChange={(e) => this.handleFileChange(e)}
+          onChange={e => this.handleFileChange(e)}
           style={{ display: 'none' }}
           disabled={this.isInputDisabled()}
           aria-label={this.ariaLabelFileInput}
         />
-        <p class="file-upload-info">
-          {this.getSupportedFileText()}
-        </p>
+        <p class="file-upload-info">{this.getSupportedFileText()}</p>
         {this.renderStatusMessage()}
       </div>
     );
   }
-
 
   renderDragAndDropArea() {
     const handleInputRef = (el: HTMLInputElement | null) => {
@@ -1005,22 +951,20 @@ export class FileUpload {
     };
 
     return (
-      <div class={{ 'disabled': this.isInputDisabled() }}>
+      <div class={{ disabled: this.isInputDisabled() }}>
         <div
           class={{ 'upload-dropzone': true, 'drag-over': this.isDragOver, 'error': this.requiredError }}
           onClick={triggerInputClick}
-          onDragOver={(e) => this.handleDragOver(e)}
-          onDragLeave={(e) => this.handleDragLeave(e)}
-          onDrop={(e) => this.handleDrop(e)}
+          onDragOver={e => this.handleDragOver(e)}
+          onDragLeave={e => this.handleDragLeave(e)}
+          onDrop={e => this.handleDrop(e)}
           role="button"
           tabIndex={0}
           aria-label={this.ariaLabelDropzone}
         >
           <ifx-icon icon="upload-16" class="custom-icon"></ifx-icon>
           <p>{this.labelDragAndDrop}</p>
-          <p class="file-upload-info">
-            {this.getSupportedFileText()}
-          </p>
+          <p class="file-upload-info">{this.getSupportedFileText()}</p>
           <div style={{ height: '0px', overflow: 'hidden' }}>
             <input
               id={this.internalId}
@@ -1028,7 +972,7 @@ export class FileUpload {
               type="file"
               accept={this.getAcceptAttribute()}
               multiple
-              onChange={(e) => this.handleFileChange(e)}
+              onChange={e => this.handleFileChange(e)}
               disabled={this.isInputDisabled()}
               aria-label={this.ariaLabelFileInput}
             />
@@ -1038,5 +982,4 @@ export class FileUpload {
       </div>
     );
   }
-
 }

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -12,10 +12,10 @@
   <style defer>
 
   </style>
-  
-<script>
 
-</script>
+  <script>
+
+  </script>
 
 
 </head>


### PR DESCRIPTION
fix(file-upload): ensure ifxFileUploadAllComplete event fires successful uploads following validation errors

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

**Before (Incorrect):**

- The event was only triggered if every(t => t.completed) — meaning all tasks succeeded.
- Failed tasks permanently blocked the event from firing.
- The array contained all files, including failed ones. 
- Tasks were added twice.

**After (Correct):**

- The event is triggered when every(t => t.completed || t.error) — meaning all tasks are finished (regardless of success or failure).
- And at least one task was successful: some(t => t.completed && !t.error).
- The array contains only successfully uploaded files.
- Tasks are added only once.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @infineon/infineon-design-system-stencil@38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0
  # or 
  yarn add @infineon/infineon-design-system-stencil@38.5.0--canary.2094.069320ed5cc512bf069ebc4c533a200ef82ac29c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
