### PR TITLE
CI: Fix storybook build when skip-release

### DIFF
--- a/.github/workflows/shared-build-storybook.yml
+++ b/.github/workflows/shared-build-storybook.yml
@@ -65,7 +65,7 @@ jobs:
         if: ${{ github.event.action != 'closed' }}
         working-directory: packages/components
         run: |
-          pnpm version ${{ inputs.package-version }} --no-git-tag-version
+          pnpm version ${{ inputs.package-version }} --no-git-tag-version --allow-same-version
 
       - name: Build Storybook
         if: ${{ github.event.action != 'closed' }}


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
* Fixes failing storybook build, when `skip-release` is used.

Related Issue
* Incomplete PR: #2225
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.15.4--canary.2227.22845388981.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@39.15.4--canary.2227.22845388981.0
  npm install angular-module-example@39.15.4--canary.2227.22845388981.0
  npm install angular-standalone-example@39.15.4--canary.2227.22845388981.0
  npm install html-cdn-example@39.15.4--canary.2227.22845388981.0
  npm install html-vite-example@39.15.4--canary.2227.22845388981.0
  npm install react-example@39.15.4--canary.2227.22845388981.0
  npm install vue-example@39.15.4--canary.2227.22845388981.0
  npm install @infineon/infineon-design-system-stencil@39.15.4--canary.2227.22845388981.0
  npm install @infineon/infineon-design-system-angular@39.15.4--canary.2227.22845388981.0
  npm install @infineon/infineon-design-system-react@39.15.4--canary.2227.22845388981.0
  npm install @infineon/infineon-design-system-vue@39.15.4--canary.2227.22845388981.0
  # or 
  yarn add example-generator@39.15.4--canary.2227.22845388981.0
  yarn add angular-module-example@39.15.4--canary.2227.22845388981.0
  yarn add angular-standalone-example@39.15.4--canary.2227.22845388981.0
  yarn add html-cdn-example@39.15.4--canary.2227.22845388981.0
  yarn add html-vite-example@39.15.4--canary.2227.22845388981.0
  yarn add react-example@39.15.4--canary.2227.22845388981.0
  yarn add vue-example@39.15.4--canary.2227.22845388981.0
  yarn add @infineon/infineon-design-system-stencil@39.15.4--canary.2227.22845388981.0
  yarn add @infineon/infineon-design-system-angular@39.15.4--canary.2227.22845388981.0
  yarn add @infineon/infineon-design-system-react@39.15.4--canary.2227.22845388981.0
  yarn add @infineon/infineon-design-system-vue@39.15.4--canary.2227.22845388981.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
