### PR TITLE
Tabs: fixes nested tabs attributes getting attached to parent tabs bug

### DIFF
--- a/packages/components/src/components/tabs/tabs.tsx
+++ b/packages/components/src/components/tabs/tabs.tsx
@@ -49,7 +49,7 @@ export class IfxTabs {
   private tabFocusHandlers: Map<HTMLElement, () => void> = new Map();
 
   /** Emitted when the active tab changes (e.g., user selects a different tab). */
-	@Event() ifxChange: EventEmitter;
+  @Event({ bubbles: false, composed: false }) ifxChange: EventEmitter;
 
   @Listen("resize", { target: "window" })
   updateBorderOnWindowResize() {

--- a/packages/components/src/components/tabs/tabs.tsx
+++ b/packages/components/src/components/tabs/tabs.tsx
@@ -138,7 +138,9 @@ export class IfxTabs {
   // when a slot is removed / added
   @Listen('slotchange')
   onSlotChange() {
-    const tabs = this.el.querySelectorAll('ifx-tab');
+    const tabs = Array.from(this.el.children).filter(
+      (child): child is HTMLIfxTabElement => child.matches("ifx-tab"),
+    );
     this.tabObjects = Array.from(tabs).map((tab) => {
       return {
         header: tab?.header,

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -14,11 +14,11 @@
     ></script>
     <script nomodule src="/build/infineon-design-system-stencil.js"></script>
 
-    <style defer>
-   
-    </style>
+    <style defer></style>
 
-    <script></script>
+    <script>
+
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Reference:
#2188 

Nested tabs were getting attached to the parent tab component. It is now fixed.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.30.0--canary.2317.25630330575.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@39.30.0--canary.2317.25630330575.0
  npm install angular-module-example@39.30.0--canary.2317.25630330575.0
  npm install angular-standalone-example@39.30.0--canary.2317.25630330575.0
  npm install html-cdn-example@39.30.0--canary.2317.25630330575.0
  npm install html-vite-example@39.30.0--canary.2317.25630330575.0
  npm install react-example@39.30.0--canary.2317.25630330575.0
  npm install vue-example@39.30.0--canary.2317.25630330575.0
  npm install @infineon/infineon-design-system-stencil@39.30.0--canary.2317.25630330575.0
  npm install @infineon/dds-tooling@39.30.0--canary.2317.25630330575.0
  npm install @infineon/design-system-mcp@39.30.0--canary.2317.25630330575.0
  npm install @infineon/infineon-design-system-angular@39.30.0--canary.2317.25630330575.0
  npm install @infineon/infineon-design-system-react@39.30.0--canary.2317.25630330575.0
  npm install @infineon/infineon-design-system-vue@39.30.0--canary.2317.25630330575.0
  # or 
  yarn add example-generator@39.30.0--canary.2317.25630330575.0
  yarn add angular-module-example@39.30.0--canary.2317.25630330575.0
  yarn add angular-standalone-example@39.30.0--canary.2317.25630330575.0
  yarn add html-cdn-example@39.30.0--canary.2317.25630330575.0
  yarn add html-vite-example@39.30.0--canary.2317.25630330575.0
  yarn add react-example@39.30.0--canary.2317.25630330575.0
  yarn add vue-example@39.30.0--canary.2317.25630330575.0
  yarn add @infineon/infineon-design-system-stencil@39.30.0--canary.2317.25630330575.0
  yarn add @infineon/dds-tooling@39.30.0--canary.2317.25630330575.0
  yarn add @infineon/design-system-mcp@39.30.0--canary.2317.25630330575.0
  yarn add @infineon/infineon-design-system-angular@39.30.0--canary.2317.25630330575.0
  yarn add @infineon/infineon-design-system-react@39.30.0--canary.2317.25630330575.0
  yarn add @infineon/infineon-design-system-vue@39.30.0--canary.2317.25630330575.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
