### PR TITLE
Modal: Fix opened prop in Vue with v-model integration

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,8 @@
 		"rules": {
 			"recommended": true,
 			"suspicious": {
-				"noExplicitAny": "warn"
+				"noExplicitAny": "warn",
+				"noAssignInExpressions": "off"
 			}
 		}
 	},

--- a/examples/angular-module-example/src/app/app-module.ts
+++ b/examples/angular-module-example/src/app/app-module.ts
@@ -50,7 +50,9 @@ import { IfxTextFieldExample } from './generated/ifx-text-field-example/ifx-text
 import { IfxTextareaExample } from './generated/ifx-textarea-example/ifx-textarea-example';
 import { IfxTooltipExample } from './generated/ifx-tooltip-example/ifx-tooltip-example';
 /* </AUTO-GENERATED-IMPORTS> */
+import { IfxModal } from "@infineon/infineon-design-system-angular";
 
+import { ModalExample } from "./manual/modal-example/modal-example";
 import { NgModelExample } from "./manual/ng-model-example/ng-model-example";
 
 @NgModule({
@@ -97,6 +99,7 @@ IfxAccordionExample,
 		    IfxTooltipExample
 		/* </AUTO-GENERATED-COMPONENTS> */
 			,
+			ModalExample,
 			NgModelExample
 	],
 	imports: [BrowserModule, FormsModule, InfineonDesignSystemModule.forRoot()],

--- a/examples/angular-module-example/src/app/app.html
+++ b/examples/angular-module-example/src/app/app.html
@@ -272,6 +272,13 @@
   <!-- </AUTO-GENERATED-COMPONENTS> -->
   
   <!-- Manual examples that require custom logic can go here -->
+  <section id="modal-example" class="component-example">
+    <h2>Modal</h2>
+    <div class="demo">
+      <app-modal-example></app-modal-example>
+    </div>
+  </section>
+
   <section id="ng-model-example" class="component-example">
     <h2>NgModule Example</h2>
     <div class="demo">

--- a/examples/angular-module-example/src/app/manual/modal-example/modal-example.html
+++ b/examples/angular-module-example/src/app/manual/modal-example/modal-example.html
@@ -1,10 +1,9 @@
-  <p>
-    This example uses modern Angular patterns: standalone components with signals for reactive state management.
-    The opened state is backed by a signal with getter/setter for ngModel compatibility.
-  </p>
+<p>
+  This example demonstrates the classic Angular NgModule pattern with primitive values and two-way binding using [(ngModel)].
+</p>
 
-  <!-- Declarative: Two-way binding with ngModel -->
-  <ifx-modal
+<!-- Declarative: Two-way binding with ngModel -->
+<ifx-modal
     caption="Modal Title"
     [captionAriaLabel]="'Additional information for caption'"
     [closeButtonAriaLabel]="'Close modal'"

--- a/examples/angular-module-example/src/app/manual/modal-example/modal-example.ts
+++ b/examples/angular-module-example/src/app/manual/modal-example/modal-example.ts
@@ -1,0 +1,80 @@
+import { Component } from '@angular/core';
+
+/**
+ * Modal Example - NgModule Component
+ * 
+ * This example demonstrates:
+ * - Classic Angular NgModule pattern with primitive values
+ * - Two-way binding with [(ngModel)] via custom IfxModalValueAccessor
+ * 
+ * For a modern standalone component approach with signals, see the standalone example.
+ */
+@Component({
+	selector: 'app-modal-example',
+	standalone: false,
+	templateUrl: './modal-example.html',
+	styleUrl: './modal-example.scss',
+})
+export class ModalExample {
+	opened = false;
+
+	protected readonly tsCode =
+		`import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-modal-example',
+  standalone: false,
+  templateUrl: './modal-example.html',
+  styleUrl: './modal-example.scss'
+})
+export class ModalExample {
+  opened = false;
+
+  openModal() {
+    this.opened = true;
+  }
+
+  protected handleOpen(event: any) {
+    console.log('ifxOpen:', event.detail);
+  }
+
+  protected handleClose(event: any) {
+    console.log('ifxClose:', event.detail);
+  }
+}`;
+
+	protected readonly htmlCode = `
+  &lt;ifx-modal
+    caption="Modal Title"
+    [captionAriaLabel]="'Additional information for caption'"
+    [closeButtonAriaLabel]="'Close modal'"
+    variant="default"
+    [closeOnOverlayClick]="false"
+    [showCloseButton]="true"
+    size="s"
+    [(ngModel)]="opened"
+    (ifxOpen)="handleOpen($event)"
+    (ifxClose)="handleClose($event)">
+    <div slot="content">
+      <span>Modal content</span>
+    </div>
+    <div slot="buttons">
+      <ifx-button variant="secondary">Cancel</ifx-button>
+      <ifx-button>OK</ifx-button>
+    </div>
+  </ifx-modal>
+
+  <ifx-button (click)="openModal()">Open Modal</ifx-button>`;
+
+	openModal() {
+		this.opened = true;
+	}
+
+	protected handleOpen(event: CustomEvent) {
+		console.log('ifxOpen:', event.detail);
+	}
+
+	protected handleClose(event: CustomEvent) {
+		console.log('ifxClose:', event.detail);
+	}
+}

--- a/examples/angular-standalone-example/src/app/app.html
+++ b/examples/angular-standalone-example/src/app/app.html
@@ -274,7 +274,7 @@
 
   <!-- Manual examples that require custom logic -->
   <section id="modal-example" class="component-example">
-    <h2>Modal</h2>
+    <h2>Modal (ngModel)</h2>
     <div class="demo">
       <app-modal-example />
     </div>

--- a/examples/angular-standalone-example/src/app/manual/modal-example/modal-example.ts
+++ b/examples/angular-standalone-example/src/app/manual/modal-example/modal-example.ts
@@ -1,42 +1,65 @@
 import {
 	Component,
-	CUSTOM_ELEMENTS_SCHEMA,
-	type ElementRef,
-	ViewChild,
+	signal,
 } from "@angular/core";
+import { FormsModule } from "@angular/forms";
 import {
+  IfxModalValueAccessor,
 	IfxButton,
 	IfxModal,
 } from "@infineon/infineon-design-system-angular/standalone";
 
+/**
+ * Modal Example - Standalone Component with Signals
+ * 
+ * This example demonstrates:
+ * - Modern Angular standalone components with signals for reactive state
+ * - Two-way binding with [(ngModel)] via custom IfxModalValueAccessor
+ * 
+ * For a classic NgModule approach without signals, see the module example.
+ */
 @Component({
 	selector: "app-modal-example",
-	imports: [IfxButton, IfxModal],
+	imports: [IfxModalValueAccessor, IfxButton, IfxModal, FormsModule],
 	templateUrl: "./modal-example.html",
 	styleUrl: "./modal-example.scss",
-	schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class ModalExample {
-	@ViewChild("modal") modalRef!: ElementRef;
+
+	private _opened = signal(false);
+
+	get opened() {
+		return this._opened();
+	}
+
+	set opened(value: boolean) {
+		this._opened.set(value);
+	}
 
 	protected readonly tsCode =
-		`import { IfxButton, IfxModal } from '@infineon/infineon-design-system-angular/standalone';
-import { Component, ViewChild, ElementRef, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+		`import { IfxModalValueAccessor, IfxButton, IfxModal } from '@infineon/infineon-design-system-angular/standalone';
+import { Component, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-modal-example',
-  imports: [ IfxButton, IfxModal ],
+  imports: [ IfxModalValueAccessor, IfxButton, IfxModal, FormsModule ],
   templateUrl: './modal-example.html',
-  styleUrl: './modal-example.scss',
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  styleUrl: './modal-example.scss'
 })
 export class ModalExample {
-  @ViewChild('modal') modalRef!: ElementRef;
+  private _opened = signal(false);
+
+  get opened() {
+    return this._opened();
+  }
+
+  set opened(value: boolean) {
+    this._opened.set(value);
+  }
 
   openModal() {
-    if (this.modalRef?.nativeElement) {
-      this.modalRef.nativeElement.opened = true;
-    }
+    this._opened.set(true);
   }
 
   protected handleOpen(event: any) {
@@ -48,15 +71,16 @@ export class ModalExample {
   }
 }`;
 
-	protected readonly htmlCode = `  &lt;ifx-modal
-    #modal
+	protected readonly htmlCode = `
+  &lt;ifx-modal
     caption=&quot;Modal Title&quot;
-    caption-aria-label=&quot;Additional information for caption&quot;
-    close-button-aria-label=&quot;Close modal&quot;
+    [captionAriaLabel]=&quot;'Additional information for caption'&quot;
+    [closeButtonAriaLabel]=&quot;'Close modal'&quot;
     variant=&quot;default&quot;
-    [close-on-overlay-click]=&quot;false&quot;
-    [show-close-button]=&quot;true&quot;
+    [closeOnOverlayClick]=&quot;false&quot;
+    [showCloseButton]=&quot;true&quot;
     size=&quot;s&quot;
+    [(ngModel)]=&quot;opened&quot;
     (ifxOpen)=&quot;handleOpen($event)&quot;
     (ifxClose)=&quot;handleClose($event)&quot;&gt;
     &lt;div slot=&quot;content&quot;&gt;
@@ -70,9 +94,7 @@ export class ModalExample {
   &lt;ifx-button (click)=&quot;openModal()&quot;&gt;Open Modal&lt;/ifx-button&gt;`;
 
 	openModal() {
-		if (this.modalRef?.nativeElement) {
-			this.modalRef.nativeElement.opened = true;
-		}
+		this._opened.set(true);
 	}
 
 	protected handleOpen(event: CustomEvent) {

--- a/examples/vue-example/package.json
+++ b/examples/vue-example/package.json
@@ -19,6 +19,7 @@
 	"devDependencies": {
 		"@tsconfig/node22": "^22.0.2",
 		"@types/node": "^22.18.11",
+		"@types/prismjs": "^1.26.6",
 		"@vitejs/plugin-vue": "^6.0.1",
 		"@vue/tsconfig": "^0.8.1",
 		"typescript": "~5.9.0",

--- a/examples/vue-example/src/App.vue
+++ b/examples/vue-example/src/App.vue
@@ -345,7 +345,7 @@ onMounted(() => {
 
     <!-- Manual examples that require custom logic -->
     <section id="modal-example" class="component-example">
-      <h2>Modal (Manual Example)</h2>
+      <h2>Modal (V-Model)</h2>
       <div class="demo">
         <ModalExample />
       </div>

--- a/examples/vue-example/src/manual/ModalExample.vue
+++ b/examples/vue-example/src/manual/ModalExample.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <ifx-modal
-      ref="modalRef"
       caption="Modal Title"
       caption-aria-label="Additional information for caption"
       close-button-aria-label="Close modal"
@@ -9,6 +8,7 @@
       :close-on-overlay-click="false"
       :show-close-button="true"
       size="s"
+      v-model="opened"
       @ifxOpen="handleOpen"
       @ifxClose="handleClose">
       <div slot="content">
@@ -29,15 +29,14 @@
 </template>
 
 <script setup lang="ts">
+import { IfxModal } from '@infineon/infineon-design-system-vue';
 import Prism from 'prismjs';
 import { ref } from 'vue';
 
-const modalRef = ref<HTMLElement | null>(null);
+const opened = ref(false);
 
 const openModal = () => {
-  if (modalRef.value) {
-    (modalRef.value as any).opened = true;
-  }
+  opened.value = true;
 };
 
 const handleOpen = (event: CustomEvent) => {
@@ -52,7 +51,6 @@ const codeExample = Prism.highlight(
   `<template>
   <div>
     <ifx-modal
-      ref="modalRef"
       caption="Modal Title"
       caption-aria-label="Additional information for caption"
       close-button-aria-label="Close modal"
@@ -60,6 +58,7 @@ const codeExample = Prism.highlight(
       :close-on-overlay-click="false"
       :show-close-button="true"
       size="s"
+      v-model="opened"
       @ifxOpen="handleOpen"
       @ifxClose="handleClose">
       <div slot="content">
@@ -75,14 +74,13 @@ const codeExample = Prism.highlight(
 </template>
 
 <script setup lang="ts">
+import { IfxModal } from '@infineon/infineon-design-system-vue';
 import { ref } from 'vue';
 
-const modalRef = ref<HTMLElement | null>(null);
+const opened = ref(false);
 
 const openModal = () => {
-  if (modalRef.value) {
-    (modalRef.value as any).opened = true;
-  }
+  opened.value = true;
 };
 
 const handleOpen = (event: CustomEvent) => {

--- a/examples/vue-example/src/manual/ModalExample.vue
+++ b/examples/vue-example/src/manual/ModalExample.vue
@@ -91,7 +91,7 @@ const handleClose = (event: CustomEvent) => {
   console.log('ifxClose:', event.detail);
 };
 <\/script>`,
-  Prism.languages.markup,
+  Prism.languages.markup!,
   'markup'
 );
 </script>

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -781,10 +781,18 @@ export namespace Components {
          */
         "closeButtonAriaLabel": string;
         /**
+          * Public method to programmatically close the modal.
+         */
+        "closeModal": () => Promise<void>;
+        /**
           * Determines whether clicking on the overlay (backdrop) will close the modal.
           * @default true
          */
         "closeOnOverlayClick": boolean;
+        /**
+          * Public method to programmatically open the modal.
+         */
+        "openModal": () => Promise<void>;
         /**
           * Controls the visibility of the modal. Can be used for both declarative and programmatic control.
           * @default false

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -762,40 +762,46 @@ export namespace Components {
     }
     interface IfxModal {
         /**
+          * Allows the display of a specific icon in the modal header when the variant is set to an alert type. Refer to the [Icon Library](https://infineon.github.io/infineon-design-system-stencil/storybook/?path=/docs/icon-library--development) for available icons.
           * @default ""
          */
         "alertIcon": string;
         /**
-          * @default "Cancel"
-         */
-        "cancelButtonLabel": string;
-        /**
+          * The title text displayed in the modal header. This should be a concise description of the modal's purpose.
           * @default "Modal Title"
          */
         "caption": string;
-        "captionAriaLabel": string | null;
-        "closeButtonAriaLabel": string | null;
         /**
+          * Provides an accessible label for the modal caption, enhancing screen reader support. If not provided, the `caption` prop will be used as the accessible name.
+         */
+        "captionAriaLabel": string | null;
+        /**
+          * Provides an accessible label for the close button, enhancing screen reader support. If not provided, a default label of "Close modal" will be used.
+          * @default "Close modal"
+         */
+        "closeButtonAriaLabel": string;
+        /**
+          * Determines whether clicking on the overlay (backdrop) will close the modal.
           * @default true
          */
         "closeOnOverlayClick": boolean;
         /**
-          * @default "OK"
-         */
-        "okButtonLabel": string;
-        /**
+          * Controls the visibility of the modal. Can be used for both declarative and programmatic control.
           * @default false
          */
         "opened"?: boolean;
         /**
+          * Controls the visibility of the close button in the modal header.
           * @default true
          */
         "showCloseButton": boolean;
         /**
+          * Specifies the size of the modal, allowing it to adapt to different content needs and screen sizes.
           * @default "s"
          */
         "size": "s" | "m" | "l";
         /**
+          * Defines the visual style of the modal, indicating its purpose or importance.
           * @default "default"
          */
         "variant": "default" | "alert-brand" | "alert-danger";
@@ -2671,6 +2677,7 @@ declare global {
     interface HTMLIfxModalElementEventMap {
         "ifxOpen": any;
         "ifxClose": any;
+        "ifxOpenedChange": { opened: boolean };
     }
     interface HTMLIfxModalElement extends Components.IfxModal, HTMLStencilElement {
         addEventListener<K extends keyof HTMLIfxModalElementEventMap>(type: K, listener: (this: HTMLIfxModalElement, ev: IfxModalCustomEvent<HTMLIfxModalElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4104,42 +4111,58 @@ declare namespace LocalJSX {
     }
     interface IfxModal {
         /**
+          * Allows the display of a specific icon in the modal header when the variant is set to an alert type. Refer to the [Icon Library](https://infineon.github.io/infineon-design-system-stencil/storybook/?path=/docs/icon-library--development) for available icons.
           * @default ""
          */
         "alertIcon"?: string;
         /**
-          * @default "Cancel"
-         */
-        "cancelButtonLabel"?: string;
-        /**
+          * The title text displayed in the modal header. This should be a concise description of the modal's purpose.
           * @default "Modal Title"
          */
         "caption"?: string;
-        "captionAriaLabel"?: string | null;
-        "closeButtonAriaLabel"?: string | null;
         /**
+          * Provides an accessible label for the modal caption, enhancing screen reader support. If not provided, the `caption` prop will be used as the accessible name.
+         */
+        "captionAriaLabel"?: string | null;
+        /**
+          * Provides an accessible label for the close button, enhancing screen reader support. If not provided, a default label of "Close modal" will be used.
+          * @default "Close modal"
+         */
+        "closeButtonAriaLabel"?: string;
+        /**
+          * Determines whether clicking on the overlay (backdrop) will close the modal.
           * @default true
          */
         "closeOnOverlayClick"?: boolean;
         /**
-          * @default "OK"
+          * Emitted when the modal finishes closing and the closing animation completes. No additional data is provided with this event.
          */
-        "okButtonLabel"?: string;
         "onIfxClose"?: (event: IfxModalCustomEvent<any>) => void;
+        /**
+          * Emitted when the modal finishes opening and the opening animation completes. No additional data is provided with this event.
+         */
         "onIfxOpen"?: (event: IfxModalCustomEvent<any>) => void;
         /**
+          * Emitted immediately when the `opened` state changes (before animations). The event detail contains `{ opened: boolean }` with the new state. Use this event for two-way binding (v-model in Vue, [(ngModel)] in Angular).
+         */
+        "onIfxOpenedChange"?: (event: IfxModalCustomEvent<{ opened: boolean }>) => void;
+        /**
+          * Controls the visibility of the modal. Can be used for both declarative and programmatic control.
           * @default false
          */
         "opened"?: boolean;
         /**
+          * Controls the visibility of the close button in the modal header.
           * @default true
          */
         "showCloseButton"?: boolean;
         /**
+          * Specifies the size of the modal, allowing it to adapt to different content needs and screen sizes.
           * @default "s"
          */
         "size"?: "s" | "m" | "l";
         /**
+          * Defines the visual style of the modal, indicating its purpose or importance.
           * @default "default"
          */
         "variant"?: "default" | "alert-brand" | "alert-danger";
@@ -5499,10 +5522,8 @@ declare namespace LocalJSX {
         "variant": "default" | "alert-brand" | "alert-danger";
         "size": "s" | "m" | "l";
         "alertIcon": string;
-        "okButtonLabel": string;
-        "cancelButtonLabel": string;
-        "closeButtonAriaLabel": string | null;
         "showCloseButton": boolean;
+        "closeButtonAriaLabel": string;
     }
     interface IfxMultiselectAttributes {
         "name": string;

--- a/packages/components/src/components/modal/modal.tsx
+++ b/packages/components/src/components/modal/modal.tsx
@@ -90,6 +90,13 @@ export class IfxModal {
 	 */
 	@Event() ifxClose: EventEmitter;
 
+	/**
+	 * Emitted immediately when the `opened` state changes (before animations).
+	 * The event detail contains `{ opened: boolean }` with the new state.
+	 * Use this event for two-way binding (v-model in Vue, [(ngModel)] in Angular).
+	 */
+	@Event() ifxOpenedChange: EventEmitter<{ opened: boolean }>;
+
 	@State() showModal: boolean = this.opened || false;
 
 	@State() slotButtonsPresent: boolean = false;
@@ -238,6 +245,7 @@ export class IfxModal {
 
 	@Watch("opened")
 	openedChanged(newValue: boolean) {
+		this.ifxOpenedChange.emit({ opened: newValue });
 		if (newValue === true) {
 			this.open();
 		} else {

--- a/packages/components/src/components/modal/modal.tsx
+++ b/packages/components/src/components/modal/modal.tsx
@@ -5,6 +5,7 @@ import {
 	type EventEmitter,
 	Host,
 	h,
+	Method,
 	Prop,
 	State,
 	Watch,
@@ -255,6 +256,22 @@ export class IfxModal {
 		} else {
 			this.close();
 		}
+	}
+
+	/**
+	 * Public method to programmatically open the modal.
+	 */
+	@Method()
+	public async openModal() {
+		this.opened = true;
+	}
+
+	/**
+	 * Public method to programmatically close the modal.
+	 */
+	@Method()
+	public async closeModal() {
+		this.opened = false;
 	}
 
 	private handleOverlayClick() {

--- a/packages/components/src/components/modal/modal.tsx
+++ b/packages/components/src/components/modal/modal.tsx
@@ -129,6 +129,10 @@ export class IfxModal {
 			isFocusable,
 		);
 		window.addEventListener("resize", this.handleResize);
+		
+		if (this.opened) {
+			this.open();
+		}
 	}
 
 	disconnectedCallback() {

--- a/packages/components/src/components/modal/modal.tsx
+++ b/packages/components/src/components/modal/modal.tsx
@@ -9,13 +9,13 @@ import {
 	State,
 	Watch,
 } from "@stencil/core";
-import { animationTo, KEYFRAMES } from "../..//shared/utils/animation";
-import { isNestedInIfxComponent } from "../..//shared/utils/dom-utils";
+import { animationTo, KEYFRAMES } from "../../shared/utils/animation";
+import { isNestedInIfxComponent } from "../../shared/utils/dom-utils";
 import {
 	isFocusable,
 	isHidden,
 	queryShadowRoot,
-} from "../..//shared/utils/focus-trap";
+} from "../../shared/utils/focus-trap";
 import { detectFramework } from "../..//shared/utils/framework-detection";
 import { trackComponent } from "../../shared/utils/tracking";
 
@@ -30,31 +30,70 @@ export interface BeforeCloseEventDetail {
 	shadow: true,
 })
 export class IfxModal {
-	@Prop({ reflect: true, mutable: true }) opened?: boolean = false;
-	@State() showModal: boolean = this.opened || false;
-
-	@Prop() readonly caption: string = "Modal Title";
-	@Prop() readonly captionAriaLabel: string | null;
-
-	@Prop() readonly closeOnOverlayClick: boolean = true;
-
-	@Event() ifxOpen: EventEmitter;
-	@Event() ifxClose: EventEmitter;
-
-	@Prop() readonly variant: "default" | "alert-brand" | "alert-danger" = "default";
-
-	@Prop() readonly size: "s" | "m" | "l" = "s";
-
-	@Prop() readonly alertIcon: string = "";
-	@Prop() readonly okButtonLabel: string = "OK";
-	@Prop() readonly cancelButtonLabel: string = "Cancel";
-	@Prop() readonly closeButtonAriaLabel: string | null;
 
 	@Element() hostElement: HTMLIfxModalElement;
 
+	/**
+	 * Controls the visibility of the modal. Can be used for both declarative and programmatic control.
+	 */
+	@Prop({ reflect: true, mutable: true }) opened?: boolean = false;
+
+
+	/**
+	 * The title text displayed in the modal header. This should be a concise description of the modal's purpose.
+	 */
+	@Prop() readonly caption: string = "Modal Title";
+
+	/**
+	 * Provides an accessible label for the modal caption, enhancing screen reader support. If not provided, the `caption` prop will be used as the accessible name.
+	 */
+	@Prop() readonly captionAriaLabel: string | null;
+
+	/**
+	 * Determines whether clicking on the overlay (backdrop) will close the modal. 
+	 */
+	@Prop() readonly closeOnOverlayClick: boolean = true;
+
+	/**
+	 * Defines the visual style of the modal, indicating its purpose or importance. 
+	 */
+	@Prop() readonly variant: "default" | "alert-brand" | "alert-danger" = "default";
+
+	/**
+	 * Specifies the size of the modal, allowing it to adapt to different content needs and screen sizes. 
+	 */
+	@Prop() readonly size: "s" | "m" | "l" = "s";
+
+	/**
+	 * Allows the display of a specific icon in the modal header when the variant is set to an alert type.
+	 * Refer to the [Icon Library](https://infineon.github.io/infineon-design-system-stencil/storybook/?path=/docs/icon-library--development) for available icons.
+	 */
+	@Prop() readonly alertIcon: string = "";
+
+	/**
+	 * Controls the visibility of the close button in the modal header. 
+	 */
+	@Prop() readonly showCloseButton: boolean = true;
+
+	/**
+	 * Provides an accessible label for the close button, enhancing screen reader support. If not provided, a default label of "Close modal" will be used.
+	 */
+	@Prop() readonly closeButtonAriaLabel: string = "Close modal";
+
+	/**
+	 * Emitted when the modal finishes opening and the opening animation completes. No additional data is provided with this event.
+	 */
+	@Event() ifxOpen: EventEmitter;
+
+	/**
+	 * Emitted when the modal finishes closing and the closing animation completes. No additional data is provided with this event.
+	 */
+	@Event() ifxClose: EventEmitter;
+
+	@State() showModal: boolean = this.opened || false;
+
 	@State() slotButtonsPresent: boolean = false;
 
-	@Prop() readonly showCloseButton: boolean = true;
 
 	private modalContainer: HTMLElement;
 	private focusableElements: HTMLElement[] = [];
@@ -198,7 +237,7 @@ export class IfxModal {
 	}
 
 	@Watch("opened")
-	openedChanged(newValue) {
+	openedChanged(newValue: boolean) {
 		if (newValue === true) {
 			this.open();
 		} else {
@@ -306,6 +345,7 @@ export class IfxModal {
 										icon="cross-16"
 										variant="tertiary"
 										onClick={() => this.doBeforeClose("CLOSE_BUTTON")}
+										ariaLabel={this.closeButtonAriaLabel}
 									></ifx-icon-button>
 								)}
 							</div>

--- a/packages/components/src/components/modal/modal.tsx
+++ b/packages/components/src/components/modal/modal.tsx
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/a11y/noNoninteractiveTabindex: focus traps are required to keep users focus within the modal */
 import {
 	Component,
 	Element,
@@ -31,14 +32,12 @@ export interface BeforeCloseEventDetail {
 	shadow: true,
 })
 export class IfxModal {
-
 	@Element() hostElement: HTMLIfxModalElement;
 
 	/**
 	 * Controls the visibility of the modal. Can be used for both declarative and programmatic control.
 	 */
 	@Prop({ reflect: true, mutable: true }) opened?: boolean = false;
-
 
 	/**
 	 * The title text displayed in the modal header. This should be a concise description of the modal's purpose.
@@ -51,17 +50,18 @@ export class IfxModal {
 	@Prop() readonly captionAriaLabel: string | null;
 
 	/**
-	 * Determines whether clicking on the overlay (backdrop) will close the modal. 
+	 * Determines whether clicking on the overlay (backdrop) will close the modal.
 	 */
 	@Prop() readonly closeOnOverlayClick: boolean = true;
 
 	/**
-	 * Defines the visual style of the modal, indicating its purpose or importance. 
+	 * Defines the visual style of the modal, indicating its purpose or importance.
 	 */
-	@Prop() readonly variant: "default" | "alert-brand" | "alert-danger" = "default";
+	@Prop() readonly variant: "default" | "alert-brand" | "alert-danger" =
+		"default";
 
 	/**
-	 * Specifies the size of the modal, allowing it to adapt to different content needs and screen sizes. 
+	 * Specifies the size of the modal, allowing it to adapt to different content needs and screen sizes.
 	 */
 	@Prop() readonly size: "s" | "m" | "l" = "s";
 
@@ -72,7 +72,7 @@ export class IfxModal {
 	@Prop() readonly alertIcon: string = "";
 
 	/**
-	 * Controls the visibility of the close button in the modal header. 
+	 * Controls the visibility of the close button in the modal header.
 	 */
 	@Prop() readonly showCloseButton: boolean = true;
 
@@ -102,7 +102,6 @@ export class IfxModal {
 
 	@State() slotButtonsPresent: boolean = false;
 
-
 	private modalContainer: HTMLElement;
 	private focusableElements: HTMLElement[] = [];
 	private closeButton: HTMLButtonElement | HTMLIfxIconButtonElement;
@@ -130,7 +129,7 @@ export class IfxModal {
 			isFocusable,
 		);
 		window.addEventListener("resize", this.handleResize);
-		
+
 		if (this.opened) {
 			this.open();
 		}
@@ -209,7 +208,7 @@ export class IfxModal {
 			});
 
 			this.hostElement.addEventListener("keydown", this.handleKeypress);
-		} catch (err) {
+		} catch (_err) {
 			this.ifxOpen.emit();
 		}
 	}
@@ -224,7 +223,7 @@ export class IfxModal {
 				this.ifxClose.emit();
 			});
 			this.hostElement.removeEventListener("keydown", this.handleKeypress);
-		} catch (err) {
+		} catch (_err) {
 			this.showModal = false;
 			this.ifxClose.emit();
 		}
@@ -339,17 +338,22 @@ export class IfxModal {
 		return (
 			<Host>
 				<div
-					ref={(el) => (this.modalContainer = el)}
+					ref={(el) => {
+						this.modalContainer = el;
+					}}
 					class={`modal-container ${this.showModal ? "open" : ""}`}
 				>
+					{/* biome-ignore lint/a11y/noStaticElementInteractions: Overlay is a functional backdrop element */}
 					<div
 						class="modal-overlay"
+						role="presentation"
 						onClick={() => this.handleOverlayClick()}
 					></div>
 					<div
 						data-focus-trap-edge
+						role="none"
 						onFocus={this.handleTopFocus}
-						tabindex="0"
+						tabIndex={0}
 					></div>
 					<div
 						class={`modal-content-container ${this.size}`}
@@ -368,6 +372,7 @@ export class IfxModal {
 							<div class="modal-header">
 								<h2 class="modal-caption">{this.caption}</h2>
 								{this.showCloseButton && (
+									// biome-ignore lint/a11y/noStaticElementInteractions: ifx-icon-button is a functional button element
 									<ifx-icon-button
 										class="modal-close-button"
 										ref={(el) => (this.closeButton = el)}
@@ -396,8 +401,9 @@ export class IfxModal {
 					</div>
 					<div
 						data-focus-trap-edge
+						role="none"
 						onFocus={this.handleBottomFocus}
-						tabindex="0"
+						tabIndex={0}
 					></div>
 				</div>
 			</Host>

--- a/packages/components/src/components/modal/readme.md
+++ b/packages/components/src/components/modal/readme.md
@@ -29,6 +29,29 @@
 | `ifxOpenedChange` | Emitted immediately when the `opened` state changes (before animations). The event detail contains `{ opened: boolean }` with the new state. Use this event for two-way binding (v-model in Vue, [(ngModel)] in Angular). | `CustomEvent<{ opened: boolean; }>` |
 
 
+## Methods
+
+### `closeModal() => Promise<void>`
+
+Public method to programmatically close the modal.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `openModal() => Promise<void>`
+
+Public method to programmatically open the modal.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/components/src/components/modal/readme.md
+++ b/packages/components/src/components/modal/readme.md
@@ -7,27 +7,26 @@
 
 ## Properties
 
-| Property               | Attribute                 | Description | Type                                           | Default         |
-| ---------------------- | ------------------------- | ----------- | ---------------------------------------------- | --------------- |
-| `alertIcon`            | `alert-icon`              |             | `string`                                       | `""`            |
-| `cancelButtonLabel`    | `cancel-button-label`     |             | `string`                                       | `"Cancel"`      |
-| `caption`              | `caption`                 |             | `string`                                       | `"Modal Title"` |
-| `captionAriaLabel`     | `caption-aria-label`      |             | `string`                                       | `undefined`     |
-| `closeButtonAriaLabel` | `close-button-aria-label` |             | `string`                                       | `undefined`     |
-| `closeOnOverlayClick`  | `close-on-overlay-click`  |             | `boolean`                                      | `true`          |
-| `okButtonLabel`        | `ok-button-label`         |             | `string`                                       | `"OK"`          |
-| `opened`               | `opened`                  |             | `boolean`                                      | `false`         |
-| `showCloseButton`      | `show-close-button`       |             | `boolean`                                      | `true`          |
-| `size`                 | `size`                    |             | `"l" \| "m" \| "s"`                            | `"s"`           |
-| `variant`              | `variant`                 |             | `"alert-brand" \| "alert-danger" \| "default"` | `"default"`     |
+| Property               | Attribute                 | Description                                                                                                                                                                                                                                                     | Type                                           | Default         |
+| ---------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- | --------------- |
+| `alertIcon`            | `alert-icon`              | Allows the display of a specific icon in the modal header when the variant is set to an alert type. Refer to the [Icon Library](https://infineon.github.io/infineon-design-system-stencil/storybook/?path=/docs/icon-library--development) for available icons. | `string`                                       | `""`            |
+| `caption`              | `caption`                 | The title text displayed in the modal header. This should be a concise description of the modal's purpose.                                                                                                                                                      | `string`                                       | `"Modal Title"` |
+| `captionAriaLabel`     | `caption-aria-label`      | Provides an accessible label for the modal caption, enhancing screen reader support. If not provided, the `caption` prop will be used as the accessible name.                                                                                                   | `string`                                       | `undefined`     |
+| `closeButtonAriaLabel` | `close-button-aria-label` | Provides an accessible label for the close button, enhancing screen reader support. If not provided, a default label of "Close modal" will be used.                                                                                                             | `string`                                       | `"Close modal"` |
+| `closeOnOverlayClick`  | `close-on-overlay-click`  | Determines whether clicking on the overlay (backdrop) will close the modal.                                                                                                                                                                                     | `boolean`                                      | `true`          |
+| `opened`               | `opened`                  | Controls the visibility of the modal. Can be used for both declarative and programmatic control.                                                                                                                                                                | `boolean`                                      | `false`         |
+| `showCloseButton`      | `show-close-button`       | Controls the visibility of the close button in the modal header.                                                                                                                                                                                                | `boolean`                                      | `true`          |
+| `size`                 | `size`                    | Specifies the size of the modal, allowing it to adapt to different content needs and screen sizes.                                                                                                                                                              | `"l" \| "m" \| "s"`                            | `"s"`           |
+| `variant`              | `variant`                 | Defines the visual style of the modal, indicating its purpose or importance.                                                                                                                                                                                    | `"alert-brand" \| "alert-danger" \| "default"` | `"default"`     |
 
 
 ## Events
 
-| Event      | Description | Type               |
-| ---------- | ----------- | ------------------ |
-| `ifxClose` |             | `CustomEvent<any>` |
-| `ifxOpen`  |             | `CustomEvent<any>` |
+| Event             | Description                                                                                                                                                                                                               | Type                                |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `ifxClose`        | Emitted when the modal finishes closing and the closing animation completes. No additional data is provided with this event.                                                                                              | `CustomEvent<any>`                  |
+| `ifxOpen`         | Emitted when the modal finishes opening and the opening animation completes. No additional data is provided with this event.                                                                                              | `CustomEvent<any>`                  |
+| `ifxOpenedChange` | Emitted immediately when the `opened` state changes (before animations). The event detail contains `{ opened: boolean }` with the new state. Use this event for two-way binding (v-model in Vue, [(ngModel)] in Angular). | `CustomEvent<{ opened: boolean; }>` |
 
 
 ## Dependencies

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -27,6 +27,11 @@ const componentModels: ComponentModelConfig[] = [
 		event: "ifxInput",
 		targetAttr: "value",
 	},
+	{
+		elements: ["ifx-modal"],
+		event: "ifxOpenedChange",
+		targetAttr: "opened",
+	},
 ];
 
 /**

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -57,6 +57,9 @@ const valueAccessorConfigs: ValueAccessorConfig[] = [
 		targetAttr: "value",
 		type: "text",
 	},
+	// Note: ifx-modal uses a custom IfxModalValueAccessor (standalone/src/lib/ifx-modal-value-accessor.ts)
+	// because of Stencil limitation: https://github.com/stenciljs/output-targets/issues/87
+	// Different targetAttr values in the same type group are not supported by code generation.
 ];
 
 export const config: Config = {

--- a/packages/wrapper-angular/src/lib/ifx-modal-value-accessor.ts
+++ b/packages/wrapper-angular/src/lib/ifx-modal-value-accessor.ts
@@ -1,0 +1,43 @@
+import { Directive, ElementRef, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { ValueAccessor } from './stencil-generated/value-accessor';
+
+/**
+ * Custom Value Accessor for ifx-modal component.
+ * 
+ * This is a workaround for https://github.com/stenciljs/output-targets/issues/87
+ * 
+ * Problem: When multiple components use type: "boolean" but different targetAttr,
+ * the generated BooleanValueAccessor.writeValue() only sets one property (e.g., 'checked'),
+ * ignoring other targetAttr values like 'opened'.
+ * 
+ * TODO: Remove this once https://github.com/stenciljs/output-targets/issues/87 is resolved
+ * and Stencil generates separate accessors or dynamic property detection.
+ */
+@Directive({
+  /* tslint:disable-next-line:directive-selector */
+  selector: 'ifx-modal[ngModel],ifx-modal[formControl],ifx-modal[formControlName]',
+  host: {
+    '(ifxOpenedChange)': 'handleChangeEvent($event.target?.["opened"])'
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => IfxModalNgModuleValueAccessor),
+      multi: true
+    }
+  ],
+  standalone: false
+})
+export class IfxModalNgModuleValueAccessor extends ValueAccessor {
+  constructor(el: ElementRef) {
+    super(el);
+  }
+  
+  override writeValue(value: any) {
+    this.el.nativeElement.opened = this.lastValue = value == null ? false : value;
+  }
+}
+
+// Export with original name for backwards compatibility
+export { IfxModalNgModuleValueAccessor as IfxModalValueAccessor };

--- a/packages/wrapper-angular/src/lib/stencil-generated/components.ts
+++ b/packages/wrapper-angular/src/lib/stencil-generated/components.ts
@@ -1262,21 +1262,22 @@ export declare interface IfxListEntry extends Components.IfxListEntry {
 
 
 @ProxyCmp({
-  inputs: ['alertIcon', 'cancelButtonLabel', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'okButtonLabel', 'opened', 'showCloseButton', 'size', 'variant']
+  inputs: ['alertIcon', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'opened', 'showCloseButton', 'size', 'variant']
 })
 @Component({
   selector: 'ifx-modal',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['alertIcon', 'cancelButtonLabel', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'okButtonLabel', 'opened', 'showCloseButton', 'size', 'variant'],
-  outputs: ['ifxOpen', 'ifxClose'],
+  inputs: ['alertIcon', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'opened', 'showCloseButton', 'size', 'variant'],
+  outputs: ['ifxOpen', 'ifxClose', 'ifxOpenedChange'],
   standalone: false
 })
 export class IfxModal {
   protected el: HTMLIfxModalElement;
   @Output() ifxOpen = new EventEmitter<CustomEvent<any>>();
   @Output() ifxClose = new EventEmitter<CustomEvent<any>>();
+  @Output() ifxOpenedChange = new EventEmitter<CustomEvent<{ opened: boolean }>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -1285,10 +1286,20 @@ export class IfxModal {
 
 
 export declare interface IfxModal extends Components.IfxModal {
-
+  /**
+   * Emitted when the modal finishes opening and the opening animation completes. No additional data is provided with this event.
+   */
   ifxOpen: EventEmitter<CustomEvent<any>>;
-
+  /**
+   * Emitted when the modal finishes closing and the closing animation completes. No additional data is provided with this event.
+   */
   ifxClose: EventEmitter<CustomEvent<any>>;
+  /**
+   * Emitted immediately when the `opened` state changes (before animations).
+The event detail contains `{ opened: boolean }` with the new state.
+Use this event for two-way binding (v-model in Vue, [(ngModel)] in Angular).
+   */
+  ifxOpenedChange: EventEmitter<CustomEvent<{ opened: boolean }>>;
 }
 
 

--- a/packages/wrapper-angular/src/lib/stencil-generated/components.ts
+++ b/packages/wrapper-angular/src/lib/stencil-generated/components.ts
@@ -1262,7 +1262,8 @@ export declare interface IfxListEntry extends Components.IfxListEntry {
 
 
 @ProxyCmp({
-  inputs: ['alertIcon', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'opened', 'showCloseButton', 'size', 'variant']
+  inputs: ['alertIcon', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'opened', 'showCloseButton', 'size', 'variant'],
+  methods: ['openModal', 'closeModal']
 })
 @Component({
   selector: 'ifx-modal',

--- a/packages/wrapper-angular/src/lib/wrapper-angular.module.ts
+++ b/packages/wrapper-angular/src/lib/wrapper-angular.module.ts
@@ -10,10 +10,11 @@ import { defineCustomElements } from "@infineon/infineon-design-system-stencil/l
 import { DIRECTIVES } from "./stencil-generated";
 import { BooleanValueAccessor } from "./stencil-generated/boolean-value-accessor";
 import { TextValueAccessor } from "./stencil-generated/text-value-accessor";
+import { IfxModalNgModuleValueAccessor } from "./ifx-modal-value-accessor";
 
 @NgModule({
-	declarations: [...DIRECTIVES, BooleanValueAccessor, TextValueAccessor],
-	exports: [...DIRECTIVES, BooleanValueAccessor, TextValueAccessor],
+	declarations: [...DIRECTIVES, BooleanValueAccessor, TextValueAccessor, IfxModalNgModuleValueAccessor],
+	exports: [...DIRECTIVES, BooleanValueAccessor, TextValueAccessor, IfxModalNgModuleValueAccessor],
 	imports: [CommonModule],
 })
 export class InfineonDesignSystemModule {

--- a/packages/wrapper-angular/src/public-api.ts
+++ b/packages/wrapper-angular/src/public-api.ts
@@ -4,6 +4,7 @@ export { DIRECTIVES } from "./lib/stencil-generated";
 
 export { BooleanValueAccessor } from "./lib/stencil-generated/boolean-value-accessor";
 export { TextValueAccessor } from "./lib/stencil-generated/text-value-accessor";
+export { IfxModalValueAccessor } from "./lib/ifx-modal-value-accessor";
 
 export * from "./lib/stencil-generated/components";
 export * from "./lib/wrapper-angular.module";

--- a/packages/wrapper-angular/standalone/src/index.ts
+++ b/packages/wrapper-angular/standalone/src/index.ts
@@ -2,5 +2,6 @@
 
 export { BooleanValueAccessor } from "./lib/stencil-generated/boolean-value-accessor";
 export { TextValueAccessor } from "./lib/stencil-generated/text-value-accessor";
+export { IfxModalValueAccessor } from "./lib/ifx-modal-value-accessor";
 
 export * from "./lib/stencil-generated/components";

--- a/packages/wrapper-angular/standalone/src/lib/ifx-modal-value-accessor.ts
+++ b/packages/wrapper-angular/standalone/src/lib/ifx-modal-value-accessor.ts
@@ -1,0 +1,40 @@
+import { Directive, ElementRef, forwardRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { ValueAccessor } from './stencil-generated/value-accessor';
+
+/**
+ * Custom Value Accessor for ifx-modal component.
+ * 
+ * This is a workaround for https://github.com/stenciljs/output-targets/issues/87
+ * 
+ * Problem: When multiple components use type: "boolean" but different targetAttr,
+ * the generated BooleanValueAccessor.writeValue() only sets one property (e.g., 'checked'),
+ * ignoring other targetAttr values like 'opened'.
+ * 
+ * TODO: Remove this once https://github.com/stenciljs/output-targets/issues/87 is resolved
+ * and Stencil generates separate accessors or dynamic property detection.
+ */
+@Directive({
+  /* tslint:disable-next-line:directive-selector */
+  selector: 'ifx-modal[ngModel],ifx-modal[formControl],ifx-modal[formControlName]',
+  host: {
+    '(ifxOpenedChange)': 'handleChangeEvent($event.target?.["opened"])'
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => IfxModalValueAccessor),
+      multi: true
+    }
+  ],
+  standalone: true
+})
+export class IfxModalValueAccessor extends ValueAccessor {
+  constructor(el: ElementRef) {
+    super(el);
+  }
+  
+  override writeValue(value: any) {
+    this.el.nativeElement.opened = this.lastValue = value == null ? false : value;
+  }
+}

--- a/packages/wrapper-angular/standalone/src/lib/stencil-generated/components.ts
+++ b/packages/wrapper-angular/standalone/src/lib/stencil-generated/components.ts
@@ -1347,20 +1347,21 @@ export declare interface IfxListEntry extends Components.IfxListEntry {
 
 @ProxyCmp({
   defineCustomElementFn: defineIfxModal,
-  inputs: ['alertIcon', 'cancelButtonLabel', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'okButtonLabel', 'opened', 'showCloseButton', 'size', 'variant']
+  inputs: ['alertIcon', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'opened', 'showCloseButton', 'size', 'variant']
 })
 @Component({
   selector: 'ifx-modal',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['alertIcon', 'cancelButtonLabel', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'okButtonLabel', 'opened', 'showCloseButton', 'size', 'variant'],
-  outputs: ['ifxOpen', 'ifxClose'],
+  inputs: ['alertIcon', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'opened', 'showCloseButton', 'size', 'variant'],
+  outputs: ['ifxOpen', 'ifxClose', 'ifxOpenedChange'],
 })
 export class IfxModal {
   protected el: HTMLIfxModalElement;
   @Output() ifxOpen = new EventEmitter<CustomEvent<any>>();
   @Output() ifxClose = new EventEmitter<CustomEvent<any>>();
+  @Output() ifxOpenedChange = new EventEmitter<CustomEvent<{ opened: boolean }>>();
   constructor(c: ChangeDetectorRef, r: ElementRef, protected z: NgZone) {
     c.detach();
     this.el = r.nativeElement;
@@ -1369,10 +1370,20 @@ export class IfxModal {
 
 
 export declare interface IfxModal extends Components.IfxModal {
-
+  /**
+   * Emitted when the modal finishes opening and the opening animation completes. No additional data is provided with this event.
+   */
   ifxOpen: EventEmitter<CustomEvent<any>>;
-
+  /**
+   * Emitted when the modal finishes closing and the closing animation completes. No additional data is provided with this event.
+   */
   ifxClose: EventEmitter<CustomEvent<any>>;
+  /**
+   * Emitted immediately when the `opened` state changes (before animations).
+The event detail contains `{ opened: boolean }` with the new state.
+Use this event for two-way binding (v-model in Vue, [(ngModel)] in Angular).
+   */
+  ifxOpenedChange: EventEmitter<CustomEvent<{ opened: boolean }>>;
 }
 
 

--- a/packages/wrapper-angular/standalone/src/lib/stencil-generated/components.ts
+++ b/packages/wrapper-angular/standalone/src/lib/stencil-generated/components.ts
@@ -1347,7 +1347,8 @@ export declare interface IfxListEntry extends Components.IfxListEntry {
 
 @ProxyCmp({
   defineCustomElementFn: defineIfxModal,
-  inputs: ['alertIcon', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'opened', 'showCloseButton', 'size', 'variant']
+  inputs: ['alertIcon', 'caption', 'captionAriaLabel', 'closeButtonAriaLabel', 'closeOnOverlayClick', 'opened', 'showCloseButton', 'size', 'variant'],
+  methods: ['openModal', 'closeModal']
 })
 @Component({
   selector: 'ifx-modal',

--- a/packages/wrapper-angular/tsconfig.json
+++ b/packages/wrapper-angular/tsconfig.json
@@ -35,5 +35,5 @@
 		"skipLibCheck": true,
 		"paths": {}
 	},
-	"exclude": ["node_modules", "dist"]
+	"exclude": ["node_modules", "dist", "standalone"]
 }

--- a/packages/wrapper-react/lib/components/stencil-generated/components.ts
+++ b/packages/wrapper-react/lib/components/stencil-generated/components.ts
@@ -672,7 +672,8 @@ export const IfxListEntry: StencilReactComponent<IfxListEntryElement, IfxListEnt
 
 export type IfxModalEvents = {
     onIfxOpen: EventName<IfxModalCustomEvent<any>>,
-    onIfxClose: EventName<IfxModalCustomEvent<any>>
+    onIfxClose: EventName<IfxModalCustomEvent<any>>,
+    onIfxOpenedChange: EventName<IfxModalCustomEvent<{ opened: boolean }>>
 };
 
 export const IfxModal: StencilReactComponent<IfxModalElement, IfxModalEvents> = /*@__PURE__*/ createComponent<IfxModalElement, IfxModalEvents>({
@@ -682,7 +683,8 @@ export const IfxModal: StencilReactComponent<IfxModalElement, IfxModalEvents> = 
     react: React,
     events: {
         onIfxOpen: 'ifxOpen',
-        onIfxClose: 'ifxClose'
+        onIfxClose: 'ifxClose',
+        onIfxOpenedChange: 'ifxOpenedChange'
     } as IfxModalEvents,
     defineCustomElement: defineIfxModal
 });

--- a/packages/wrapper-vue/lib/stencil-generated/components.ts
+++ b/packages/wrapper-vue/lib/stencil-generated/components.ts
@@ -547,7 +547,7 @@ export const IfxListEntry: StencilVueComponent<JSX.IfxListEntry> = /*@__PURE__*/
 ]);
 
 
-export const IfxModal: StencilVueComponent<JSX.IfxModal> = /*@__PURE__*/ defineContainer<JSX.IfxModal>('ifx-modal', defineIfxModal, [
+export const IfxModal: StencilVueComponent<JSX.IfxModal, JSX.IfxModal["opened"]> = /*@__PURE__*/ defineContainer<JSX.IfxModal, JSX.IfxModal["opened"]>('ifx-modal', defineIfxModal, [
   'opened',
   'caption',
   'captionAriaLabel',
@@ -555,16 +555,17 @@ export const IfxModal: StencilVueComponent<JSX.IfxModal> = /*@__PURE__*/ defineC
   'variant',
   'size',
   'alertIcon',
-  'okButtonLabel',
-  'cancelButtonLabel',
-  'closeButtonAriaLabel',
   'showCloseButton',
+  'closeButtonAriaLabel',
   'ifxOpen',
-  'ifxClose'
+  'ifxClose',
+  'ifxOpenedChange'
 ], [
   'ifxOpen',
-  'ifxClose'
-]);
+  'ifxClose',
+  'ifxOpenedChange'
+],
+'opened', 'ifxOpenedChange', undefined);
 
 
 export const IfxMultiselect: StencilVueComponent<JSX.IfxMultiselect> = /*@__PURE__*/ defineContainer<JSX.IfxMultiselect>('ifx-multiselect', defineIfxMultiselect, [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,9 @@ importers:
       '@types/node':
         specifier: ^22.18.11
         version: 22.19.13
+      '@types/prismjs':
+        specifier: ^1.26.6
+        version: 1.26.6
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
         version: 6.0.4(vite@7.3.1(@types/node@22.19.13)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.29(typescript@5.9.3))


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

### Description
Implements two-way binding support for the modal component's `opened` property in Vue and fixes initial state bug.

**Changes:**
- Added v-model support (Vue) and ngModel support (Angular) to support bidirectional binding for `opened` prop.
- Fixed modal to be open when initial value of `opened` is true
- Added public Methods `openModal()` and `closeModal()`
- Documentated public API with JSDocs


#### Usage
##### Vue
```html
<!-- Before -->
<ifx-modal :opened="opened" @ifxClose="opened = false" />

<!-- After -->
<ifx-modal v-model="opened" />
```

##### Angular
```html
<!-- After -->
<ifx-modal [(ngModel)]="opened" />
```

### Related Issue
Fixes #2215 

### Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.15.2--canary.2218.22758606826.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@39.15.2--canary.2218.22758606826.0
  npm install angular-module-example@39.15.2--canary.2218.22758606826.0
  npm install angular-standalone-example@39.15.2--canary.2218.22758606826.0
  npm install html-cdn-example@39.15.2--canary.2218.22758606826.0
  npm install html-vite-example@39.15.2--canary.2218.22758606826.0
  npm install react-example@39.15.2--canary.2218.22758606826.0
  npm install vue-example@39.15.2--canary.2218.22758606826.0
  npm install @infineon/infineon-design-system-stencil@39.15.2--canary.2218.22758606826.0
  npm install @infineon/infineon-design-system-angular@39.15.2--canary.2218.22758606826.0
  npm install @infineon/infineon-design-system-react@39.15.2--canary.2218.22758606826.0
  npm install @infineon/infineon-design-system-vue@39.15.2--canary.2218.22758606826.0
  # or 
  yarn add example-generator@39.15.2--canary.2218.22758606826.0
  yarn add angular-module-example@39.15.2--canary.2218.22758606826.0
  yarn add angular-standalone-example@39.15.2--canary.2218.22758606826.0
  yarn add html-cdn-example@39.15.2--canary.2218.22758606826.0
  yarn add html-vite-example@39.15.2--canary.2218.22758606826.0
  yarn add react-example@39.15.2--canary.2218.22758606826.0
  yarn add vue-example@39.15.2--canary.2218.22758606826.0
  yarn add @infineon/infineon-design-system-stencil@39.15.2--canary.2218.22758606826.0
  yarn add @infineon/infineon-design-system-angular@39.15.2--canary.2218.22758606826.0
  yarn add @infineon/infineon-design-system-react@39.15.2--canary.2218.22758606826.0
  yarn add @infineon/infineon-design-system-vue@39.15.2--canary.2218.22758606826.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
