### PR TITLE
Sanitize native anchor hrefs to block javascript: and vbscript: URL schemes

### DIFF
--- a/packages/components/src/components/action-list/action-list-item.tsx
+++ b/packages/components/src/components/action-list/action-list-item.tsx
@@ -8,6 +8,7 @@ import {
 	Watch,
 } from "@stencil/core";
 import classNames from "classnames";
+import { sanitizeHref } from "../../shared/utils/url-utils";
 
 export interface ActionListItemClickEvent {
 	value?: string;
@@ -332,7 +333,7 @@ export class ActionListItem {
 				{this.href && !this.disabled ? (
 					<a
 						class="action-list-item__content"
-						href={this.href}
+						href={sanitizeHref(this.href)}
 						target={this.target}
 						rel={this.target === "_blank" ? "noopener noreferrer" : undefined}
 					>

--- a/packages/components/src/components/breadcrumb/breadcrumb-item-label.tsx
+++ b/packages/components/src/components/breadcrumb/breadcrumb-item-label.tsx
@@ -6,6 +6,7 @@ import {
 	h,
 	Prop,
 } from "@stencil/core";
+import { sanitizeHref } from "../../shared/utils/url-utils";
 
 @Component({
 	tag: "ifx-breadcrumb-item-label",
@@ -38,7 +39,7 @@ export class BreadcrumbItemLabel {
 	render() {
 		return (
 			<a
-				href={this.href}
+				href={sanitizeHref(this.href)}
 				target={this.target}
 				class="breadcrumb-item-label-container"
 				role="link"

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -13,6 +13,7 @@ import classNames from "classnames";
 import { isNestedInIfxComponent } from "../..//shared/utils/dom-utils";
 import { detectFramework } from "../..//shared/utils/framework-detection";
 import { trackComponent } from "../../shared/utils/tracking";
+import { sanitizeHref } from "../../shared/utils/url-utils";
 
 @Component({
 	tag: "ifx-button",
@@ -153,7 +154,7 @@ export class Button {
 					tabIndex={this.disabled ? -1 : 0}
 					ref={(el) => (this.focusableElement = el)}
 					class={this.getClassNames()}
-					href={!this.disabled ? this.internalHref : undefined}
+					href={!this.disabled ? sanitizeHref(this.internalHref) : undefined}
 					target={this.target}
 					onClick={this.handleClick}
 					rel={this.target === "_blank" ? "noopener noreferrer" : undefined}

--- a/packages/components/src/components/card/card.tsx
+++ b/packages/components/src/components/card/card.tsx
@@ -10,6 +10,7 @@ import {
 import { isNestedInIfxComponent } from "../..//shared/utils/dom-utils";
 import { detectFramework } from "../..//shared/utils/framework-detection";
 import { trackComponent } from "../../shared/utils/tracking";
+import { sanitizeHref } from "../../shared/utils/url-utils";
 
 @Component({
 	tag: "ifx-card",
@@ -97,7 +98,7 @@ export class Card {
 						<div class="horizontal">
 							<a
 								class={`card-img ${this.noImg ? "noImage" : ""} ${this.internalHref ? "card-href" : ""}`}
-								href={this.internalHref}
+								href={sanitizeHref(this.internalHref)}
 							>
 								<slot
 									name="img"
@@ -108,7 +109,7 @@ export class Card {
 							<div class="lower__body-wrapper">
 								<a
 									class={`upper-body ${this.internalHref ? "card-href" : ""}`}
-									href={this.internalHref}
+									href={sanitizeHref(this.internalHref)}
 									id="upper-body-content"
 								>
 									<slot />
@@ -124,7 +125,7 @@ export class Card {
 						<div class="vertical">
 							<a
 								class={`upper__body-wrapper ${this.internalHref ? "card-href" : ""}`}
-								href={this.internalHref}
+									href={sanitizeHref(this.internalHref)}
 								target={this.target}
 							>
 								<div class={`card-img ${this.noImg ? "noImage" : ""}`}>

--- a/packages/components/src/components/download/download.tsx
+++ b/packages/components/src/components/download/download.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Prop } from "@stencil/core";
+import { sanitizeHref } from "../../shared/utils/url-utils";
 
 @Component({
 	tag: "ifx-download",
@@ -32,7 +33,7 @@ export class Download {
 						.then((res) => res.blob())
 						.then((blob) => {
 							const link = document.createElement("a");
-							link.href = URL.createObjectURL(blob);
+							link.href = sanitizeHref(URL.createObjectURL(blob));
 							link.download = fileName;
 							link.click();
 						});

--- a/packages/components/src/components/dropdown/dropdown-item/dropdown-item.tsx
+++ b/packages/components/src/components/dropdown/dropdown-item/dropdown-item.tsx
@@ -8,6 +8,7 @@ import {
 	Prop,
 	State,
 } from "@stencil/core";
+import { sanitizeHref } from "../../../shared/utils/url-utils";
 
 interface ItemProps {
 	class: string;
@@ -85,7 +86,7 @@ export class DropdownItem {
 		];
 
 		return hasHref ? (
-			<a {...common} href={this.href} target={this.target}>
+			<a {...common} href={sanitizeHref(this.href)} target={this.target}>
 				{content}
 			</a>
 		) : (

--- a/packages/components/src/components/icon-button/icon-button.tsx
+++ b/packages/components/src/components/icon-button/icon-button.tsx
@@ -13,6 +13,7 @@ import classNames from "classnames";
 import { isNestedInIfxComponent } from "../..//shared/utils/dom-utils";
 import { detectFramework } from "../..//shared/utils/framework-detection";
 import { trackComponent } from "../../shared/utils/tracking";
+import { sanitizeHref } from "../../shared/utils/url-utils";
 
 @Component({
 	tag: "ifx-icon-button",
@@ -113,7 +114,7 @@ export class IconButton {
 					<a
 						ref={(el) => (this.focusableElement = el)}
 						class={this.getClassNames()}
-						href={!this.disabled ? this.href : undefined}
+						href={!this.disabled ? sanitizeHref(this.href) : undefined}
 						target={this.target}
 						rel={this.target === "_blank" ? "noopener noreferrer" : undefined}
 					>

--- a/packages/components/src/components/link/link.tsx
+++ b/packages/components/src/components/link/link.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import { isNestedInIfxComponent } from "../..//shared/utils/dom-utils";
 import { detectFramework } from "../..//shared/utils/framework-detection";
 import { trackComponent } from "../../shared/utils/tracking";
+import { sanitizeHref } from "../../shared/utils/url-utils";
 
 @Component({
 	tag: "ifx-link",
@@ -85,7 +86,7 @@ export class Link {
 				tabindex="0"
 				aria-label={this.ariaLabelText}
 				aria-disabled={this.disabled || !this.internalHref}
-				href={this.disabled ? undefined : this.internalHref}
+				href={this.disabled ? undefined : sanitizeHref(this.internalHref)}
 				download={this.download}
 				target={this.internalTarget}
 				class={this.linkClassNames()}

--- a/packages/components/src/components/navigation/navbar/navbar-item.tsx
+++ b/packages/components/src/components/navigation/navbar/navbar-item.tsx
@@ -9,6 +9,7 @@ import {
 	Prop,
 	State,
 } from "@stencil/core";
+import { sanitizeHref } from "../../../shared/utils/url-utils";
 
 @Component({
 	tag: "ifx-navbar-item",
@@ -523,7 +524,7 @@ export class NavbarItem {
 				</div>
 				<a
 					tabindex={-1}
-					href={this.internalHref}
+					href={sanitizeHref(this.internalHref)}
 					target={this.target}
 					onClick={() => this.toggleItemMenu()}
 					class={`navbar__item ${this.isSidebarMenuItem ? "sidebarMenuItem" : ""} ${!this.showLabel ? "removeLabel" : ""} ${this.isMenuItem ? "menuItem" : ""} ${this.hasChildNavItems ? "isParent" : ""}`}

--- a/packages/components/src/components/navigation/navbar/navbar-profile.tsx
+++ b/packages/components/src/components/navigation/navbar/navbar-profile.tsx
@@ -7,6 +7,7 @@ import {
 	Prop,
 	State,
 } from "@stencil/core";
+import { sanitizeHref } from "../../../shared/utils/url-utils";
 
 @Component({
 	tag: "ifx-navbar-profile",
@@ -186,7 +187,7 @@ export class NavbarProfile {
 		return (
 			<div class="container">
 				<a
-					href={this.internalHref}
+					href={sanitizeHref(this.internalHref)}
 					target={this.target}
 					onClick={() => this.toggleItemMenu()}
 					class={`navbar__item ${!this.showLabel ? "removeLabel" : ""} ${this.hasChildNavItems ? "isParent" : ""}`}

--- a/packages/components/src/components/navigation/navbar/navbar.tsx
+++ b/packages/components/src/components/navigation/navbar/navbar.tsx
@@ -10,6 +10,7 @@ import {
 } from "@stencil/core";
 import { detectFramework } from "../../../shared/utils/framework-detection";
 import { trackComponent } from "../../../shared/utils/tracking";
+import { sanitizeHref } from "../../../shared/utils/url-utils";
 
 @Component({
   tag: "ifx-navbar",
@@ -801,7 +802,7 @@ disconnectedCallback() {
       <div class={logoClasses} aria-label="Brand">
         <a
           class="navbar__logo-link"
-          href={this.internalLogoHref}
+          href={sanitizeHref(this.internalLogoHref)}
           target={this.internalLogoHrefTarget}
           aria-label="Go to application home"
         >

--- a/packages/components/src/components/navigation/sidebar/sidebar-item.tsx
+++ b/packages/components/src/components/navigation/sidebar/sidebar-item.tsx
@@ -10,6 +10,7 @@ import {
 	State,
 	Watch,
 } from "@stencil/core";
+import { sanitizeHref } from "../../../shared/utils/url-utils";
 
 @Component({
 	tag: "ifx-sidebar-item",
@@ -324,7 +325,7 @@ export class SidebarItem {
 				<a
 					tabIndex={1}
 					onKeyDown={(event) => this.handleKeyDown(event)}
-					href={this.internalHref}
+					href={sanitizeHref(this.internalHref)}
 					onClick={() => this.toggleSubmenu()}
 					target={this.target}
 					class={`sidebar__nav-item ${!this.isNested && this.isExpandable ? "header__section" : ""} ${this.isSubMenuItem ? "submenu__item" : ""}`}

--- a/packages/components/src/components/navigation/sidebar/sidebar.tsx
+++ b/packages/components/src/components/navigation/sidebar/sidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from "@stencil/core";
 import { detectFramework } from "../../../shared/utils/framework-detection";
 import { trackComponent } from "../../../shared/utils/tracking";
+import { sanitizeHref } from "../../../shared/utils/url-utils";
 
 const ACTIVE = "active";
 const ACTIVE_SECTION = "active-section";
@@ -660,7 +661,7 @@ export class Sidebar {
 							<div class="sidebar__nav-bar-logo">
 								<div class={`sidebar__nav-bar-logo-img`}>
 									<a
-										href={this.internalLogoHref}
+										href={sanitizeHref(this.internalLogoHref)}
 										target={this.internalLogoHrefTarget}
 										onClick={() => this.onLogoImgClick()}
 									>
@@ -729,7 +730,7 @@ export class Sidebar {
 									{this.internalTermsofUse !== "" && (
 										<a
 											target={this.footerHrefTarget}
-											href={this.internalTermsofUse}
+											href={sanitizeHref(this.internalTermsofUse)}
 										>
 											Terms of use
 										</a>
@@ -737,7 +738,7 @@ export class Sidebar {
 									{this.internalImprint !== "" && (
 										<a
 											target={this.footerHrefTarget}
-											href={this.internalImprint}
+											href={sanitizeHref(this.internalImprint)}
 										>
 											Imprint
 										</a>
@@ -745,7 +746,7 @@ export class Sidebar {
 									{this.internalPrivacyPolicy !== "" && (
 										<a
 											target={this.footerHrefTarget}
-											href={this.internalPrivacyPolicy}
+											href={sanitizeHref(this.internalPrivacyPolicy)}
 										>
 											Privacy policy
 										</a>

--- a/packages/components/src/components/search-bar/search-bar.tsx
+++ b/packages/components/src/components/search-bar/search-bar.tsx
@@ -12,6 +12,7 @@ import {
 import { isNestedInIfxComponent } from "../..//shared/utils/dom-utils";
 import { detectFramework } from "../..//shared/utils/framework-detection";
 import { trackComponent } from "../../shared/utils/tracking";
+import { sanitizeHref } from "../../shared/utils/url-utils";
 
 @Component({
 	tag: "ifx-search-bar",
@@ -152,7 +153,7 @@ export class SearchBar {
 					{this.showCloseButton &&
 						<a
 							aria-label="Close button"
-							href="javascript:void(0)"
+							href={sanitizeHref("javascript:void(0)")}
 							onClick={this.handleCloseButton}
 						>
 							Close

--- a/packages/components/src/shared/utils/url-utils.spec.ts
+++ b/packages/components/src/shared/utils/url-utils.spec.ts
@@ -1,0 +1,25 @@
+import { sanitizeHref } from "./url-utils";
+
+describe("sanitizeHref", () => {
+	it.each([
+		"javascript:alert(1)",
+		" JAVASCRIPT:alert(1)",
+		"vbscript:msgbox(1)",
+	])("blocks executable protocol %s", (href) => {
+		expect(sanitizeHref(href)).toBeUndefined();
+	});
+
+	it.each([
+		undefined,
+		"",
+		"/relative/path",
+		"data:text/plain,hello",
+		"blob:https://example.com/id",
+		"file:///tmp/example.txt",
+		"custom:value",
+		"https://example.com/path",
+		"not a valid URL %",
+	])("preserves allowed or unvalidated value %s", (href) => {
+		expect(sanitizeHref(href)).toBe(href);
+	});
+});

--- a/packages/components/src/shared/utils/url-utils.ts
+++ b/packages/components/src/shared/utils/url-utils.ts
@@ -1,0 +1,15 @@
+const DUMMY_BASE_URL = "https://example.com/";
+const BLOCKED_PROTOCOLS = new Set(["javascript:", "vbscript:"]);
+
+export function sanitizeHref(href: string | undefined): string | undefined {
+	if (href === undefined) {
+		return undefined;
+	}
+
+	try {
+		const protocol = new URL(href, DUMMY_BASE_URL).protocol;
+		return BLOCKED_PROTOCOLS.has(protocol) ? undefined : href;
+	} catch {
+		return href;
+	}
+}


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

## Description

Adds shared `href` sanitization to prevent executable URL schemes from reaching native anchor `href` attributes. Blocks `javascript:` and `vbscript:` while preserving other protocols and malformed values unchanged.

## Related Issue

Closes #2445

## Context

Implemented in `components` using the platform `URL` parser with a fixed base URL. Applied consistently to native anchor sinks, including dynamically created download links.

Validated with focused Jest tests and Biome checks for the new utility.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>40.6.3--canary.2509.34595058352.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install example-generator@40.6.3--canary.2509.34595058352.0
  npm install angular-module-example@40.6.3--canary.2509.34595058352.0
  npm install angular-standalone-example@40.6.3--canary.2509.34595058352.0
  npm install html-cdn-example@40.6.3--canary.2509.34595058352.0
  npm install html-vite-example@40.6.3--canary.2509.34595058352.0
  npm install react-example@40.6.3--canary.2509.34595058352.0
  npm install vue-example@40.6.3--canary.2509.34595058352.0
  npm install @infineon/infineon-design-system-stencil@40.6.3--canary.2509.34595058352.0
  npm install @infineon/dds-tooling@40.6.3--canary.2509.34595058352.0
  npm install @infineon/design-system-mcp@40.6.3--canary.2509.34595058352.0
  npm install @infineon/infineon-design-system-angular@40.6.3--canary.2509.34595058352.0
  npm install @infineon/infineon-design-system-react@40.6.3--canary.2509.34595058352.0
  npm install @infineon/infineon-design-system-vue@40.6.3--canary.2509.34595058352.0
  # or 
  yarn add example-generator@40.6.3--canary.2509.34595058352.0
  yarn add angular-module-example@40.6.3--canary.2509.34595058352.0
  yarn add angular-standalone-example@40.6.3--canary.2509.34595058352.0
  yarn add html-cdn-example@40.6.3--canary.2509.34595058352.0
  yarn add html-vite-example@40.6.3--canary.2509.34595058352.0
  yarn add react-example@40.6.3--canary.2509.34595058352.0
  yarn add vue-example@40.6.3--canary.2509.34595058352.0
  yarn add @infineon/infineon-design-system-stencil@40.6.3--canary.2509.34595058352.0
  yarn add @infineon/dds-tooling@40.6.3--canary.2509.34595058352.0
  yarn add @infineon/design-system-mcp@40.6.3--canary.2509.34595058352.0
  yarn add @infineon/infineon-design-system-angular@40.6.3--canary.2509.34595058352.0
  yarn add @infineon/infineon-design-system-react@40.6.3--canary.2509.34595058352.0
  yarn add @infineon/infineon-design-system-vue@40.6.3--canary.2509.34595058352.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
