### PR TITLE
Navbar: when click on item in mobile sidebar, sidebar should close

### DIFF
--- a/packages/components/src/components/navigation/navbar/navbar-item.tsx
+++ b/packages/components/src/components/navigation/navbar/navbar-item.tsx
@@ -386,7 +386,8 @@ export class NavbarItem {
 
 		if (
 			(slotName === "mobile-menu-top" || slotName === "second__layer") &&
-			!this.hasChildNavItems
+			!this.hasChildNavItems &&
+			!this.isMenuItem
 		) {
 			this.ifxNavItem.emit({ component: this.el, action: "closeMobileSidebar" });
 			return;

--- a/packages/components/src/components/navigation/navbar/navbar-item.tsx
+++ b/packages/components/src/components/navigation/navbar/navbar-item.tsx
@@ -383,6 +383,15 @@ export class NavbarItem {
 
 	private toggleItemMenu() {
 		const slotName = this.el.getAttribute("slot").toLowerCase();
+
+		if (
+			(slotName === "mobile-menu-top" || slotName === "second__layer") &&
+			!this.hasChildNavItems
+		) {
+			this.ifxNavItem.emit({ component: this.el, action: "closeMobileSidebar" });
+			return;
+		}
+
 		if (slotName === "mobile-menu-top" || slotName === "second__layer") {
 			this.openSubLayerMenu();
 		} else if (!this.internalHref) {

--- a/packages/components/src/components/navigation/navbar/navbar.tsx
+++ b/packages/components/src/components/navigation/navbar/navbar.tsx
@@ -150,6 +150,10 @@ export class Navbar {
         }
       }
     }
+
+    if (event.detail.action === "closeMobileSidebar") {
+      this.closeSidebar();
+    }
   }
 
   private isNavbarItem(element: Element): element is HTMLIfxNavbarItemElement {
@@ -360,6 +364,14 @@ export class Navbar {
     this.isMobileMenuOpen = isOpen;
     this.handleBodyScroll(isOpen ? "hide" : "show");
     this.ifxNavbarMobileMenuIsOpen?.emit(isOpen);
+  }
+
+  private closeSidebar() {
+    if (!this.isMobileMenuOpen) return;
+
+    this.isMobileMenuOpen = false;
+    this.handleBodyScroll("show");
+    this.ifxNavbarMobileMenuIsOpen?.emit(false);
   }
 
   private handleBodyScroll(action: "hide" | "show") {

--- a/packages/components/src/components/navigation/sidebar/sidebar.scss
+++ b/packages/components/src/components/navigation/sidebar/sidebar.scss
@@ -16,6 +16,7 @@
   border-right: 1px solid #EEEDED;
   width: 264px;
   height: 100%;
+  background: red;
   font-family: var(--ifx-font-family); // tokens.$ifxFontFamilyBody;
 
   &.fixed {

--- a/packages/components/src/components/navigation/sidebar/sidebar.scss
+++ b/packages/components/src/components/navigation/sidebar/sidebar.scss
@@ -16,7 +16,6 @@
   border-right: 1px solid #EEEDED;
   width: 264px;
   height: 100%;
-  background: red;
   font-family: var(--ifx-font-family); // tokens.$ifxFontFamilyBody;
 
   &.fixed {

--- a/packages/components/src/components/navigation/sidebar/sidebar.tsx
+++ b/packages/components/src/components/navigation/sidebar/sidebar.tsx
@@ -483,7 +483,7 @@ export class Sidebar {
     this.activeItem = event.detail;
     this.activeItem.setAttribute("active", "true");
 
-    if (!event.detail.isNested) {
+    if (!this.hasChildren(event.detail.shadowRoot)) {
       this.closeMobileSidebar();
     }
 
@@ -498,7 +498,7 @@ export class Sidebar {
 
   @Listen("ifxSidebarActionItem")
   handleSidebarActionItem(event: CustomEvent) {
-    if (!event.detail.isNested) {
+    if (!this.hasChildren(event.detail.shadowRoot)) {
       this.closeMobileSidebar();
     }
   }

--- a/packages/components/src/components/navigation/sidebar/sidebar.tsx
+++ b/packages/components/src/components/navigation/sidebar/sidebar.tsx
@@ -483,7 +483,9 @@ export class Sidebar {
     this.activeItem = event.detail;
     this.activeItem.setAttribute("active", "true");
 
-    this.closeMobileSidebar();
+    if (!event.detail.isNested) {
+      this.closeMobileSidebar();
+    }
 
     // Get the parent element of the activated item
     const parent = this.getNavItem(
@@ -495,8 +497,10 @@ export class Sidebar {
   }
 
   @Listen("ifxSidebarActionItem")
-  handleSidebarActionItem() {
-    this.closeMobileSidebar();
+  handleSidebarActionItem(event: CustomEvent) {
+    if (!event.detail.isNested) {
+      this.closeMobileSidebar();
+    }
   }
 
   private closeMobileSidebar() {

--- a/packages/components/src/components/navigation/sidebar/sidebar.tsx
+++ b/packages/components/src/components/navigation/sidebar/sidebar.tsx
@@ -483,12 +483,25 @@ export class Sidebar {
     this.activeItem = event.detail;
     this.activeItem.setAttribute("active", "true");
 
+    this.closeMobileSidebar();
+
     // Get the parent element of the activated item
     const parent = this.getNavItem(
       event.detail.parentElement.parentElement.parentElement,
     );
     if (parent) {
       this.handleClassList(parent, "add", "active-section");
+    }
+  }
+
+  @Listen("ifxSidebarActionItem")
+  handleSidebarActionItem() {
+    this.closeMobileSidebar();
+  }
+
+  private closeMobileSidebar() {
+    if (window.matchMedia("(max-width: 800px)").matches) {
+      this.collapse();
     }
   }
 


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
When on mobile, clicking on an item without nested items closes the navbar and sidebar. 

Requirements:
- clicking on a nested layer item should close the entire dropdown menu if on desktop, or sidebar menu if on mobile

Reference:
#2461, https://github.com/Infineon/infineon-design-system-stencil/issues/2106

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>39.45.1--canary.2462.31782687641.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@39.45.1--canary.2462.31782687641.0
  npm install angular-module-example@39.45.1--canary.2462.31782687641.0
  npm install angular-standalone-example@39.45.1--canary.2462.31782687641.0
  npm install html-cdn-example@39.45.1--canary.2462.31782687641.0
  npm install html-vite-example@39.45.1--canary.2462.31782687641.0
  npm install react-example@39.45.1--canary.2462.31782687641.0
  npm install vue-example@39.45.1--canary.2462.31782687641.0
  npm install @infineon/infineon-design-system-stencil@39.45.1--canary.2462.31782687641.0
  npm install @infineon/dds-tooling@39.45.1--canary.2462.31782687641.0
  npm install @infineon/design-system-mcp@39.45.1--canary.2462.31782687641.0
  npm install @infineon/infineon-design-system-angular@39.45.1--canary.2462.31782687641.0
  npm install @infineon/infineon-design-system-react@39.45.1--canary.2462.31782687641.0
  npm install @infineon/infineon-design-system-vue@39.45.1--canary.2462.31782687641.0
  # or 
  yarn add example-generator@39.45.1--canary.2462.31782687641.0
  yarn add angular-module-example@39.45.1--canary.2462.31782687641.0
  yarn add angular-standalone-example@39.45.1--canary.2462.31782687641.0
  yarn add html-cdn-example@39.45.1--canary.2462.31782687641.0
  yarn add html-vite-example@39.45.1--canary.2462.31782687641.0
  yarn add react-example@39.45.1--canary.2462.31782687641.0
  yarn add vue-example@39.45.1--canary.2462.31782687641.0
  yarn add @infineon/infineon-design-system-stencil@39.45.1--canary.2462.31782687641.0
  yarn add @infineon/dds-tooling@39.45.1--canary.2462.31782687641.0
  yarn add @infineon/design-system-mcp@39.45.1--canary.2462.31782687641.0
  yarn add @infineon/infineon-design-system-angular@39.45.1--canary.2462.31782687641.0
  yarn add @infineon/infineon-design-system-react@39.45.1--canary.2462.31782687641.0
  yarn add @infineon/infineon-design-system-vue@39.45.1--canary.2462.31782687641.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
