### PR TITLE
Storybook: Remove opacity token from documentation

### DIFF
--- a/packages/components/src/storybook/stories/foundations/Tokens.mdx
+++ b/packages/components/src/storybook/stories/foundations/Tokens.mdx
@@ -200,15 +200,6 @@ import { Meta } from '@storybook/addon-docs/blocks';
 | `--ifx-size-5000` | `$ifxSize5000` | 400px |
 | `--ifx-size-6000` | `$ifxSize6000` | 480px |
 
-### Opacity
-| CSS Variable | SCSS Variable | Value |
-|--------------|---------------|-------|
-| `--ifx-opacity-0` | `$ifxOpacity0` | 0 |
-| `--ifx-opacity-25` | `$ifxOpacity25` | 0.25 |
-| `--ifx-opacity-50` | `$ifxOpacity50` | 0.5 |
-| `--ifx-opacity-75` | `$ifxOpacity75` | 0.75 |
-| `--ifx-opacity-100` | `$ifxOpacity100` | 1 |
-
 ### Typography
 | CSS Variable | SCSS Variable | Value |
 |--------------|---------------|-------|


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Removed the opacity tokens (`--ifx-opacity-0` through `--ifx-opacity-100` and the SCSS equivalents `$ifxOpacity0`–`$ifxOpacity100`) from the DDS. These tokens have no matching Figma variables, so they were orphaned code-side entries with no design-side ownership. Deleting them keeps the token layer in one-to-one alignment with Figma, which is the source of truth for DDS design tokens. Both the tokens themselves and the `Opacity` table in the Storybook documentation are removed. Any component consuming these tokens is migrated off them beforehand so no component behavior changes as a result of the removal.

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
- Affected area: Token layer (CSS custom properties + SCSS variables) and the opacity documentation page in Storybook (MDX).
- Framework: Infineon Design System (DDS) — Stencil-based Web Components in TypeScript, documented in Storybook (MDX).
- Change scope: Token removal + documentation removal. Component code untouched, or — if any component consumed the tokens — migrated off them in the same PR.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.36.0--canary.2415.29504635968.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@39.36.0--canary.2415.29504635968.0
  npm install angular-module-example@39.36.0--canary.2415.29504635968.0
  npm install angular-standalone-example@39.36.0--canary.2415.29504635968.0
  npm install html-cdn-example@39.36.0--canary.2415.29504635968.0
  npm install html-vite-example@39.36.0--canary.2415.29504635968.0
  npm install react-example@39.36.0--canary.2415.29504635968.0
  npm install vue-example@39.36.0--canary.2415.29504635968.0
  npm install @infineon/infineon-design-system-stencil@39.36.0--canary.2415.29504635968.0
  npm install @infineon/dds-tooling@39.36.0--canary.2415.29504635968.0
  npm install @infineon/design-system-mcp@39.36.0--canary.2415.29504635968.0
  npm install @infineon/infineon-design-system-angular@39.36.0--canary.2415.29504635968.0
  npm install @infineon/infineon-design-system-react@39.36.0--canary.2415.29504635968.0
  npm install @infineon/infineon-design-system-vue@39.36.0--canary.2415.29504635968.0
  # or 
  yarn add example-generator@39.36.0--canary.2415.29504635968.0
  yarn add angular-module-example@39.36.0--canary.2415.29504635968.0
  yarn add angular-standalone-example@39.36.0--canary.2415.29504635968.0
  yarn add html-cdn-example@39.36.0--canary.2415.29504635968.0
  yarn add html-vite-example@39.36.0--canary.2415.29504635968.0
  yarn add react-example@39.36.0--canary.2415.29504635968.0
  yarn add vue-example@39.36.0--canary.2415.29504635968.0
  yarn add @infineon/infineon-design-system-stencil@39.36.0--canary.2415.29504635968.0
  yarn add @infineon/dds-tooling@39.36.0--canary.2415.29504635968.0
  yarn add @infineon/design-system-mcp@39.36.0--canary.2415.29504635968.0
  yarn add @infineon/infineon-design-system-angular@39.36.0--canary.2415.29504635968.0
  yarn add @infineon/infineon-design-system-react@39.36.0--canary.2415.29504635968.0
  yarn add @infineon/infineon-design-system-vue@39.36.0--canary.2415.29504635968.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
