### PR TITLE
Card: removes pointer-events for nested link elements

### DIFF
--- a/packages/components/src/components/card/card-headline/card-headline.scss
+++ b/packages/components/src/components/card/card-headline/card-headline.scss
@@ -1,7 +1,7 @@
 @use "@infineon/design-system-tokens/dist/tokens";
 
 :host {
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .card__headline-wrapper {
@@ -13,6 +13,7 @@
 }
 
 .card-headline {
+  pointer-events: none;
   margin-top: 0;
   padding-top: 0;
   font-family: var(--ifx-font-family); // tokens.$ifxFontFamilyBody;
@@ -32,4 +33,9 @@
     line-height: var(--card-headline-line-height, 28px);
   }
 
+}
+
+::slotted(a),
+::slotted(button) {
+  pointer-events: auto;
 }

--- a/packages/components/src/components/card/card-headline/card-headline.scss
+++ b/packages/components/src/components/card/card-headline/card-headline.scss
@@ -36,6 +36,8 @@
 }
 
 ::slotted(a),
-::slotted(button) {
+::slotted(button),
+::slotted(ifx-link),
+::slotted(ifx-button) {
   pointer-events: auto;
 }

--- a/packages/components/src/components/card/card-headline/card-headline.spec.ts
+++ b/packages/components/src/components/card/card-headline/card-headline.spec.ts
@@ -1,4 +1,5 @@
 // src/components/card/card-headline/card-headline.spec.ts
+import * as fs from "node:fs";
 import { newSpecPage } from "jest-stencil-runner";
 import { CardHeadline } from "./card-headline";
 
@@ -31,5 +32,13 @@ describe("ifx-card-headline", () => {
 		const slotElement = root.shadowRoot.querySelector("slot");
 		const headlineContent = slotElement.assignedNodes()[0].textContent;
 		expect(headlineContent).toBe("Test content");
+	});
+
+	it("should keep slotted anchors and buttons interactive", async () => {
+		const css = fs.readFileSync(`${__dirname}/card-headline.scss`, "utf8");
+
+		expect(css).toContain("::slotted(a)");
+		expect(css).toContain("::slotted(button)");
+		expect(css).toContain("pointer-events: auto;");
 	});
 });

--- a/packages/components/src/components/card/card-headline/card-headline.spec.ts
+++ b/packages/components/src/components/card/card-headline/card-headline.spec.ts
@@ -39,6 +39,8 @@ describe("ifx-card-headline", () => {
 
 		expect(css).toContain("::slotted(a)");
 		expect(css).toContain("::slotted(button)");
+		expect(css).toContain("::slotted(ifx-link)");
+		expect(css).toContain("::slotted(ifx-button)");
 		expect(css).toContain("pointer-events: auto;");
 	});
 });

--- a/packages/components/src/components/card/card-overline/card-overline.scss
+++ b/packages/components/src/components/card/card-overline/card-overline.scss
@@ -1,10 +1,11 @@
 @use "@infineon/design-system-tokens/dist/tokens";
 
 :host {
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .card-overline {
+  pointer-events: none;
   font-family: var(--ifx-font-family);
   font-size: tokens.$ifxFontSizeM;
   font-weight: tokens.$ifxFontWeightRegular;
@@ -19,4 +20,9 @@
 
   word-break: break-all;
 
+}
+
+::slotted(a),
+::slotted(button) {
+  pointer-events: auto;
 }

--- a/packages/components/src/components/card/card-overline/card-overline.scss
+++ b/packages/components/src/components/card/card-overline/card-overline.scss
@@ -23,6 +23,8 @@
 }
 
 ::slotted(a),
-::slotted(button) {
+::slotted(button),
+::slotted(ifx-link),
+::slotted(ifx-button) {
   pointer-events: auto;
 }

--- a/packages/components/src/components/card/card-overline/card-overline.spec.ts
+++ b/packages/components/src/components/card/card-overline/card-overline.spec.ts
@@ -1,4 +1,5 @@
 // src/components/card/card-overline/card-overline.spec.ts
+import * as fs from "node:fs";
 import { newSpecPage } from "jest-stencil-runner";
 import { CardOverline } from "./card-overline";
 
@@ -29,5 +30,13 @@ describe("ifx-card-overline", () => {
 		const slotElement = root.shadowRoot.querySelector("slot");
 		const cardOverlineText = slotElement.assignedNodes()[0].textContent;
 		expect(cardOverlineText).toBe("Card Overline");
+	});
+
+	it("should keep slotted anchors and buttons interactive", async () => {
+		const css = fs.readFileSync(`${__dirname}/card-overline.scss`, "utf8");
+
+		expect(css).toContain("::slotted(a)");
+		expect(css).toContain("::slotted(button)");
+		expect(css).toContain("pointer-events: auto;");
 	});
 });

