### PR TITLE
Ci: Don't fail pipeline when webex message fails

### DIFF
--- a/auto.config.js
+++ b/auto.config.js
@@ -20,6 +20,7 @@ module.exports = function rc() {
 				{
 					threshold: "patch",
 					message: "## VERSION UPDATE\n\nA new version has been released: [%version](%link).\n\n### Changelog\n\n%notes",
+					failOnError: false
 				},
 			],
 			"first-time-contributor"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@biomejs/biome": "2.4.5",
 		"@stencil-community/eslint-plugin": "^0.10.0",
 		"auto": "^11.3.0",
-		"auto-plugin-webex": "^1.1.0",
+		"auto-plugin-webex": "^1.2.0",
 		"concurrently": "^9.2.1",
 		"eslint": "^9.39.1",
 		"lerna": "^9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^11.3.0
         version: 11.3.6(@types/node@25.4.0)(encoding@0.1.13)(typescript@5.9.3)
       auto-plugin-webex:
-        specifier: ^1.1.0
-        version: 1.1.0(@types/node@25.4.0)(encoding@0.1.13)(typescript@5.9.3)
+        specifier: ^1.2.0
+        version: 1.2.0(@types/node@25.4.0)(encoding@0.1.13)(typescript@5.9.3)
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -3766,8 +3766,8 @@ packages:
     resolution: {integrity: sha512-KbWgR8wOYRAPekEmMXrYYdc7BRyhn2Ftk7KWfMUnQ43hFdojWEFRxhhRUm3/OFEdPa1r0KAvTTg9YQK57xTe0g==}
     engines: {node: '>=0.8'}
 
-  auto-plugin-webex@1.1.0:
-    resolution: {integrity: sha512-/Zx/hxXumPDaFes0Cj6qPqdp42Aq0wRHVupMeFF2N/kG7LSLXkjrFC/CZz4vE3w5GhGH/IUw+WQY9PTfbHDP7Q==}
+  auto-plugin-webex@1.2.0:
+    resolution: {integrity: sha512-2W0Sl8c0Jj9ODkA2FbkfvpRZmzfoE+LlkXmpIicGQv/8TWlPJFk5glkyUWtbImwRjhGGV7CfLo/R/yeEhQcZSw==}
 
   auto@11.3.6:
     resolution: {integrity: sha512-Db13X4WVNPzPtWKSoiOzhfW2g3zNUTDR1X3wkQPdIW21xtajwm5Taqg3BXWR2u7/45W0bU+6YykVgioNRwrwIw==}
@@ -11307,7 +11307,7 @@ snapshots:
       proggy: 3.0.0
       promise-all-reject-late: 1.0.1
       promise-call-limit: 3.0.2
-      semver: 7.7.2
+      semver: 7.7.4
       ssri: 12.0.0
       treeverse: 3.0.0
       walk-up-path: 4.0.0
@@ -11316,11 +11316,11 @@ snapshots:
 
   '@npmcli/fs@4.0.0':
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.4
 
   '@npmcli/fs@5.0.0':
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.4
 
   '@npmcli/git@6.0.3':
     dependencies:
@@ -11330,7 +11330,7 @@ snapshots:
       npm-pick-manifest: 10.0.0
       proc-log: 5.0.0
       promise-retry: 2.0.1
-      semver: 7.7.2
+      semver: 7.7.4
       which: 5.0.0
 
   '@npmcli/git@7.0.2':
@@ -11341,7 +11341,7 @@ snapshots:
       lru-cache: 11.2.6
       npm-pick-manifest: 11.0.3
       proc-log: 6.1.0
-      semver: 7.7.2
+      semver: 7.7.4
       which: 6.0.1
 
   '@npmcli/installed-package-contents@3.0.0':
@@ -11367,7 +11367,7 @@ snapshots:
       json-parse-even-better-errors: 5.0.0
       pacote: 21.5.0
       proc-log: 6.1.0
-      semver: 7.7.2
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11386,7 +11386,7 @@ snapshots:
       hosted-git-info: 9.0.2
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.7.2
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
   '@npmcli/package-json@7.0.5':
@@ -11396,7 +11396,7 @@ snapshots:
       hosted-git-info: 9.0.2
       json-parse-even-better-errors: 5.0.0
       proc-log: 6.1.0
-      semver: 7.7.2
+      semver: 7.7.4
       spdx-expression-parse: 4.0.0
 
   '@npmcli/promise-spawn@8.0.3':
@@ -11443,7 +11443,7 @@ snapshots:
       enquirer: 2.3.6
       minimatch: 10.2.4
       nx: 22.5.4
-      semver: 7.7.2
+      semver: 7.7.4
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
@@ -12880,7 +12880,7 @@ snapshots:
 
   author-regex@1.0.0: {}
 
-  auto-plugin-webex@1.1.0(@types/node@25.4.0)(encoding@0.1.13)(typescript@5.9.3):
+  auto-plugin-webex@1.2.0(@types/node@25.4.0)(encoding@0.1.13)(typescript@5.9.3):
     dependencies:
       '@auto-it/core': 11.3.6(@types/node@25.4.0)(encoding@0.1.13)(typescript@5.9.3)
       endent: 2.1.0
