### PR TITLE
Chip:fix read-only state

### DIFF
--- a/packages/components/src/components/chip/chip.scss
+++ b/packages/components/src/components/chip/chip.scss
@@ -116,8 +116,8 @@
       &.read-only { 
         border: 1px solid tokens.$ifxColorEngineering400;
         &:focus-visible { 
-            outline: 2px solid tokens.$ifxColorOcean500;
-            outline-offset: 2px;
+            //outline: 2px solid tokens.$ifxColorOcean500;
+            //outline-offset: 2px;
         }
         &.disabled {
             border: 1px solid tokens.$ifxColorEngineering300;
@@ -191,6 +191,16 @@
           border: none;
         }
       }
+    }
+    &.read-only {
+        cursor: default;
+        &:hover,
+        &:focus,
+        &:focus-visible,
+        &:active {
+            outline: none;
+            box-shadow: none;
+        }
     }
     
     &.chip__wrapper--small {


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
- change the cursor over read-only to the default cursor
- delete the focus and active states do that the chip doesn't have visual changes
- applied for all chip variants (outlined, filled-light, filled-dark) and all sizes (small, medium, large)

Reference:
#2416 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.38.0--canary.2424.29843252974.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@39.38.0--canary.2424.29843252974.0
  npm install angular-module-example@39.38.0--canary.2424.29843252974.0
  npm install angular-standalone-example@39.38.0--canary.2424.29843252974.0
  npm install html-cdn-example@39.38.0--canary.2424.29843252974.0
  npm install html-vite-example@39.38.0--canary.2424.29843252974.0
  npm install react-example@39.38.0--canary.2424.29843252974.0
  npm install vue-example@39.38.0--canary.2424.29843252974.0
  npm install @infineon/infineon-design-system-stencil@39.38.0--canary.2424.29843252974.0
  npm install @infineon/dds-tooling@39.38.0--canary.2424.29843252974.0
  npm install @infineon/design-system-mcp@39.38.0--canary.2424.29843252974.0
  npm install @infineon/infineon-design-system-angular@39.38.0--canary.2424.29843252974.0
  npm install @infineon/infineon-design-system-react@39.38.0--canary.2424.29843252974.0
  npm install @infineon/infineon-design-system-vue@39.38.0--canary.2424.29843252974.0
  # or 
  yarn add example-generator@39.38.0--canary.2424.29843252974.0
  yarn add angular-module-example@39.38.0--canary.2424.29843252974.0
  yarn add angular-standalone-example@39.38.0--canary.2424.29843252974.0
  yarn add html-cdn-example@39.38.0--canary.2424.29843252974.0
  yarn add html-vite-example@39.38.0--canary.2424.29843252974.0
  yarn add react-example@39.38.0--canary.2424.29843252974.0
  yarn add vue-example@39.38.0--canary.2424.29843252974.0
  yarn add @infineon/infineon-design-system-stencil@39.38.0--canary.2424.29843252974.0
  yarn add @infineon/dds-tooling@39.38.0--canary.2424.29843252974.0
  yarn add @infineon/design-system-mcp@39.38.0--canary.2424.29843252974.0
  yarn add @infineon/infineon-design-system-angular@39.38.0--canary.2424.29843252974.0
  yarn add @infineon/infineon-design-system-react@39.38.0--canary.2424.29843252974.0
  yarn add @infineon/infineon-design-system-vue@39.38.0--canary.2424.29843252974.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