--- a/packages/components/src/components/card/card-overline/card-overline.spec.ts
+++ b/packages/components/src/components/card/card-overline/card-overline.spec.ts
@@ -37,6 +37,8 @@ describe("ifx-card-overline", () => {
 
 		expect(css).toContain("::slotted(a)");
 		expect(css).toContain("::slotted(button)");
+		expect(css).toContain("::slotted(ifx-link)");
+		expect(css).toContain("::slotted(ifx-button)");
 		expect(css).toContain("pointer-events: auto;");
 	});
 });

--- a/packages/components/src/components/card/card-text/card-text.scss
+++ b/packages/components/src/components/card/card-text/card-text.scss
@@ -1,7 +1,7 @@
 @use "@infineon/design-system-tokens/dist/tokens";
 
 :host {
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .card__text-wrapper {
@@ -13,6 +13,7 @@
 }
 
 .card-text {
+  pointer-events: none;
   line-height: tokens.$ifxLineHeightM;
   font-size: tokens.$ifxFontSizeM;
   font-weight: 400;
@@ -22,4 +23,9 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+::slotted(a),
+::slotted(button) {
+  pointer-events: auto;
 }

--- a/packages/components/src/components/card/card-text/card-text.scss
+++ b/packages/components/src/components/card/card-text/card-text.scss
@@ -26,6 +26,8 @@
 }
 
 ::slotted(a),
-::slotted(button) {
+::slotted(button),
+::slotted(ifx-link),
+::slotted(ifx-button) {
   pointer-events: auto;
 }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description:
- Removed pointer-events: none from the host and applied it to the text container so the text area does not capture click events.
- Interactive slotted elements such as anchor links and buttons are explicitly re-enabled with pointer-events: auto using ::slotted(a) and ::slotted(button). 

(Same for headline and overline)

Reference:
#2434 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>40.4.0--canary.2471.33527664502.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@40.4.0--canary.2471.33527664502.0
  npm install angular-module-example@40.4.0--canary.2471.33527664502.0
  npm install angular-standalone-example@40.4.0--canary.2471.33527664502.0
  npm install html-cdn-example@40.4.0--canary.2471.33527664502.0
  npm install html-vite-example@40.4.0--canary.2471.33527664502.0
  npm install react-example@40.4.0--canary.2471.33527664502.0
  npm install vue-example@40.4.0--canary.2471.33527664502.0
  npm install @infineon/infineon-design-system-stencil@40.4.0--canary.2471.33527664502.0
  npm install @infineon/dds-tooling@40.4.0--canary.2471.33527664502.0
  npm install @infineon/design-system-mcp@40.4.0--canary.2471.33527664502.0
  npm install @infineon/infineon-design-system-angular@40.4.0--canary.2471.33527664502.0
  npm install @infineon/infineon-design-system-react@40.4.0--canary.2471.33527664502.0
  npm install @infineon/infineon-design-system-vue@40.4.0--canary.2471.33527664502.0
  # or 
  yarn add example-generator@40.4.0--canary.2471.33527664502.0
  yarn add angular-module-example@40.4.0--canary.2471.33527664502.0
  yarn add angular-standalone-example@40.4.0--canary.2471.33527664502.0
  yarn add html-cdn-example@40.4.0--canary.2471.33527664502.0
  yarn add html-vite-example@40.4.0--canary.2471.33527664502.0
  yarn add react-example@40.4.0--canary.2471.33527664502.0
  yarn add vue-example@40.4.0--canary.2471.33527664502.0
  yarn add @infineon/infineon-design-system-stencil@40.4.0--canary.2471.33527664502.0
  yarn add @infineon/dds-tooling@40.4.0--canary.2471.33527664502.0
  yarn add @infineon/design-system-mcp@40.4.0--canary.2471.33527664502.0
  yarn add @infineon/infineon-design-system-angular@40.4.0--canary.2471.33527664502.0
  yarn add @infineon/infineon-design-system-react@40.4.0--canary.2471.33527664502.0
  yarn add @infineon/infineon-design-system-vue@40.4.0--canary.2471.33527664502.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