@@ -13593,7 +13593,7 @@ snapshots:
       handlebars: 4.7.8
       json-stringify-safe: 5.0.1
       meow: 8.1.2
-      semver: 7.7.2
+      semver: 7.7.4
       split: 1.0.1
 
   conventional-commits-filter@3.0.0:
@@ -14757,7 +14757,7 @@ snapshots:
   git-semver-tags@5.0.1:
     dependencies:
       meow: 8.1.2
-      semver: 7.7.2
+      semver: 7.7.4
 
   git-up@7.0.0:
     dependencies:
@@ -15068,7 +15068,7 @@ snapshots:
       npm-package-arg: 13.0.1
       promzard: 2.0.0
       read: 4.1.0
-      semver: 7.7.2
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 6.0.2
 
@@ -16065,7 +16065,7 @@ snapshots:
       npm-package-arg: 13.0.1
       npm-registry-fetch: 19.1.0
       proc-log: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       sigstore: 4.1.0
       ssri: 12.0.0
     transitivePeerDependencies:
@@ -16256,7 +16256,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.4
 
   make-error@1.3.6: {}
 
@@ -16899,7 +16899,7 @@ snapshots:
       make-fetch-happen: 15.0.2
       nopt: 9.0.0
       proc-log: 6.1.0
-      semver: 7.7.2
+      semver: 7.7.4
       tar: 7.5.11
       tinyglobby: 0.2.12
       which: 6.0.1
@@ -16950,11 +16950,11 @@ snapshots:
 
   npm-install-checks@7.1.2:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.4
 
   npm-install-checks@8.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.4
 
   npm-normalize-package-bin@4.0.0: {}
 
@@ -16964,7 +16964,7 @@ snapshots:
     dependencies:
       hosted-git-info: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       validate-npm-package-name: 6.0.2
 
   npm-package-arg@13.0.0:
@@ -16978,7 +16978,7 @@ snapshots:
     dependencies:
       hosted-git-info: 9.0.2
       proc-log: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       validate-npm-package-name: 6.0.2
 
   npm-packlist@10.0.3:
@@ -16996,14 +16996,14 @@ snapshots:
       npm-install-checks: 7.1.2
       npm-normalize-package-bin: 4.0.0
       npm-package-arg: 12.0.2
-      semver: 7.7.2
+      semver: 7.7.4
 
   npm-pick-manifest@11.0.3:
     dependencies:
       npm-install-checks: 8.0.0
       npm-normalize-package-bin: 5.0.0
       npm-package-arg: 13.0.0
-      semver: 7.7.2
+      semver: 7.7.4
 
   npm-registry-fetch@19.1.0:
     dependencies:
@@ -17077,7 +17077,7 @@ snapshots:
       ora: 5.3.0
       picocolors: 1.1.1
       resolve.exports: 2.0.3
-      semver: 7.7.2
+      semver: 7.7.4
       string-width: 4.2.3
       tar-stream: 2.2.0
       tmp: 0.2.5


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
* Updated auto-plugin-webex
* Configured not to fail the pipeline, when publishing webex message fails
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.15.7--canary.2238.23011970000.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@39.15.7--canary.2238.23011970000.0
  npm install angular-module-example@39.15.7--canary.2238.23011970000.0
  npm install angular-standalone-example@39.15.7--canary.2238.23011970000.0
  npm install html-cdn-example@39.15.7--canary.2238.23011970000.0
  npm install html-vite-example@39.15.7--canary.2238.23011970000.0
  npm install react-example@39.15.7--canary.2238.23011970000.0
  npm install vue-example@39.15.7--canary.2238.23011970000.0
  npm install @infineon/infineon-design-system-stencil@39.15.7--canary.2238.23011970000.0
  npm install @infineon/infineon-design-system-angular@39.15.7--canary.2238.23011970000.0
  npm install @infineon/infineon-design-system-react@39.15.7--canary.2238.23011970000.0
  npm install @infineon/infineon-design-system-vue@39.15.7--canary.2238.23011970000.0
  # or 
  yarn add example-generator@39.15.7--canary.2238.23011970000.0
  yarn add angular-module-example@39.15.7--canary.2238.23011970000.0
  yarn add angular-standalone-example@39.15.7--canary.2238.23011970000.0
  yarn add html-cdn-example@39.15.7--canary.2238.23011970000.0
  yarn add html-vite-example@39.15.7--canary.2238.23011970000.0
  yarn add react-example@39.15.7--canary.2238.23011970000.0
  yarn add vue-example@39.15.7--canary.2238.23011970000.0
  yarn add @infineon/infineon-design-system-stencil@39.15.7--canary.2238.23011970000.0
  yarn add @infineon/infineon-design-system-angular@39.15.7--canary.2238.23011970000.0
  yarn add @infineon/infineon-design-system-react@39.15.7--canary.2238.23011970000.0
  yarn add @infineon/infineon-design-system-vue@39.15.7--canary.2238.23011970000.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
