### PR TITLE
Single select: fixes extra space typo bug in role attribute

### DIFF
--- a/packages/components/src/components/select/single-select/select.tsx
+++ b/packages/components/src/components/select/single-select/select.tsx
@@ -702,10 +702,7 @@ export class Choices implements IChoicesProps, IChoicesMethods {
               //modifying the template of each item in the options list
               choice: ({ classNames }, data) => {
                 return template(`
-              <div class="${classNames.item} ${classNames.itemChoice} ${self.getSizeClass()} 
-              ${data.selected || self.selectedOption?.value === data.value || self.getPreSelected(self)?.value === data.value ? 'selected' : ''} 
-              ${data.placeholder ? classNames.placeholder : ''} 
-              ${data.disabled && !this.error ? classNames.itemDisabled : classNames.itemSelectable} 
+              <div class="${classNames.item} ${classNames.itemChoice} ${self.getSizeClass()} ${data.selected || self.selectedOption?.value === data.value || self.getPreSelected(self)?.value === data.value ? 'selected' : ''} ${data.placeholder ? classNames.placeholder : ''} ${data.disabled && !this.error ? classNames.itemDisabled : classNames.itemSelectable}"
                     role="${data.groupId && data.groupId > 0 ? 'treeitem' : 'option'}"
                     data-choice ${data.disabled && !this.error ? 'data-choice-disabled aria-disabled="true"' : 'data-choice-selectable'}                     data-id="${data.id}"
                     data-value="${data.value}"


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
remove the space before 'option' in role attribute of single select component

Related Issue
issue #2358 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.33.0--canary.2364.28013113833.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@39.33.0--canary.2364.28013113833.0
  npm install angular-module-example@39.33.0--canary.2364.28013113833.0
  npm install angular-standalone-example@39.33.0--canary.2364.28013113833.0
  npm install html-cdn-example@39.33.0--canary.2364.28013113833.0
  npm install html-vite-example@39.33.0--canary.2364.28013113833.0
  npm install react-example@39.33.0--canary.2364.28013113833.0
  npm install vue-example@39.33.0--canary.2364.28013113833.0
  npm install @infineon/infineon-design-system-stencil@39.33.0--canary.2364.28013113833.0
  npm install @infineon/dds-tooling@39.33.0--canary.2364.28013113833.0
  npm install @infineon/design-system-mcp@39.33.0--canary.2364.28013113833.0
  npm install @infineon/infineon-design-system-angular@39.33.0--canary.2364.28013113833.0
  npm install @infineon/infineon-design-system-react@39.33.0--canary.2364.28013113833.0
  npm install @infineon/infineon-design-system-vue@39.33.0--canary.2364.28013113833.0
  # or 
  yarn add example-generator@39.33.0--canary.2364.28013113833.0
  yarn add angular-module-example@39.33.0--canary.2364.28013113833.0
  yarn add angular-standalone-example@39.33.0--canary.2364.28013113833.0
  yarn add html-cdn-example@39.33.0--canary.2364.28013113833.0
  yarn add html-vite-example@39.33.0--canary.2364.28013113833.0
  yarn add react-example@39.33.0--canary.2364.28013113833.0
  yarn add vue-example@39.33.0--canary.2364.28013113833.0
  yarn add @infineon/infineon-design-system-stencil@39.33.0--canary.2364.28013113833.0
  yarn add @infineon/dds-tooling@39.33.0--canary.2364.28013113833.0
  yarn add @infineon/design-system-mcp@39.33.0--canary.2364.28013113833.0
  yarn add @infineon/infineon-design-system-angular@39.33.0--canary.2364.28013113833.0
  yarn add @infineon/infineon-design-system-react@39.33.0--canary.2364.28013113833.0
  yarn add @infineon/infineon-design-system-vue@39.33.0--canary.2364.28013113833.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
