### PR TITLE
Search-bar: focus field when search bar is opened

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -1688,6 +1688,10 @@ export namespace Components {
          */
         "placeholder": string;
         /**
+          * Focuses the search input.
+         */
+        "setFocus": () => Promise<void>;
+        /**
           * Show the clear icon when there is a non-empty value.
           * @default false
          */

--- a/packages/components/src/components/search-bar/search-bar.tsx
+++ b/packages/components/src/components/search-bar/search-bar.tsx
@@ -65,6 +65,7 @@ export class SearchBar {
 	@Event() ifxOpen!: EventEmitter;
 
 	@State() internalState!: boolean;
+	private pendingFocus = false;
 
 	/**
 	 * Opens the search bar when triggered programatically
@@ -72,6 +73,7 @@ export class SearchBar {
 	 */
 	@Method()
 	public async open() {
+		this.pendingFocus = true;
 		this.internalState = true;
 	}
 
@@ -91,8 +93,10 @@ export class SearchBar {
 	}
 
 	private handleCloseButton = () => {
-		this.internalState = !this.internalState;
-		this.ifxOpen.emit(this.internalState);
+		const newState = !this.internalState;
+		if (newState) this.pendingFocus = true;
+		this.internalState = newState;
+		this.ifxOpen.emit(newState);
 	};
 
 	private setInitialState() {
@@ -102,6 +106,13 @@ export class SearchBar {
 	componentWillLoad() {
 		this.setInitialState();
 		//this.ifxOpen.emit(this.internalState);
+	}
+
+	componentDidUpdate() {
+		if (this.pendingFocus) {
+			this.pendingFocus = false;
+			(this.el.shadowRoot?.querySelector('ifx-search-field') as HTMLIfxSearchFieldElement)?.setFocus();
+		}
 	}
 
 	async componentDidLoad() {

--- a/packages/components/src/components/search-bar/search-bar.tsx
+++ b/packages/components/src/components/search-bar/search-bar.tsx
@@ -111,7 +111,10 @@ export class SearchBar {
 	componentDidUpdate() {
 		if (this.pendingFocus) {
 			this.pendingFocus = false;
-			(this.el.shadowRoot?.querySelector('ifx-search-field') as HTMLIfxSearchFieldElement)?.setFocus();
+			const searchField = this.el.shadowRoot?.querySelector('ifx-search-field') as HTMLIfxSearchFieldElement;
+			if (typeof searchField?.setFocus === 'function') {
+				searchField.setFocus();
+			}
 		}
 	}
 

--- a/packages/components/src/components/search-field/readme.md
+++ b/packages/components/src/components/search-field/readme.md
@@ -57,6 +57,16 @@ Type: `Promise<void>`
 
 
 
+### `setFocus() => Promise<void>`
+
+Focuses the search input.
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
 
 ## Dependencies
 

--- a/packages/components/src/components/search-field/search-field.tsx
+++ b/packages/components/src/components/search-field/search-field.tsx
@@ -311,6 +311,14 @@ export class SearchField {
 	}
 
 	/**
+	 * Focuses the search input.
+	 */
+	@Method()
+	public async setFocus(): Promise<void> {
+		this.inputElement?.focus();
+	}
+
+	/**
 	 * Public method to clear search history.
 	 * This will clear the history from both localStorage and the internal state, and also reset any dropdown-related states.
 	 */

--- a/packages/wrapper-angular/src/lib/stencil-generated/components.ts
+++ b/packages/wrapper-angular/src/lib/stencil-generated/components.ts
@@ -1755,7 +1755,7 @@ Payload is the new open state.
 
 @ProxyCmp({
   inputs: ['ariaDescribedBy', 'ariaLabelText', 'ariaLabelledBy', 'autocomplete', 'deleteIconAriaLabel', 'disabled', 'dropdownAriaLabel', 'enableHistory', 'historyDeleteAriaLabel', 'historyHeaderText', 'historyItemAriaLabel', 'historyKey', 'maxHistoryItems', 'maxSuggestions', 'maxlength', 'placeholder', 'showDeleteIcon', 'showSuggestions', 'size', 'suggestionAriaLabel', 'suggestions', 'value'],
-  methods: ['clearSearchHistory']
+  methods: ['setFocus', 'clearSearchHistory']
 })
 @Component({
   selector: 'ifx-search-field',

--- a/packages/wrapper-angular/standalone/src/lib/stencil-generated/components.ts
+++ b/packages/wrapper-angular/standalone/src/lib/stencil-generated/components.ts
@@ -1840,7 +1840,7 @@ Payload is the new open state.
 @ProxyCmp({
   defineCustomElementFn: defineIfxSearchField,
   inputs: ['ariaDescribedBy', 'ariaLabelText', 'ariaLabelledBy', 'autocomplete', 'deleteIconAriaLabel', 'disabled', 'dropdownAriaLabel', 'enableHistory', 'historyDeleteAriaLabel', 'historyHeaderText', 'historyItemAriaLabel', 'historyKey', 'maxHistoryItems', 'maxSuggestions', 'maxlength', 'placeholder', 'showDeleteIcon', 'showSuggestions', 'size', 'suggestionAriaLabel', 'suggestions', 'value'],
-  methods: ['clearSearchHistory']
+  methods: ['setFocus', 'clearSearchHistory']
 })
 @Component({
   selector: 'ifx-search-field',


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
When the search icon is clicked and the input field expands, automatically focus the input field so the user can start typing immediately (doesn't need to click again)

Related Issue
Issue #2322 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.33.0--canary.2351.27192727369.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@39.33.0--canary.2351.27192727369.0
  npm install angular-module-example@39.33.0--canary.2351.27192727369.0
  npm install angular-standalone-example@39.33.0--canary.2351.27192727369.0
  npm install html-cdn-example@39.33.0--canary.2351.27192727369.0
  npm install html-vite-example@39.33.0--canary.2351.27192727369.0
  npm install react-example@39.33.0--canary.2351.27192727369.0
  npm install vue-example@39.33.0--canary.2351.27192727369.0
  npm install @infineon/infineon-design-system-stencil@39.33.0--canary.2351.27192727369.0
  npm install @infineon/dds-tooling@39.33.0--canary.2351.27192727369.0
  npm install @infineon/design-system-mcp@39.33.0--canary.2351.27192727369.0
  npm install @infineon/infineon-design-system-angular@39.33.0--canary.2351.27192727369.0
  npm install @infineon/infineon-design-system-react@39.33.0--canary.2351.27192727369.0
  npm install @infineon/infineon-design-system-vue@39.33.0--canary.2351.27192727369.0
  # or 
  yarn add example-generator@39.33.0--canary.2351.27192727369.0
  yarn add angular-module-example@39.33.0--canary.2351.27192727369.0
  yarn add angular-standalone-example@39.33.0--canary.2351.27192727369.0
  yarn add html-cdn-example@39.33.0--canary.2351.27192727369.0
  yarn add html-vite-example@39.33.0--canary.2351.27192727369.0
  yarn add react-example@39.33.0--canary.2351.27192727369.0
  yarn add vue-example@39.33.0--canary.2351.27192727369.0
  yarn add @infineon/infineon-design-system-stencil@39.33.0--canary.2351.27192727369.0
  yarn add @infineon/dds-tooling@39.33.0--canary.2351.27192727369.0
  yarn add @infineon/design-system-mcp@39.33.0--canary.2351.27192727369.0
  yarn add @infineon/infineon-design-system-angular@39.33.0--canary.2351.27192727369.0
  yarn add @infineon/infineon-design-system-react@39.33.0--canary.2351.27192727369.0
  yarn add @infineon/infineon-design-system-vue@39.33.0--canary.2351.27192727369.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
